### PR TITLE
Fixes install missing header when using CMake out-of-source build

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -12,7 +12,7 @@
 # Generated from template './include/CMakeLists.txt.template'.
 ################################################################################
 install(
-    DIRECTORY pqxx
+    DIRECTORY pqxx "${PROJECT_BINARY_DIR}/include/pqxx"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING
         PATTERN array.hxx

--- a/include/CMakeLists.txt.template
+++ b/include/CMakeLists.txt.template
@@ -1,5 +1,5 @@
 install(
-    DIRECTORY pqxx
+    DIRECTORY pqxx "${PROJECT_BINARY_DIR}/include/pqxx"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING
 ###MAKTEMPLATE:FOREACH include/pqxx/*.hxx


### PR DESCRIPTION
I get the following error after CMake out-of-source build: "include/pqxx/compiler-public.hxx(13): fatal error C1083:  cannot open include file 'pqxx/config-public-compiler.h':No such file"

I found the cause of this problem, `install(DIRECOTRY pqxx)` command in `include/CMakeLists.txt`,

If the argument is a relative path, `install` command searches the CMake source directory, but  `config-public-compiler.h` is generated under `${PROJECT_BINARY_DIR}/include/pqxx` (CMake out-of-source build has a different `PROJECT_SOURCE_DIR` and `PROJECT_BINARY_DIR`).

This problem can be solved by adding an `${PROJECT_BINARY_DIR}/include/pqxx` to `install(DIRECTORY)` command arguments.


