### PR TITLE
Fix incorrect error code parsing in result

### DIFF
--- a/src/result.cxx
+++ b/src/result.cxx
@@ -191,7 +191,7 @@ void pqxx::result::ThrowSQLError(
     case '0':
       if (equal(code, "40000")) throw transaction_rollback{Err};
       if (equal(code, "40001")) throw serialization_failure{Err};
-      if (equal(code, "40001")) throw statement_completion_unknown{Err};
+      if (equal(code, "40003")) throw statement_completion_unknown{Err};
       if (equal(code, "40P01")) throw deadlock_detected{Err};
       break;
     case '2':


### PR DESCRIPTION
result.cxx contains the response code 40001 twice - once for
serialization failiure and once for statement completion unknown.

According to the documentation it should be 40001 for serialization
failiure and 40003 for statement completion unknown.

Ref: https://www.postgresql.org/docs/current/errcodes-appendix.html