### PR TITLE
Fix some warnings

### DIFF
--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -266,7 +266,7 @@ template<> struct PQXX_LIBEXPORT string_traits<std::nullptr_t>
 {
   static constexpr const char *name() noexcept { return "nullptr_t"; }
   static constexpr bool has_null() noexcept { return true; }
-  static constexpr bool is_null(nullptr_t) noexcept { return true; }
+  static constexpr bool is_null(std::nullptr_t) noexcept { return true; }
   static constexpr std::nullptr_t null() { return nullptr; }
   static std::string to_string(const std::nullptr_t &)
 	{ return "null"; }

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -29,7 +29,7 @@ namespace pqxx::internal
 /** Each instantiation contains a static member called @c value which is the
  * type's name, as a string.
  */
-template<typename TYPE> const char *const type_name;
+template<typename TYPE> const char *const type_name = nullptr;
 
 #define PQXX_DECLARE_TYPE_NAME(TYPE) \
   template<> const char *const type_name<TYPE> = #TYPE

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -336,7 +336,7 @@ from_string(const std::string &Str, std::string &Obj)			//[t46]
  * resulting string will be human-readable and in a format suitable for use in
  * SQL queries.
  */
-template<typename T> constexpr std::string to_string(const T &Obj)
+template<typename T> std::string to_string(const T &Obj)
 	{ return string_traits<T>::to_string(Obj); }
 
 //@}

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -91,7 +91,7 @@ constexpr oid oid_none = 0;
  * @param end end of items sequence
  * @param access functor defining how to dereference sequence elements
  */
-template<typename ITER, typename ACCESS> constexpr
+template<typename ITER, typename ACCESS>
 std::string separated_list(						//[t00]
 	const std::string &sep,
 	ITER begin,
@@ -113,13 +113,13 @@ std::string separated_list(						//[t00]
 
 
 /// Render sequence as a string, using given separator between items.
-template<typename ITER> constexpr std::string
+template<typename ITER> std::string
 separated_list(const std::string &sep, ITER begin, ITER end)		//[t00]
 	{ return separated_list(sep, begin, end, [](ITER i){ return *i; }); }
 
 
 /// Render items in a container as a string, using given separator.
-template<typename CONTAINER> constexpr auto
+template<typename CONTAINER> auto
 separated_list(const std::string &sep, const CONTAINER &c)		//[t10]
 	/*
 	Always std::string; necessary because SFINAE doesn't work with the
@@ -167,7 +167,7 @@ template<
 		int
 	>::type=0
 >
-constexpr std::string
+std::string
 separated_list(const std::string &sep, const TUPLE &t, const ACCESS& access)
 {
   return
@@ -184,7 +184,7 @@ template<
 		int
 	>::type=0
 >
-constexpr std::string
+std::string
 separated_list(const std::string &sep, const TUPLE &t)
 {
   return separated_list(sep, t, [](const TUPLE &tup){return *tup;});


### PR DESCRIPTION
Just a couple of little things. The main bit is removal of `constexpr` where functions are dealing with `std::string` which is a not constexpr compatible.