### PR TITLE
Improve generate config-public-compiler.h when using CMake

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -76,7 +76,7 @@ endif (def)
 set(CMAKE_REQUIRED_QUIET OFF)
 
 set(AC_CONFIG_H_IN "${PROJECT_SOURCE_DIR}/include/pqxx/config.h.in")
-set(CM_CONFIG_H_IN "${PROJECT_BINARY_DIR}/include/pqxx/config.h.in")
+set(CM_CONFIG_H_IN "${PROJECT_BINARY_DIR}/include/pqxx/config_cmake.h.in")
 set(CM_CONFIG_PUB "${PROJECT_BINARY_DIR}/include/pqxx/config-public-compiler.h")
 set(CM_CONFIG_INT "${PROJECT_BINARY_DIR}/include/pqxx/config-internal-compiler.h")
 message(STATUS "Generating config.h")


### PR DESCRIPTION
When CMake in-source build, the source directory and the binary directory are the same.

CMake set the same value for `AC_CONFIG_H_IN` and `CM_CONFIG_H_IN`.
`file(WRITE "${CM_CONFIG_H_IN}" "")` command is clear file contents so that the generated `config-public-compiler.h` is also empty.

This problem can be avoided by changing the value of `CM_CONFIG_H_IN`.