### PR TITLE
build: autotools: fix autotools SONAME

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,12 @@ AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR([config/m4])
 AM_INIT_AUTOMAKE
 
+PQXX_MAJOR=m4_esyscmd_s([./tools/extract_version --major])
+PQXX_MINOR=m4_esyscmd_s([./tools/extract_version --minor])
 PQXX_ABI=m4_esyscmd_s([./tools/extract_version --abi])
 AC_SUBST(PQXXVERSION)
+AC_SUBST(PQXX_MAJOR)
+AC_SUBST(PQXX_MINOR)
 AC_SUBST(PQXX_ABI)
 
 AC_CONFIG_HEADER([include/pqxx/config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AM_INIT_AUTOMAKE
 PQXX_MAJOR=m4_esyscmd_s([./tools/extract_version --major])
 PQXX_MINOR=m4_esyscmd_s([./tools/extract_version --minor])
 PQXX_ABI=m4_esyscmd_s([./tools/extract_version --abi])
-AC_SUBST(PQXXVERSION)
+AC_SUBST(PQXXVERSION, $PACKAGE_VERSION)
 AC_SUBST(PQXX_MAJOR)
 AC_SUBST(PQXX_MINOR)
 AC_SUBST(PQXX_ABI)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,7 @@ libpqxx_la_SOURCES = \
 	util.cxx \
 	version.cxx
 
-libpqxx_version = -release $(PQXX_ABI)
+libpqxx_version = -version-info $(PQXX_MAJOR):$(PQXX_MINOR):0
 
 libpqxx_la_LDFLAGS = $(libpqxx_version) \
 	-rpath $(libdir) \


### PR DESCRIPTION
This uses the `libtool` `-version-info` for setting the shared library SONAME instead of `-release`. When using the `-release` flag, every release of the package will be binary incompatible with any other release. On the other hand, in simple cases where semantic versioning is followed, minor releases may be ABI-compatible. Thus, in these simple cases, the major and minor releases correspond to the `current` and `revision` parameters used for `-version-info`.

This should complete the fix for #2 since both autotools and CMake should correctly set the SONAME.

This also properly sets the previously undefined `PQXXVERSION` output value to the `$PACKAGE_VERSION` set by `AC_INIT`.

**NOTE**: I have not at present regenerated the autotools output files in this PR. This is because I am using a newer version of autotools (i.e. automake 1.16.1 vs. 1.15.1), and don't want to force an update only to have the maintainer's version later downgraded. Either I can regenerate the autotools output for this PR, or the maintainer can do so.