### PR TITLE
Use error message when throwing exception

### DIFF
--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -493,7 +493,7 @@ void pqxx::transaction_base::CheckPendingError()
   {
     const std::string Err(m_pending_error);
     m_pending_error.clear();
-    throw failure(m_pending_error);
+    throw failure(Err);
   }
 }
 


### PR DESCRIPTION
The `failure` is created from an empty string, this PR changes it to use the error message saved in `Err` instead.