### PR TITLE
Fix excessive quoting in copy path

### DIFF
--- a/win32/vc-libpqxx.mak
+++ b/win32/vc-libpqxx.mak
@@ -264,7 +264,7 @@ $(OUTDIR)\$(LIBPQDLL):: $(OUTDIR)
 	@echo Instead, keep it with your program and distribute it along
 	@echo with the program.
 	@echo -------------------------------------------------------------
-	copy "$(LIBPQPATH)\$(LIBPQDLL)" "$(OUTDIR)"
+	copy $(LIBPQPATH)\$(LIBPQDLL) "$(OUTDIR)"
 
 $(OUTDIR)\$(LIBPQDDLL):: $(OUTDIR)
 	@echo -------------------------------------------------------------
@@ -274,13 +274,13 @@ $(OUTDIR)\$(LIBPQDDLL):: $(OUTDIR)
 	@echo where your program's .EXE resides, or you must make sure that
 	@echo it is in your system PATH.
 	@echo -------------------------------------------------------------
-	copy "$(LIBPQDPATH)\$(LIBPQDDLL)" "$(OUTDIR)"
+	copy $(LIBPQDPATH)\$(LIBPQDDLL) "$(OUTDIR)"
 
 $(OUTDIR)\$(LIBPQLIB):: $(OUTDIR)
-	copy "$(LIBPQPATH)\$(LIBPQLIB)" "$(OUTDIR)"
+	copy $(LIBPQPATH)\$(LIBPQLIB) "$(OUTDIR)"
 
 $(OUTDIR)\$(LIBPQDLIB):: $(OUTDIR)
-	copy "$(LIBPQDPATH)\$(LIBPQDLIB)" "$(OUTDIR)"
+	copy $(LIBPQDPATH)\$(LIBPQDLIB) "$(OUTDIR)"
 
 $(OUTFILE_STATICDEBUG).lib:: $(OUTDIR) $(OBJ_STATICDEBUG)
 	$(LIBTOOL) $(LIB_FLAGS) $(OBJ_STATICDEBUG) /out:"$(OUTFILE_STATICDEBUG).lib"


### PR DESCRIPTION
The additional quoting in .mak file prevents user from using quoted paths in 'common' file. The default path for PostgreSQL on Windows for prebuilt packages contains space and it's natural a user may want to use quotes, but it will lead to an error like this:
```
copy ""C:\Program Files\PostgreSQL\10"\lib\libpq.dll" "lib"
The system cannot find the file specified.
NMAKE : fatal error U1077: 'copy' : return code '0x1'
```
This PR fixes such situation