### PR TITLE
Adds advice to use correct variant of the command prompt for x64 target

### DIFF
--- a/win32/INSTALL.txt
+++ b/win32/INSTALL.txt
@@ -81,8 +81,9 @@ Select a recent version of postgres and download the corrresponding .tar.gz or
 .tar.bz2 archive for that version.  Unpack the sources to some directory on your
 computer.
 
-Select "Visual Studio Command Prompt" from the Start menu.  Alternatively,
-open a Command Prompt window and run:
+Select "Visual Studio Command Prompt" from the Start menu ("Developer Command 
+Prompt" if building for x86 and "x64 Native Tools Command Prompt" if building 
+for x64). Alternatively, open a Command Prompt window and run:
 
     VCVARSALL.BAT amd64
 
@@ -156,8 +157,9 @@ The rest of the procedure depends on your compiler.
 
 If you're using Visual C++:
 
-1) Select Visual Studio Command Prompt from the Start menu.  Alternatively,
-   open a Command Prompt window and run
+1) Select Visual Studio Command Prompt from the Start menu ("Developer Command 
+   Prompt" if building for x86 and "x64 Native Tools Command Prompt" if building 
+   for x64). Alternatively, open a Command Prompt window and run
 
        VCVARSALL.BAT amd64
 


### PR DESCRIPTION
Using the default Visual Studio Developer Command Prompt will fail to build with linker errors if using the x64 version of Postgres as the source. To build successfully using the x64 version of Postgres source your must run the ```nmake``` command under the "x64 Native Tools Command Prompt" instead.

I tested this process with the "x64 Native Tools Command Prompt" and built 64 bit libpqxx .lib and .dll successfully.