### PR TITLE
Use WSAPoll only on win version >= 0x0600

### DIFF
--- a/src/connection_base.cxx
+++ b/src/connection_base.cxx
@@ -1142,7 +1142,8 @@ void wait_fd(int fd, bool forwrite=false, timeval *tv=nullptr)
 {
   if (fd < 0) throw pqxx::broken_connection();
 
-#if defined(_WIN32)
+// WSAPoll is available in winsock2.h only for versions of Windows >= 0x0600
+#if defined(_WIN32) && (_WIN32_WINNT >= 0x6000)
   const short events = (forwrite ? POLLWRNORM : POLLRDNORM);
   WSAPOLLFD fdarray{SOCKET(fd), events, 0};
   WSAPoll(&fdarray, 1, tv_milliseconds(tv));


### PR DESCRIPTION
Fix for #63 
This still does not fix the issue that when using ./configure in Windows at least in MSYS2/MingW i686 the _WIN32_WINNT is not set to the correct Windows version.