### PR TITLE
documentation build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,19 +38,21 @@ AC_ARG_ENABLE(
 	documentation,
 	[AS_HELP_STRING([--enable-documentation], [Generate documentation])],
 	[],
-	[enable_documentation=yes])
-if test "$enable_documentation" = "yes"
-then
-AC_PATH_PROG([DOXYGEN], [doxygen])
-AM_CONDITIONAL([BUILD_REFERENCE], [/bin/true])
-AC_CHECK_PROG(HAVE_DOT, dot, yes, no)
-AC_PATH_PROG([XMLTO], [xmlto])
-AM_CONDITIONAL([BUILD_TUTORIAL], [/bin/true])
-else
-AM_CONDITIONAL(BUILD_REFERENCE, [/bin/false])
-AM_CONDITIONAL(BUILD_TUTORIAL, [/bin/false])
-fi
-
+	[enable_documentation=auto])
+AC_ARG_VAR([DOXYGEN],
+	[Path to doxygen needed to build reference documentation])
+AC_PATH_TOOL([DOXYGEN], [doxygen], [nodoxygen])
+AC_ARG_VAR([HAVE_DOT],
+	[Variable used by doxygen to declare availibility of dot])
+AC_CHECK_TOOL([HAVE_DOT], [dot], [YES], [NO])
+AC_ARG_VAR([XMLTO], [Path to xmlto needed to build tutorial documentation])
+AC_PATH_TOOL([XMLTO], [xmlto], [noxmlto])
+AS_IF([test "$enable_documentation" = "yes" && test "$DOXYGEN" = "nodoxygen" -o "$XMLTO" = "noxmlto"],
+	[AC_MSG_ERROR([could not files tools necessary to build documentation])])
+AM_CONDITIONAL([BUILD_REFERENCE],
+	[test "$enable_documentation" != "no" -a "$DOXYGEN" != "nodoxygen"])
+AM_CONDITIONAL([BUILD_TUTORIAL],
+	[test "$enable_documentation" != "no" -a "$XMLTO" != "xmlto"])
 
 AM_MAINTAINER_MODE
 

--- a/tools/extract_version
+++ b/tools/extract_version
@@ -53,17 +53,17 @@ case "$ARG" in
 
 -a|--abi)
 	# Print just the ABI version (major & minor).
-	sed $srcdir/VERSION -e 's/^\([^.]*\.[^.]*\)\..*/\1/'
+	sed -e 's/^\([^.]*\.[^.]*\)\..*/\1/' $srcdir/VERSION
 	;;
 
 -M|--major)
 	# Print the major version number.
-	sed $srcdir/VERSION -e 's/^\([^.]*\)\..*/\1/'
+	sed -e 's/^\([^.]*\)\..*/\1/' $srcdir/VERSION
 	;;
 
 -m|--minor)
 	# Print the minor version number.
-	sed $srcdir/VERSION -e 's/^[^.]*\.\([^.]*\)\..*/\1/'
+	sed -e 's/^[^.]*\.\([^.]*\)\..*/\1/' $srcdir/VERSION
 	;;
 
 *)


### PR DESCRIPTION
I still had a 2008 subversion copy of libpqxx. High time to try out the github releases. One change: I suppose that in the past, tar files were created with "make dist" - the advantage was that documentation was available direct from the release tar ball. In the new world of github, what is commited in the repository is distributed, therefore we all need to make our own documentation, hence hitting the problems fixed in this pull request.