### PR TITLE
Avoid MSVC compile error

### DIFF
--- a/test/unit/test_stream_from.cxx
+++ b/test/unit/test_stream_from.cxx
@@ -157,7 +157,7 @@ void test_optional(pqxx::connection_base &connection)
   ASSERT_FIELD_EQUAL(std::get<1>(got_tuple), "2018-11-17 21:23:00");
   ASSERT_FIELD_NULL(std::get<2>(got_tuple));
   ASSERT_FIELD_NULL(std::get<3>(got_tuple));
-  ASSERT_FIELD_EQUAL(std::get<4>(got_tuple), "こんにちは");
+  ASSERT_FIELD_EQUAL(std::get<4>(got_tuple), "\u3053\u3093\u306b\u3061\u308f");
   ASSERT_FIELD_EQUAL(
     std::get<5>(got_tuple), (bytea{'f', 'o', 'o', ' ', 'b', 'a', 'r', '\0'}));
 
@@ -195,7 +195,7 @@ void test_stream_from()
     4321, ipv4{8, 8, 8, 8}, "hello world", bytea{'\x00', '\x01', '\x02'});
   tx.exec_params(
     "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)", 5678,
-    "2018-11-17 21:23:00", nullptr, nullptr, "こんにちは",
+    "2018-11-17 21:23:00", nullptr, nullptr, "\u3053\u3093\u306b\u3061\u308f",
     bytea{'f', 'o', 'o', ' ', 'b', 'a', 'r', '\0'});
   tx.exec_params(
     "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)", 910, nullptr,

--- a/test/unit/test_stream_to.cxx
+++ b/test/unit/test_stream_to.cxx
@@ -28,7 +28,7 @@ void test_nonoptionals(pqxx::connection_base &connection)
     1234, "now", 4321, ipv4{8, 8, 8, 8}, "hello world",
     bytea{'\x00', '\x01', '\x02'});
   inserter << std::make_tuple(
-    5678, "2018-11-17 21:23:00", nullptr, nullptr, "こんにちは",
+    5678, "2018-11-17 21:23:00", nullptr, nullptr, "\u3053\u3093\u306b\u3061\u308f",
     bytea{'f', 'o', 'o', ' ', 'b', 'a', 'r', '\0'});
   inserter << std::make_tuple(910, nullptr, nullptr, nullptr, "\\N", bytea{});
 


### PR DESCRIPTION
Ref #282

Visual Studio may fail to compile if multi-byte characters are included in the source code.
This is because Visual Studio does not assume that the source code is written in UTF-8.

The workaround for this problem is to save the file in UTF-8 with BOM or use escaped characters.