### PR TITLE
Add a missed template parameter

### DIFF
--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -134,7 +134,7 @@ value built in.  In that case, define your nullness traits from
 
     namespace pqxx
     {
-    template<> struct nullness_traits<T> : pqxx::no_null {};
+    template<> struct nullness_traits<T> : pqxx::no_null<T> {};
     }
 
 (Here again you're defining this in the pqxx namespace.)


### PR DESCRIPTION
It looks like that the example (from docs) for `nullness_traits` contains a little mistake:

```c++
namespace pqxx
{
template<> struct nullness_traits<T> : pqxx::no_null {};
}
```

, `pqxx::no_null` - template class, so it required to specify a template parameter.

```c++
namespace pqxx
{
template<> struct nullness_traits<T> : pqxx::no_null<T> {};
}
```
