### PR TITLE
Remove Makefile.in from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ tools/rmlo
 README
 win32/common
 **/Makefile
-**/Makefile.in
 **/*.la
 **/*.lo
 **/*.o


### PR DESCRIPTION
Those files are part of the repo and required for a ./configure && make building.

I need this change to be able to include libpqxx in an npm package, where all files from .gitignore are skipped in the packaging.

And by the way, thanks for providing this library!