### PR TITLE
Generalize transactor callable

### DIFF
--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -14,6 +14,8 @@
 #include "pqxx/compiler-public.hxx"
 #include "pqxx/internal/compiler-internal-pre.hxx"
 
+#include <functional>
+
 #include "pqxx/connection.hxx"
 #include "pqxx/transaction.hxx"
 
@@ -94,8 +96,8 @@ namespace pqxx
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>
-inline auto perform(TRANSACTION_CALLBACK const &callback, int attempts = 3)
-  -> decltype(callback())
+inline auto perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
+  -> decltype(std::invoke(callback))
 {
   if (attempts <= 0)
     throw std::invalid_argument{
@@ -105,7 +107,7 @@ inline auto perform(TRANSACTION_CALLBACK const &callback, int attempts = 3)
   {
     try
     {
-      return callback();
+      return std::invoke(callback);
     }
     catch (in_doubt_error const &)
     {

--- a/test/unit/test_transactor.cxx
+++ b/test/unit/test_transactor.cxx
@@ -19,7 +19,7 @@ void test_transactor_newstyle_executes_simple_query()
 void test_transactor_newstyle_can_return_void()
 {
   bool done{false};
-  pqxx::perform([&done] { done = true; });
+  pqxx::perform([&done]() noexcept { done = true; });
   PQXX_CHECK(done, "Callback was not executed.");
 }
 
@@ -27,7 +27,7 @@ void test_transactor_newstyle_can_return_void()
 void test_transactor_newstyle_completes_upon_success()
 {
   int attempts{0};
-  pqxx::perform([&attempts]() { attempts++; });
+  pqxx::perform([&attempts]() noexcept { attempts++; });
   PQXX_CHECK_EQUAL(attempts, 1, "Successful transactor didn't run 1 time.");
 }
 


### PR DESCRIPTION
This permits calling `pqxx::perform` on a more general set of callable[1] objects by using `std::invoke`[2] for perfect forwarding.

I originally ran into an issue while trying to port a code base using `libpqxx` v4 to the v6/v7 transactors. While using a lambda function which captures all references necessary for the transaction does work and allows modifying the referenced data, even though the function call is const-qualified[3] as necessitated by the current signature of `pqxx::perform`[4], this requires having separate, externally referenced object(s) to store the state of the transaction. Previously, it was possible to have the state fully encapsulated inside the transactor object which could be modified as a result of the transaction. This generalization allows for this possibility by removing the const qualifier on the callable and uses perfect forwarding to invoke it.

[1] https://en.cppreference.com/w/cpp/named_req/Callable
[2] https://en.cppreference.com/w/cpp/utility/functional/invoke
[3] https://en.cppreference.com/w/cpp/language/lambda#ClosureType::operator.28.29.28params.29
[4] https://github.com/jtv/libpqxx/blob/7662d181ac5890933146818709352e5722d36c16/include/pqxx/transactor.hxx#L97