### PR TITLE
Update configure to strip whitespace

### DIFF
--- a/configure
+++ b/configure
@@ -19003,7 +19003,7 @@ fi
 
 if test -n "$PKG_CONFIG" && test -x "$PKG_CONFIG"; then
 if test -z "$with_postgres_include"; then :
-  with_postgres_include=$($PKG_CONFIG libpq --cflags | sed 's/^-I//')
+  with_postgres_include=$($PKG_CONFIG libpq --cflags | sed 's/^-I//' | sed 's/ *$//g')
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: using PostgreSQL headers at $with_postgres_include" >&5
 $as_echo "$as_me: using PostgreSQL headers at $with_postgres_include" >&6;}


### PR DESCRIPTION
Strip trailing spaces, needed on a Red Hat 6.6 Linux scientific compute cluster with a local install of PostgreSQL the complete issue has been documented at https://stackoverflow.com/questions/58755491