### PR TITLE
Add possibility to use libpq builded from sources.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -14,7 +14,6 @@ include(CheckSymbolExists)
 include(CMakeDetermineCompileFeatures)
 include(CheckCXXSourceCompiles)
 include(CMakeFindDependencyMacro)
-find_dependency(PostgreSQL)
 
 check_function_exists("poll" PQXX_HAVE_POLL)
 

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -24,6 +24,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <vector>
+#include <limits>
 
 #include "pqxx/except.hxx"
 #include "pqxx/types.hxx"


### PR DESCRIPTION
This PR adds possibility to build `libpqxx` with `libpq` builded from sources(for example with cmake's `externalproject_add` directive) or just with manually defined `PostgreSQL_INCLUDE_DIRS` and `PostgreSQL_LIBRARIES`.
This `find_dependency(PostgreSQL)` is redundant because it checks librarry in the system path and prevents to generate header file when we setup `PostgreSQL_INCLUDE_DIRS` manually.

In my Ubuntu 20.04 cmake could not find a libpq. But it works with pkg-config. So with this changes It is possible to use pkg-config to setup needed variables. For example:
```
include(FindPkgConfig)
pkg_search_module(PostgreSQL REQUIRED libpq)
add_subdirectory(libs/libpqxx)
```
Addtionally I added  
`#include <limits>`
because it was missed and project don't compiles with gcc-10.
 

