### PR TITLE
Use the return value of PQescapeStringConn in order to speedup the result string creation

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -806,9 +806,9 @@ std::string pqxx::connection::esc(std::string_view str) const
   int err = 0;
   // TODO: Can we make a callback-based string_view alternative to this?
   // TODO: If we can, then quote() can wrap PQescapeLiteral()!
-  PQescapeStringConn(m_conn, buf.data(), str.data(), str.size(), &err);
+  const auto copied = PQescapeStringConn(m_conn, buf.data(), str.data(), str.size(), &err);
   if (err) throw argument_error{err_msg()};
-  return std::string{buf.data()};
+  return std::string{buf.data(), copied};
 }
 
 


### PR DESCRIPTION
Let's avoid to perform the copy until a 0 is found.

With the change the result string creation is ~3.8 time faster.

http://quick-bench.com/2T6xIpi8dMohB3j51X_O0TxTgZI