### PR TITLE
Fix handling of eof() in streambuffer underflow

### DIFF
--- a/include/pqxx/largeobject.hxx
+++ b/include/pqxx/largeobject.hxx
@@ -454,11 +454,10 @@ protected:
   {
     if (this->gptr() == nullptr)
       return eof();
-    char *const eb{this->eback()};
-    auto const res{int_type(
-      adjust_eof(m_obj.cread(this->eback(), static_cast<size_t>(m_bufsize))))};
-    this->setg(eb, eb, eb + ((res == eof()) ? 0 : res));
-    return ((res == 0) or (res == eof())) ? eof() : *eb;
+    auto *const eb{this->eback()};
+    auto const res = adjust_eof(m_obj.cread(this->eback(), static_cast<size_t>(m_bufsize)));
+    this->setg(eb, eb, eb + (res == eof() ? 0 : static_cast<size_t>(res)));
+    return (res == eof() || res == 0) ? eof() : traits_type::to_int_type(*eb);
   }
 
 private:


### PR DESCRIPTION
Fixes #284 

The gist is that the read character `char_type` needs to be converted to the corresponding `int_type` through `char_traits<char>::to_int_type(c)`, and that comparison with `eof()` should always involve the `int_type`, not the `char_type`. 

`char_type` is the actual data type of the buffer elements.
`int_type` is a type that could contain at least all valid `char_type` and the `eof()`, and as such is larger than `char_type`. 