### PR TITLE
"encoding_group.hxx" and "type_utils.hxx" required in Makefile

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -38,6 +38,7 @@ nobase_include_HEADERS= pqxx/pqxx \
 	pqxx/internal/callgate.hxx \
 	pqxx/internal/libpq-forward.hxx \
 	pqxx/internal/statement_parameters.hxx \
+	pqxx/internal/type_utils.hxx \
 	pqxx/internal/gates/connection-dbtransaction.hxx \
 	pqxx/internal/gates/connection-errorhandler.hxx \
 	pqxx/internal/gates/connection-largeobject.hxx \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -36,6 +36,7 @@ nobase_include_HEADERS= pqxx/pqxx \
 	pqxx/types pqxx/types.hxx \
 	pqxx/version pqxx/version.hxx \
 	pqxx/internal/callgate.hxx \
+	pqxx/internal/encoding_group.hxx \
 	pqxx/internal/libpq-forward.hxx \
 	pqxx/internal/statement_parameters.hxx \
 	pqxx/internal/type_utils.hxx \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -390,6 +390,7 @@ nobase_include_HEADERS = pqxx/pqxx \
 	pqxx/internal/callgate.hxx \
 	pqxx/internal/libpq-forward.hxx \
 	pqxx/internal/statement_parameters.hxx \
+	pqxx/internal/type_utils.hxx \
 	pqxx/internal/gates/connection-dbtransaction.hxx \
 	pqxx/internal/gates/connection-errorhandler.hxx \
 	pqxx/internal/gates/connection-largeobject.hxx \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -388,6 +388,7 @@ nobase_include_HEADERS = pqxx/pqxx \
 	pqxx/types pqxx/types.hxx \
 	pqxx/version pqxx/version.hxx \
 	pqxx/internal/callgate.hxx \
+	pqxx/internal/encoding_group.hxx \
 	pqxx/internal/libpq-forward.hxx \
 	pqxx/internal/statement_parameters.hxx \
 	pqxx/internal/type_utils.hxx \


### PR DESCRIPTION
...These two files were not added to the makefile earlier today in commit fe89b85c641816f386d46dba26719b3501ad04ce - My Docker build failed due to this, but now succeeds as normal.