### PR TITLE
In internal::params and transaction_base, move or forward arguments when appropriate.

### DIFF
--- a/include/pqxx/internal/statement_parameters.hxx
+++ b/include/pqxx/internal/statement_parameters.hxx
@@ -112,7 +112,7 @@ struct params
   /// Construct directly from a series of statement arguments.
   /** The arrays all default to zero, null, and empty strings.
    */
-  template<typename ...Args> params(Args... args)
+  template<typename ...Args> params(Args && ... args)
   {
     strings.reserve(sizeof...(args));
     lengths.reserve(sizeof...(args));
@@ -120,7 +120,7 @@ struct params
     binaries.reserve(sizeof...(args));
 
     // Start recursively storing parameters.
-    add_fields(args...);
+    add_fields(std::forward<Args>(args)...);
   }
 
   /// Compose a vector of pointers to parameter string values.
@@ -164,12 +164,12 @@ struct params
 
 private:
   /// Add a non-null string field.
-  void add_field(const std::string &str)
+  void add_field(std::string str)
   {
     lengths.push_back(int(str.size()));
     nonnulls.push_back(1);
     binaries.push_back(0);
-    strings.push_back(str);
+    strings.emplace_back(std::move(str));
   }
 
   /// Compile one argument (specialised for null pointer, a null value).
@@ -232,11 +232,11 @@ private:
    * @param args Optional remaining arguments, to be compiled recursively.
    */
   template<typename Arg, typename ...More>
-  void add_fields(Arg arg, More... args)
+  void add_fields(Arg &&arg, More && ... args)
   {
-    add_field(arg);
+    add_field(std::forward<Arg>(arg));
     // Compile remaining arguments, if any.
-    add_fields(args...);
+    add_fields(std::forward<More>(args)...);
   }
 
   /// Terminating version of add_fields, at the end of the list.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -308,36 +308,36 @@ public:
   //@{
   /// Execute an SQL statement with parameters.
   template<typename ...Args>
-  result exec_params(const std::string &query, Args ...args)
+  result exec_params(const std::string &query, Args &&...args)
   {
-    return internal_exec_params(query, internal::params(args...));
+    return internal_exec_params(query, internal::params(std::forward<Args>(args)...));
   }
 
   // Execute parameterised statement, expect a single-row result.
   /** @throw unexpected_rows if the result does not consist of exactly one row.
    */
   template<typename ...Args>
-  row exec_params1(const std::string &query, Args... args)
+  row exec_params1(const std::string &query, Args&&... args)
   {
-    return exec_params_n(1, query, args...).front();
+    return exec_params_n(1, query, std::forward<Args>(args)...).front();
   }
 
   // Execute parameterised statement, expect a result with zero rows.
   /** @throw unexpected_rows if the result contains rows.
    */
   template<typename ...Args>
-  result exec_params0(const std::string &query, Args ...args)
+  result exec_params0(const std::string &query, Args &&...args)
   {
-    return exec_params_n(0, query, args...);
+    return exec_params_n(0, query, std::foward<Args>(args)...);
   }
 
   // Execute parameterised statement, expect exactly a given number of rows.
   /** @throw unexpected_rows if the result contains the wrong number of rows.
    */
   template<typename ...Args>
-  result exec_params_n(size_t rows, const std::string &query, Args ...args)
+  result exec_params_n(size_t rows, const std::string &query, Args &&...args)
   {
-    const auto r = exec_params(query, args...);
+    const auto r = exec_params(query, std::forward<Args>(args)...);
     check_rowcount_params(rows, r.size());
     return r;
   }
@@ -381,27 +381,27 @@ public:
 
   /// Execute a prepared statement, with optional arguments.
   template<typename ...Args>
-  result exec_prepared(const std::string &statement, Args... args)
+  result exec_prepared(const std::string &statement, Args&&... args)
   {
-    return internal_exec_prepared(statement, internal::params(args...));
+    return internal_exec_prepared(statement, internal::params(std::forward<Args>(args)...));
   }
 
   /// Execute a prepared statement, and expect a single-row result.
   /** @throw pqxx::unexpected_rows if the result was not exactly 1 row.
    */
   template<typename ...Args>
-  row exec_prepared1(const std::string &statement, Args... args)
+  row exec_prepared1(const std::string &statement, Args&&... args)
   {
-    return exec_prepared_n(1, statement, args...).front();
+    return exec_prepared_n(1, statement, std::forward<Args>(args)...).front();
   }
 
   /// Execute a prepared statement, and expect a result with zero rows.
   /** @throw pqxx::unexpected_rows if the result contained rows.
    */
   template<typename ...Args>
-  result exec_prepared0(const std::string &statement, Args... args)
+  result exec_prepared0(const std::string &statement, Args&&... args)
   {
-    return exec_prepared_n(0, statement, args...);
+    return exec_prepared_n(0, statement, std::forward<Args>(args)...);
   }
 
   /// Execute a prepared statement, expect a result with given number of rows.
@@ -412,9 +412,9 @@ public:
   result exec_prepared_n(
 	size_t rows,
 	const std::string &statement,
-	Args... args)
+	Args&&... args)
   {
-    const auto r = exec_prepared(statement, args...);
+    const auto r = exec_prepared(statement, std::forward<Args>(args)...);
     check_rowcount_prepared(statement, rows, r.size());
     return r;
   }


### PR DESCRIPTION
This avoids unnecessary copies when the user passes a big rvalue std::string, for example.