### PR TITLE
build: CMake pqxx improvements

### DIFF
--- a/libpqxx.pc.in
+++ b/libpqxx.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: libpqxx
 Description: C++ client API for the PostgreSQL database management system.
 Version: @VERSION@
-Libs: -L${libdir} -L@with_postgres_lib@ -lpqxx
-Cflags: -I${includedir} -I@with_postgres_include@
+Libs: -L${libdir} -lpqxx
+Cflags: -I${includedir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,27 @@ macro(library_target_setup tgt)
     	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
+    get_target_property(name ${tgt} NAME)
+    get_target_property(output_name ${tgt} OUTPUT_NAME)
+    if(NOT name STREQUAL output_name)
+        # Create library symlink
+        get_target_property(target_type ${tgt} TYPE)
+        if(target_type STREQUAL "SHARED_LIBRARY")
+            set(library_prefix ${CMAKE_SHARED_LIBRARY_PREFIX})
+            set(library_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
+        elseif(target_type STREQUAL "STATIC_LIBRARY")
+            set(library_prefix ${CMAKE_STATIC_LIBRARY_PREFIX})
+            set(library_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
+        endif()
+        add_custom_target(library_symlink ALL
+        	${CMAKE_COMMAND} -E create_symlink
+        		${library_prefix}${output_name}${library_suffix}
+        		${library_prefix}${name}${library_suffix}
+        )
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${library_prefix}${name}${library_suffix}
+        	DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+    endif()
 endmacro()
 
 file(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,3 +100,14 @@ set_target_properties(
 	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
 )
 library_target_setup(pqxx)
+
+# install pkg-config file
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix \${prefix})
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(VERSION ${PROJECT_VERSION})
+configure_file(${CMAKE_SOURCE_DIR}/libpqxx.pc.in ${CMAKE_BINARY_DIR}/libpqxx.pc)
+install(FILES ${CMAKE_BINARY_DIR}/libpqxx.pc
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,8 +74,8 @@ if(NOT SKIP_PQXX_SHARED)
     add_library(pqxx_shared SHARED ${CXX_SOURCES} ${CXX_SHARED_EXTRA_SOURCE})
     target_compile_definitions(pqxx_shared PUBLIC PQXX_SHARED)
     set_target_properties(
-        pqxx_shared PROPERTIES
-        OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    	pqxx_shared PROPERTIES
+    	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     )
     library_target_setup(pqxx_shared)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,23 +67,15 @@ file(
 	version.cxx
 )
 
-if(NOT SKIP_PQXX_SHARED)
-    set(CXX_SHARED_EXTRA_SOURCE)
+add_library(pqxx ${CXX_SOURCES})
 
-    # Build a shared library
-    add_library(pqxx_shared SHARED ${CXX_SOURCES} ${CXX_SHARED_EXTRA_SOURCE})
-    target_compile_definitions(pqxx_shared PUBLIC PQXX_SHARED)
-    set_target_properties(
-    	pqxx_shared PROPERTIES
-    	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-    )
-    library_target_setup(pqxx_shared)
+get_target_property(pqxx_target_type pqxx TYPE)
+if(pqxx_target_type STREQUAL "SHARED_LIBRARY")
+    target_compile_definitions(pqxx PUBLIC PQXX_SHARED)
 endif()
 
-# XXX: Experimentally disabled.
-#if(NOT SKIP_PQXX_STATIC)
-#    # Build a static libary
-#    add_library(pqxx_static STATIC ${CXX_SOURCES})
-#    set_target_properties(pqxx_static PROPERTIES OUTPUT_NAME pqxx)
-#    library_target_setup(pqxx_static)
-#endif()
+set_target_properties(
+	pqxx PROPERTIES
+	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+)
+library_target_setup(pqxx)

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -33,23 +33,15 @@ file(
 ###MAKTEMPLATE:ENDFOREACH
 )
 
-if(NOT SKIP_PQXX_SHARED)
-    set(CXX_SHARED_EXTRA_SOURCE)
+add_library(pqxx ${CXX_SOURCES})
 
-    # Build a shared library
-    add_library(pqxx_shared SHARED ${CXX_SOURCES} ${CXX_SHARED_EXTRA_SOURCE})
-    target_compile_definitions(pqxx_shared PUBLIC PQXX_SHARED)
-    set_target_properties(
-    	pqxx_shared PROPERTIES
-    	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-    )
-    library_target_setup(pqxx_shared)
+get_target_property(pqxx_target_type pqxx TYPE)
+if(pqxx_target_type STREQUAL "SHARED_LIBRARY")
+    target_compile_definitions(pqxx PUBLIC PQXX_SHARED)
 endif()
 
-# XXX: Experimentally disabled.
-#if(NOT SKIP_PQXX_STATIC)
-#    # Build a static libary
-#    add_library(pqxx_static STATIC ${CXX_SOURCES})
-#    set_target_properties(pqxx_static PROPERTIES OUTPUT_NAME pqxx)
-#    library_target_setup(pqxx_static)
-#endif()
+set_target_properties(
+	pqxx PROPERTIES
+	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+)
+library_target_setup(pqxx)

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -24,6 +24,27 @@ macro(library_target_setup tgt)
     	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
+    get_target_property(name ${tgt} NAME)
+    get_target_property(output_name ${tgt} OUTPUT_NAME)
+    if(NOT name STREQUAL output_name)
+        # Create library symlink
+        get_target_property(target_type ${tgt} TYPE)
+        if(target_type STREQUAL "SHARED_LIBRARY")
+            set(library_prefix ${CMAKE_SHARED_LIBRARY_PREFIX})
+            set(library_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
+        elseif(target_type STREQUAL "STATIC_LIBRARY")
+            set(library_prefix ${CMAKE_STATIC_LIBRARY_PREFIX})
+            set(library_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
+        endif()
+        add_custom_target(library_symlink ALL
+        	${CMAKE_COMMAND} -E create_symlink
+        		${library_prefix}${output_name}${library_suffix}
+        		${library_prefix}${name}${library_suffix}
+        )
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${library_prefix}${name}${library_suffix}
+        	DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+    endif()
 endmacro()
 
 file(

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -66,3 +66,14 @@ set_target_properties(
 	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
 )
 library_target_setup(pqxx)
+
+# install pkg-config file
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix \${prefix})
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(VERSION ${PROJECT_VERSION})
+configure_file(${CMAKE_SOURCE_DIR}/libpqxx.pc.in ${CMAKE_BINARY_DIR}/libpqxx.pc)
+install(FILES ${CMAKE_BINARY_DIR}/libpqxx.pc
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -40,8 +40,8 @@ if(NOT SKIP_PQXX_SHARED)
     add_library(pqxx_shared SHARED ${CXX_SOURCES} ${CXX_SHARED_EXTRA_SOURCE})
     target_compile_definitions(pqxx_shared PUBLIC PQXX_SHARED)
     set_target_properties(
-        pqxx_shared PROPERTIES
-        OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    	pqxx_shared PROPERTIES
+    	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     )
     library_target_setup(pqxx_shared)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,7 +74,7 @@ file(
 )
 
 add_executable(runner ${TEST_SOURCES})
-target_link_libraries(runner PUBLIC pqxx_shared)
+target_link_libraries(runner PUBLIC pqxx)
 add_test(
 	NAME runner
 	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}

--- a/test/CMakeLists.txt.template
+++ b/test/CMakeLists.txt.template
@@ -9,7 +9,7 @@ file(
 )
 
 add_executable(runner ${TEST_SOURCES})
-target_link_libraries(runner PUBLIC pqxx_shared)
+target_link_libraries(runner PUBLIC pqxx)
 add_test(
 	NAME runner
 	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -54,7 +54,7 @@ file(
 )
 
 add_executable(unit_runner ${UNIT_TEST_SOURCES})
-target_link_libraries(unit_runner PUBLIC pqxx_shared)
+target_link_libraries(unit_runner PUBLIC pqxx)
 target_include_directories(unit_runner PRIVATE ${PostgreSQL_INCLUDE_DIRS})
 add_test(
 	NAME unit_runner

--- a/test/unit/CMakeLists.txt.template
+++ b/test/unit/CMakeLists.txt.template
@@ -10,7 +10,7 @@ file(
 )
 
 add_executable(unit_runner ${UNIT_TEST_SOURCES})
-target_link_libraries(unit_runner PUBLIC pqxx_shared)
+target_link_libraries(unit_runner PUBLIC pqxx)
 target_include_directories(unit_runner PRIVATE ${PostgreSQL_INCLUDE_DIRS})
 add_test(
 	NAME unit_runner


### PR DESCRIPTION
This fixes several issues in the CMake build system, as discussed in #239.

1. Fixes some indentation following up from ce46fa732b11249cc0e0df01d57f7ad210ec9dd0
2. Removes the separate static and shared library targets. Instead, use `-DBUILD_SHARED_LIBS` to control which type of library to build.
3. Creates and installs symlinks for e.g. `libpqxx.so -> libpqxx-7.0.so`.
4. Fixes and installs the `libpqxx` pkg-config as part of the CMake installation. (Note that since PostgreSQL/`libpq` is a private dependency of `libpqxx`, it should not be part of the link interface for projects using `libpqxx`.)