### PR TITLE
Fix compile error "C2039: 'size_t': is not a member of 'std'" on MSVC

### DIFF
--- a/include/pqxx/internal/encoding_group.hxx
+++ b/include/pqxx/internal/encoding_group.hxx
@@ -9,6 +9,7 @@
 #ifndef PQXX_H_ENCODING_GROUP
 #define PQXX_H_ENCODING_GROUP
 
+#include <cstddef>
 
 namespace pqxx::internal
 {


### PR DESCRIPTION
Fix #316 