### PR TITLE
build: autotools: define PQXXVERSION output variable value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_CONFIG_MACRO_DIR([config/m4])
 AM_INIT_AUTOMAKE
 
 PQXX_ABI=m4_esyscmd_s([./tools/extract_version --abi])
-AC_SUBST(PQXXVERSION)
+AC_SUBST(PQXXVERSION, $PACKAGE_VERSION)
 AC_SUBST(PQXX_ABI)
 
 AC_CONFIG_HEADER([include/pqxx/config.h])


### PR DESCRIPTION
Previously, `PQXXVERSION` was unset and therefore empty in the output files. This sets it to the `$PACKAGE_VERSION` defined by `AC_INIT`.

 * `configure.ac`: define `PQXXVERSION` as `$PACKAGE_VERSION`

**NOTE**: I have not at present regenerated the autotools output files in this PR. This is because I am using a newer version of autotools (i.e. automake 1.16.1 vs. 1.15.1), and don't want to force an update only to have the maintainer's version later downgraded. Either I can regenerate the autotools output for this PR, or the maintainer can do so.