### PR TITLE
Make pkg config default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,7 +392,7 @@ AC_ARG_WITH(
         [test "x$with_postgres_include" = "xyes"],
         [with_postgres_include=""]))
 
-if test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
+if test -n "$PKG_CONFIG" && test -x "$PKG_CONFIG"; then
 AS_IF(
     [test -z "$with_postgres_include"],
     [with_postgres_include=$($PKG_CONFIG libpq --cflags | sed 's/^-I//')])
@@ -400,7 +400,7 @@ AC_MSG_NOTICE([using PostgreSQL headers at $with_postgres_include])
 AC_SUBST(with_postgres_include)
 POSTGRES_INCLUDE="-I${with_postgres_include}"
 AC_SUBST(POSTGRES_INCLUDE)
-elif test -n "$PG_CONFIG" && test -r "$PG_CONFIG"; then
+elif test -n "$PG_CONFIG" && test -x "$PG_CONFIG"; then
 AS_IF(
     [test -z "$with_postgres_include"],
     [with_postgres_include=$($PG_CONFIG --includedir)])
@@ -426,7 +426,7 @@ AC_ARG_WITH(
         [test "x$with_postgres_lib" = "xyes"],
         [with_postgres_lib=""]))
 
-if test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
+if test -n "$PKG_CONFIG" && test -x "$PKG_CONFIG"; then
     AS_IF(
        [test -z "$with_postgres_lib"],
        [with_postgres_lib=$($PKG_CONFIG libpq --libs-only-L | sed 's/^-L//')])
@@ -435,7 +435,7 @@ if test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
     AC_SUBST(with_postgres_lib, "")
     #POSTGRES_LIB="-R${with_postgres_lib}"
     AC_SUBST(POSTGRES_LIB)
-elif test -n "$PG_CONFIG" && test -r "$PG_CONFIG"; then
+elif test -n "$PG_CONFIG" && test -x "$PG_CONFIG"; then
     AS_IF(
        [test -z "$with_postgres_lib"],
        [with_postgres_lib=$($PG_CONFIG --libdir)])

--- a/configure.ac
+++ b/configure.ac
@@ -392,18 +392,18 @@ AC_ARG_WITH(
         [test "x$with_postgres_include" = "xyes"],
         [with_postgres_include=""]))
 
-if test -n "$PG_CONFIG" && test -r "$PG_CONFIG"; then
+if test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
 AS_IF(
     [test -z "$with_postgres_include"],
-    [with_postgres_include=$($PG_CONFIG --includedir)])
+    [with_postgres_include=$($PKG_CONFIG libpq --cflags | sed 's/^-I//')])
 AC_MSG_NOTICE([using PostgreSQL headers at $with_postgres_include])
 AC_SUBST(with_postgres_include)
 POSTGRES_INCLUDE="-I${with_postgres_include}"
 AC_SUBST(POSTGRES_INCLUDE)
-elif test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
+elif test -n "$PG_CONFIG" && test -r "$PG_CONFIG"; then
 AS_IF(
     [test -z "$with_postgres_include"],
-    [with_postgres_include=$($PKG_CONFIG libpq --cflags | sed 's/^-I//')])
+    [with_postgres_include=$($PG_CONFIG --includedir)])
 AC_MSG_NOTICE([using PostgreSQL headers at $with_postgres_include])
 AC_SUBST(with_postgres_include)
 POSTGRES_INCLUDE="-I${with_postgres_include}"
@@ -426,21 +426,21 @@ AC_ARG_WITH(
         [test "x$with_postgres_lib" = "xyes"],
         [with_postgres_lib=""]))
 
-if test -n "$PG_CONFIG" && test -r "$PG_CONFIG"; then
-    AS_IF(
-       [test -z "$with_postgres_lib"],
-       [with_postgres_lib=$($PG_CONFIG --libdir)])
-    AC_MSG_NOTICE([using PostgreSQL libraries at $with_postgres_lib])
-    AC_SUBST(with_postgres_lib)
-    #POSTGRES_LIB="-R${with_postgres_lib}"
-    AC_SUBST(POSTGRES_LIB)
-elif test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
+if test -n "$PKG_CONFIG" && test -r "$PKG_CONFIG"; then
     AS_IF(
        [test -z "$with_postgres_lib"],
        [with_postgres_lib=$($PKG_CONFIG libpq --libs-only-L | sed 's/^-L//')])
     AC_MSG_NOTICE([using PostgreSQL libraries at $with_postgres_lib])
     # configure insists on inserting a library search path, so give him a standard one ...
     AC_SUBST(with_postgres_lib, "")
+    #POSTGRES_LIB="-R${with_postgres_lib}"
+    AC_SUBST(POSTGRES_LIB)
+elif test -n "$PG_CONFIG" && test -r "$PG_CONFIG"; then
+    AS_IF(
+       [test -z "$with_postgres_lib"],
+       [with_postgres_lib=$($PG_CONFIG --libdir)])
+    AC_MSG_NOTICE([using PostgreSQL libraries at $with_postgres_lib])
+    AC_SUBST(with_postgres_lib)
     #POSTGRES_LIB="-R${with_postgres_lib}"
     AC_SUBST(POSTGRES_LIB)
 fi


### PR DESCRIPTION
Make pkg-config the preferred/default config program by first checking for pkg-config and, if that is not available, check for pg_config.