### PR TITLE
array.cxx skip escapes fix

### DIFF
--- a/src/array.cxx
+++ b/src/array.cxx
@@ -79,9 +79,9 @@ std::string parse_single_quoted_string(const char begin[], const char end[])
   output.reserve(std::size_t(end - begin - 2));
   for (const char *here = begin + 1; here < end - 1; here++)
   {
-    auto c = *here;
     // Skip escapes.
-    if (c == '\'' || c == '\\') here++;
+    if (*here == '\'' || *here == '\\') here++;
+    auto c = *here;
     output.push_back(c);
   }
 
@@ -133,9 +133,9 @@ std::string parse_double_quoted_string(const char begin[], const char end[])
   output.reserve(std::size_t(end - begin - 2));
   for (const char *here = begin + 1; here < end - 1; here++)
   {
-    auto c = *here;
     // Skip escapes.
-    if (c == '\\') here++;
+    if (*here == '\\') here++;
+    auto c = *here;
     output.push_back(c);
   }
 


### PR DESCRIPTION
In original code
`auto c = *here;
// Skip escapes.
if (c == '\'' || c == '\\') here++;
output.push_back(c);`

you skip content, but no escapes