### PR TITLE
Remove confusing commentary on pqxx::field::size()

### DIFF
--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -116,9 +116,6 @@ public:
   [[nodiscard]] bool is_null() const noexcept;
 
   /// Return number of bytes taken up by the field's value.
-  /**
-   * Includes the terminating zero byte.
-   */
   [[nodiscard]] size_type size() const noexcept;
 
   /// Read value into obj; or if null, leave obj untouched and return @c false.


### PR DESCRIPTION
According to the implementation of `field::view()`, common sense and some experiments, terminating zero byte is not included in size().