### PR TITLE
build: cmake: use PROJECT_BINARY_DIR instead of CMAKE_BINARY_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ set(exec_prefix \${prefix})
 set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
 set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 set(VERSION ${PROJECT_VERSION})
-configure_file(${PROJECT_SOURCE_DIR}/libpqxx.pc.in ${CMAKE_BINARY_DIR}/libpqxx.pc)
-install(FILES ${CMAKE_BINARY_DIR}/libpqxx.pc
+configure_file(${PROJECT_SOURCE_DIR}/libpqxx.pc.in ${PROJECT_BINARY_DIR}/libpqxx.pc)
+install(FILES ${PROJECT_BINARY_DIR}/libpqxx.pc
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -73,7 +73,7 @@ set(exec_prefix \${prefix})
 set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
 set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 set(VERSION ${PROJECT_VERSION})
-configure_file(${PROJECT_SOURCE_DIR}/libpqxx.pc.in ${CMAKE_BINARY_DIR}/libpqxx.pc)
-install(FILES ${CMAKE_BINARY_DIR}/libpqxx.pc
+configure_file(${PROJECT_SOURCE_DIR}/libpqxx.pc.in ${PROJECT_BINARY_DIR}/libpqxx.pc)
+install(FILES ${PROJECT_BINARY_DIR}/libpqxx.pc
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )


### PR DESCRIPTION
`CMAKE_BINARY_DIR` refers to the top-level binary directory of the root CMake project. This is correct if `libpqxx` is not bundled as a dependency i.e. though `add_directory`, but `PROJECT_BINARY_DIR` will correctly handle this case as well.

This is the corresponding change to #256 but for the binary directory.

 * `src/CMakeLists.txt{,.template}`: `CMAKE_BINARY_DIR` -> `PROJECT_BINARY_DIR`