### PR TITLE
Fixed a mismatched tag in the doc/libpqxx.xml 

### DIFF
--- a/doc/libpqxx.xml
+++ b/doc/libpqxx.xml
@@ -42,7 +42,6 @@
       for more information.
     </para>
 
-    </section>
   </chapter>
 
   <chapter id="classoverview">


### PR DESCRIPTION
There is a error in parsing this file:

> XML Parsing Error: mismatched tag. Expected: </chapter>.
> Location: file:///home/src/libpqxx/doc/libpqxx.xml
> Line Number 45, Column 7:    </section>
> ------^