### PR TITLE
test: Properly order tests executed by test runner

### DIFF
--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -113,7 +113,7 @@ void create_pqxxevents(transaction_base &t)
 
 namespace
 {
-std::map<char const *, pqxx::test::testfunc> *all_tests{nullptr};
+std::map<std::string const, pqxx::test::testfunc> *all_tests{nullptr};
 } // namespace
 
 
@@ -123,7 +123,7 @@ void register_test(char const name[], pqxx::test::testfunc func)
 {
   if (all_tests == nullptr)
   {
-    all_tests = new std::map<char const *, pqxx::test::testfunc>();
+    all_tests = new std::map<std::string const, pqxx::test::testfunc>();
   }
   else
   {

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -3,8 +3,10 @@
 #include <cassert>
 #include <iostream>
 #include <list>
+#include <map>
 #include <new>
 #include <stdexcept>
+#include <string>
 
 #include <pqxx/transaction>
 

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -1,5 +1,5 @@
-#include <map>
 #include <stdexcept>
+#include <string>
 
 #include <pqxx/result>
 #include <pqxx/row>


### PR DESCRIPTION
The order of tests run is determined by the test map order, and since some tests depend on the output from previous tests, the map must be ordered based on lexicographical comparison. Using `char const*` for the map keys results in the map order being determined by the pointer order, not the lexicographical string order. Additionally, the pointer order is indeterminate since the C-string storage and static initialization order is indeterminate[1]. Thus, use a `std::string` key to create a test map in lexicographical order and run the tests in the correct order.

 * `test/runner.cxx`:
    - Use `std::string` for test map keys
    - Fix some `include`'s
  * `test/test_helpers.hxx`: Fix some `include`'s

[1] https://en.cppreference.com/w/cpp/language/initialization#Non-local_variables