### PR TITLE
include sys/time.h outside fallback select

### DIFF
--- a/configure
+++ b/configure
@@ -17285,22 +17285,6 @@ fi
 done
 
 
-if test "$select_h" != "yes"
-then
-for ac_header in sys/time.h
-do :
-  ac_fn_cxx_check_header_mongrel "$LINENO" "sys/time.h" "ac_cv_header_sys_time_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_time_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SYS_TIME_H 1
-_ACEOF
-
-fi
-
-done
-
-fi
-
 # Some systems keep select() in a separate library which is not linked by
 # default.  See if we need one of those.
 socklibok=no
@@ -17418,6 +17402,18 @@ the config.log file for more clues as to why this failed.
 fi
 
 fi # No poll()
+
+for ac_header in sys/time.h
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "sys/time.h" "ac_cv_header_sys_time_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_time_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_TIME_H 1
+_ACEOF
+
+fi
+
+done
 
 
 # Add options to compiler command line, if compiler accepts them.

--- a/configure.ac
+++ b/configure.ac
@@ -117,11 +117,6 @@ then
 select_h=no
 AC_CHECK_HEADERS([sys/select.h], [select_h=yes])
 
-if test "$select_h" != "yes"
-then
-AC_CHECK_HEADERS([sys/time.h])
-fi
-
 # Some systems keep select() in a separate library which is not linked by
 # default.  See if we need one of those.
 socklibok=no
@@ -150,6 +145,7 @@ fi
 
 fi # No poll()
 
+AC_CHECK_HEADERS([sys/time.h])
 
 # Add options to compiler command line, if compiler accepts them.
 add_compiler_opts_if_ok() {

--- a/src/connection_base.cxx
+++ b/src/connection_base.cxx
@@ -38,9 +38,9 @@
 #if defined(HAVE_UNISTD_H)
 #include <unistd.h>
 #endif
+#endif
 #if defined(HAVE_SYS_TIME_H)
 #include <sys/time.h>
-#endif
 #endif
 
 #include "libpq-fe.h"


### PR DESCRIPTION
The implementation of 'wait_fd' (inside 'connection_base.cxx') always
relies on the existence of the 'timeval' structure. In Linux, this
structure is provided by the header 'sys/time.h'. If polling or select
capabilities are detected, the structure is never included into the
source and will result in a compilation error (GCC 7.x):

    connection_base.cxx:1153:28: error: ‘{anonymous}::tv_milliseconds’ declared as an ‘inline’ variable
     inline int tv_milliseconds(timeval *tv = nullptr)
                                ^~~~~~~
    ...

The following moves the 'HAVE_SYS_TIME_H' check outside the
select-fallback case so that the header can be included no matter the
event-function feature is used.

### other

- Compile check on Fedora 27 x86_64 GCC 7.2.1 GLIBC.
- Compile check on Fedora 27 x86_64 MUSL 2017.11-RC1 toolchain.
- See also [Buildroot failure 48b015650ede4e55e199538072c7228cccf64422](http://autobuild.buildroot.net/results/48b015650ede4e55e199538072c7228cccf64422/build-end.log).