### PR TITLE
cmake: regenerate CMakeLists.txt following removal of `include/pqxx/doc/README.md`

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -79,7 +79,6 @@ if(HAVE_DOXYGEN)
         "${PROJECT_SOURCE_DIR}/include/pqxx/util.hxx"
         "${PROJECT_SOURCE_DIR}/include/pqxx/version.hxx"
         "${PROJECT_SOURCE_DIR}/include/pqxx/zview.hxx"
-        "${PROJECT_SOURCE_DIR}/include/pqxx/doc/README.md"
         "${PROJECT_SOURCE_DIR}/include/pqxx/doc/accessing-results.md"
         "${PROJECT_SOURCE_DIR}/include/pqxx/doc/datatypes.md"
         "${PROJECT_SOURCE_DIR}/include/pqxx/doc/escaping.md"

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# ##############################################################################
+################################################################################
 # AUTOMATICALLY GENERATED FILE -- DO NOT EDIT.
 #
 # This file is generated automatically by libpqxx's template2mak.py script, and
@@ -10,7 +10,7 @@
 # libpqxx source archive.
 #
 # Generated from template './include/CMakeLists.txt.template'.
-# ##############################################################################
+################################################################################
 install(
     DIRECTORY pqxx "${PROJECT_BINARY_DIR}/include/pqxx"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -114,7 +114,6 @@ install(
     DIRECTORY pqxx/doc/
     DESTINATION ${CMAKE_INSTALL_DOCDIR}
     FILES_MATCHING
-    PATTERN README.md
     PATTERN accessing-results.md
     PATTERN datatypes.md
     PATTERN escaping.md


### PR DESCRIPTION
Following the removal of `include/pqxx/doc/README.md`, references to it should be removed from the CMake files, or CMake will fail to run. This is fixed by regenerating the relevant CMake files from their corresponding templates.

Fixes #269.

 * `doc/CMakeLists.txt`: regenerate from template
 * `include/CMakeLists.txt`: Likewise.