### PR TITLE
libpqxx-compile-with-vs2019

### DIFF
--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -108,7 +108,7 @@ template<typename T> constexpr inline char *bottom_to_buf(char *end)
 template<typename T> inline char *
 wrap_to_chars(char *begin, char *end, const T &value)
 {
-  const auto res = std::to_chars(begin, end - 1, value);
+  auto res = std::to_chars(begin, end - 1, value);
   if (res.ec != std::errc()) switch (res.ec)
   {
   case std::errc::value_too_large:


### PR DESCRIPTION
I compiled libpqxx with vs2019 and the nmake.exe reported an error that the program tries to change a const variable in `src/strconv.cxx`, line 124. I found it in line 111 that the type of `res` is `const auto`, so I delete the `const` and passed the compilation.