### PR TITLE
Avoid create symlink on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,8 +96,8 @@ if(pqxx_target_type STREQUAL "SHARED_LIBRARY")
 endif()
 
 set_target_properties(
-	pqxx PROPERTIES
-	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    pqxx PROPERTIES
+    OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,pqxx,pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}>
 )
 library_target_setup(pqxx)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ macro(library_target_setup tgt)
     )
     get_target_property(name ${tgt} NAME)
     get_target_property(output_name ${tgt} OUTPUT_NAME)
-    if(NOT name STREQUAL output_name)
+    if(NOT name STREQUAL output_name AND NOT CMAKE_HOST_WIN32)
         # Create library symlink
         get_target_property(target_type ${tgt} TYPE)
         if(target_type STREQUAL "SHARED_LIBRARY")

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -62,8 +62,8 @@ if(pqxx_target_type STREQUAL "SHARED_LIBRARY")
 endif()
 
 set_target_properties(
-	pqxx PROPERTIES
-	OUTPUT_NAME pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    pqxx PROPERTIES
+    OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,pqxx,pqxx-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}>
 )
 library_target_setup(pqxx)
 

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -26,7 +26,7 @@ macro(library_target_setup tgt)
     )
     get_target_property(name ${tgt} NAME)
     get_target_property(output_name ${tgt} OUTPUT_NAME)
-    if(NOT name STREQUAL output_name)
+    if(NOT name STREQUAL output_name AND NOT CMAKE_HOST_WIN32)
         # Create library symlink
         get_target_property(target_type ${tgt} TYPE)
         if(target_type STREQUAL "SHARED_LIBRARY")


### PR DESCRIPTION
Ref #265 

This pull request has two changes.

1. Avoid create symbolic link when CMake build machine is Windows (host os).
2. Don't add version suffix to library name when building library for Windows (target os).

The important thing is that CMake takes into account different patterns of target OS and host OS (cross-compilation).
Since the host OS and the target OS are evaluated separately, for example, when building for Windows on Linux, no version suffix is ​​added to the generated Windows library.