### PR TITLE
Fix infinite recursion in writing non-null optional into stream_to

### DIFF
--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -254,7 +254,7 @@ template<typename T> struct string_traits<std::optional<T>>
   static zview to_buf(char *begin, char *end, std::optional<T> const &value)
   {
     if (value.has_value())
-      return to_buf(begin, end, *value);
+      return string_traits<T>::to_buf(begin, end, *value);
     else
       return zview{};
   }


### PR DESCRIPTION
Found while experimenting with #357 