### PR TITLE
Fix unit tests not compiling when libpqxx is configured with CMake

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB UNIT_TEST_SOURCES *.cxx)
 
-add_executable(unit_runner ${TEST_SOURCES})
+add_executable(unit_runner ${UNIT_TEST_SOURCES})
 target_link_libraries(unit_runner PUBLIC pqxx_shared)
 add_test(NAME unit_runner WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND unit_runner)

--- a/test/unit/runner.cxx
+++ b/test/unit/runner.cxx
@@ -1,1 +1,1 @@
-#include "test_main.hxx"
+#include "../test_main.hxx"

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -1,4 +1,4 @@
-#include "test_helpers.hxx"
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -1,4 +1,4 @@
-#include "test_helpers.hxx"
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_cancel_query.cxx
+++ b/test/unit/test_cancel_query.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_error_verbosity.cxx
+++ b/test/unit/test_error_verbosity.cxx
@@ -1,4 +1,4 @@
-#include "test_helpers.hxx"
+#include "../test_helpers.hxx"
 
 extern "C"
 {

--- a/test/unit/test_errorhandler.cxx
+++ b/test/unit/test_errorhandler.cxx
@@ -1,6 +1,6 @@
 #include <vector>
 
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_escape.cxx
+++ b/test/unit/test_escape.cxx
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_exceptions.cxx
+++ b/test/unit/test_exceptions.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 #include <pqxx/except>
 

--- a/test/unit/test_float.cxx
+++ b/test/unit/test_float.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_parameterized.cxx
+++ b/test/unit/test_parameterized.cxx
@@ -1,4 +1,4 @@
-#include "test_helpers.hxx"
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_pipeline.cxx
+++ b/test/unit/test_pipeline.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -3,7 +3,7 @@
 #include <iterator>
 #include <list>
 
-#include "test_helpers.hxx"
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_read_transaction.cxx
+++ b/test/unit/test_read_transaction.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_result_iteration.cxx
+++ b/test/unit/test_result_iteration.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 namespace
 {

--- a/test/unit/test_result_slicing.cxx
+++ b/test/unit/test_result_slicing.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 namespace
 {

--- a/test/unit/test_simultaneous_transactions.cxx
+++ b/test/unit/test_simultaneous_transactions.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_sql_cursor.cxx
+++ b/test/unit/test_sql_cursor.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_stateless_cursor.cxx
+++ b/test/unit/test_stateless_cursor.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_string_conversion.cxx
+++ b/test/unit/test_string_conversion.cxx
@@ -1,4 +1,4 @@
-#include "test_helpers.hxx"
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_subtransaction.cxx
+++ b/test/unit/test_subtransaction.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_test_helpers.cxx
+++ b/test/unit/test_test_helpers.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_thread_safety_model.cxx
+++ b/test/unit/test_thread_safety_model.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 #include <pqxx/util>
 

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;

--- a/test/unit/test_transactor.cxx
+++ b/test/unit/test_transactor.cxx
@@ -1,4 +1,4 @@
-#include <test_helpers.hxx>
+#include "../test_helpers.hxx"
 
 using namespace std;
 using namespace pqxx;


### PR DESCRIPTION
Note that this still fails to compile on macOS due to `std::experimental::optional` not having a public `value()` method — see [this Stack Overflow question](https://stackoverflow.com/questions/44217316/how-do-i-use-stdoptional-in-c).  That's an issue with macOS, not libpqxx, and can be the subject of a later discussion.