### PR TITLE
Remove unused private member variables

### DIFF
--- a/include/pqxx/prepared_statement.hxx
+++ b/include/pqxx/prepared_statement.hxx
@@ -94,8 +94,6 @@ public:
 private:
   transaction_base &m_home;
   const std::string m_statement;
-  std::vector<std::string> m_values;
-  std::vector<bool> m_nonnull;
 
   invocation &setparam(const std::string &, bool nonnull);
 };


### PR DESCRIPTION
The two private member variables `m_values` and `m_nonnull` in `invocation` are not used and can be removed without problems.

Additionally, the base class `statement_parameters` contains two members of the same names, so having them declared again in the child class is likely unintentional.