### PR TITLE
Update field.hxx

### DIFF
--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -205,6 +205,7 @@ protected:
 
 private:
   /// Implementation for get().
+#if defined(PQXX_HAVE_OPTIONAL) || defined(PQXX_HAVE_EXP_OPTIONAL)
   /**
    * Abstracts away the difference between std::optional and
    * std::experimental::optional.  Both can be supported at the same time,
@@ -215,6 +216,7 @@ private:
     if (is_null()) return OPTIONAL();
     else return OPTIONAL(as<T>());
   }
+#endif
 
   const result *m_home;
   size_t m_row;


### PR DESCRIPTION
This is to to compile under VS2015, it is not used in Vs2015, since std:optional is not available there, get compilation error in VS2015:
Error	C4430	Build	missing type specifier - int assumed. Note: C++ does not support default-int
