### PR TITLE
build: cmake: fix indentation from #232

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,9 +78,9 @@ if(NOT SKIP_PQXX_SHARED)
     add_library(pqxx_shared SHARED ${CXX_SOURCES} ${CXX_SHARED_EXTRA_SOURCE})
     target_compile_definitions(pqxx_shared PUBLIC -DPQXX_SHARED)
     set_target_properties(pqxx_shared PROPERTIES
-        OUTPUT_NAME pqxx
-        VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-        SOVERSION ${PROJECT_VERSION_MAJOR}
+    	OUTPUT_NAME pqxx
+    	VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+    	SOVERSION ${PROJECT_VERSION_MAJOR}
     )
     library_target_setup(pqxx_shared)
 endif()

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -44,9 +44,9 @@ if(NOT SKIP_PQXX_SHARED)
     add_library(pqxx_shared SHARED ${CXX_SOURCES} ${CXX_SHARED_EXTRA_SOURCE})
     target_compile_definitions(pqxx_shared PUBLIC -DPQXX_SHARED)
     set_target_properties(pqxx_shared PROPERTIES
-        OUTPUT_NAME pqxx
-        VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-        SOVERSION ${PROJECT_VERSION_MAJOR}
+    	OUTPUT_NAME pqxx
+    	VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+    	SOVERSION ${PROJECT_VERSION_MAJOR}
     )
     library_target_setup(pqxx_shared)
 endif()


### PR DESCRIPTION
When PR #232 was submitted, it had both indentation and line-continuation using 4-column format. It should have been rebased on top of PR #234 before merging, but I did not get there in time. This PR corrects that by using tabs for line-continuations as per #234.

 * `src/CMakeLists.txt{,.template}`: Use tabs for line continuations