### PR TITLE
build: cmake: do not install include/pqxx/doc directory

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -107,6 +107,7 @@ install(
 		PATTERN internal/gates/transaction-transactionfocus.hxx
 		PATTERN config-public-compiler.h
 		PATTERN pqxx
+		PATTERN doc EXCLUDE
 )
 
 install(

--- a/include/CMakeLists.txt.template
+++ b/include/CMakeLists.txt.template
@@ -14,6 +14,7 @@ install(
 ###MAKTEMPLATE:ENDFOREACH
 		PATTERN config-public-compiler.h
 		PATTERN pqxx
+		PATTERN doc EXCLUDE
 )
 
 install(


### PR DESCRIPTION
Previously, `include/pqxx/doc` was being installed in e.g. `${CMAKE_INSTALL_PREFIX}/include/pqxx/doc`. It contained no files since these files are installed by the subsequent install command in the documentation directory (i.e. `${CMAKE_INSTALL_PREFIX}/share/doc/libpqxx`), as desired, but the (empty) source directory was still being installed in the `include` directory. This prevents this by explicitly excluding the `doc` directory from the list of files installed in the `include` directory.

 * `include/CMakeLists.txt{,.template}`: exclude doc directory from `include/pqxx` installation