### PR TITLE
Replace find_dependency(PostgreSQL) with find_package(PostgreSQL REQU…

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -14,7 +14,10 @@ include(CheckSymbolExists)
 include(CMakeDetermineCompileFeatures)
 include(CheckCXXSourceCompiles)
 include(CMakeFindDependencyMacro)
-find_dependency(PostgreSQL)
+
+if(NOT PostgreSQL_FOUND)
+    find_package(PostgreSQL REQUIRED)
+endif()
 
 check_function_exists("poll" PQXX_HAVE_POLL)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 # Generated from template './src/CMakeLists.txt.template'.
 ################################################################################
-if(NOT PostgreSQL_INCLUDE_DIRS)
+if(NOT PostgreSQL_FOUND)
     find_package(PostgreSQL REQUIRED)
 endif()
 

--- a/src/CMakeLists.txt.template
+++ b/src/CMakeLists.txt.template
@@ -1,4 +1,4 @@
-if(NOT PostgreSQL_INCLUDE_DIRS)
+if(NOT PostgreSQL_FOUND)
     find_package(PostgreSQL REQUIRED)
 endif()
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 # Generated from template './test/unit/CMakeLists.txt.template'.
 # ##############################################################################
-if(NOT PostgreSQL_INCLUDE_DIRS)
+if(NOT PostgreSQL_FOUND)
     find_package(PostgreSQL REQUIRED)
 endif()
 

--- a/test/unit/CMakeLists.txt.template
+++ b/test/unit/CMakeLists.txt.template
@@ -1,4 +1,4 @@
-if(NOT PostgreSQL_INCLUDE_DIRS)
+if(NOT PostgreSQL_FOUND)
     find_package(PostgreSQL REQUIRED)
 endif()
 


### PR DESCRIPTION
Related #292. 

Should use `find_package()` over `find_dependency()` in non CMake Package Configuration File: https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html