### PR TITLE
Add implicit zview ctors from const std::string& and string literals

### DIFF
--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -402,14 +402,6 @@ public:
 
   /// Execute a prepared statement, with optional arguments.
   template<typename... Args>
-  result exec_prepared(std::string const &statement, Args &&... args)
-  {
-    return internal_exec_prepared(
-      zview{statement.c_str(), statement.size()},
-      internal::params(std::forward<Args>(args)...));
-  }
-
-  template<typename... Args>
   result exec_prepared(zview statement, Args &&... args)
   {
     return internal_exec_prepared(
@@ -420,12 +412,6 @@ public:
   /** @throw pqxx::unexpected_rows if the result was not exactly 1 row.
    */
   template<typename... Args>
-  row exec_prepared1(std::string const &statement, Args &&... args)
-  {
-    return exec_prepared_n(1, statement, std::forward<Args>(args)...).front();
-  }
-
-  template<typename... Args>
   row exec_prepared1(zview statement, Args &&... args)
   {
     return exec_prepared_n(1, statement, std::forward<Args>(args)...).front();
@@ -434,12 +420,6 @@ public:
   /// Execute a prepared statement, and expect a result with zero rows.
   /** @throw pqxx::unexpected_rows if the result contained rows.
    */
-  template<typename... Args>
-  result exec_prepared0(std::string const &statement, Args &&... args)
-  {
-    return exec_prepared_n(0, statement, std::forward<Args>(args)...);
-  }
-
   template<typename... Args>
   result exec_prepared0(zview statement, Args &&... args)
   {
@@ -450,15 +430,6 @@ public:
   /** @throw pqxx::unexpected_rows if the result did not contain exactly the
    *  given number of rows.
    */
-  template<typename... Args>
-  result exec_prepared_n(
-    result::size_type rows, std::string const &statement, Args &&... args)
-  {
-    auto const r{exec_prepared(statement, std::forward<Args>(args)...)};
-    check_rowcount_prepared(statement, rows, r.size());
-    return r;
-  }
-
   template<typename... Args>
   result
   exec_prepared_n(result::size_type rows, zview statement, Args &&... args)
@@ -554,7 +525,7 @@ private:
 
   /// Throw unexpected_rows if prepared statement returned wrong no. of rows.
   void check_rowcount_prepared(
-    std::string const &statement, result::size_type expected_rows,
+    zview statement, result::size_type expected_rows,
     result::size_type actual_rows);
 
   /// Throw unexpected_rows if wrong row count from parameterised statement.

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -39,7 +39,7 @@ public:
   constexpr zview() noexcept = default;
 
   /// Convenience overload: construct using pointer and signed length.
-  constexpr zview(const char text[], std::ptrdiff_t len) :
+  constexpr zview(char const text[], std::ptrdiff_t len) :
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
@@ -57,13 +57,13 @@ public:
   {}
 
   /* implicit */
-  zview(const std::string& str) :
+  zview(std::string const& str) :
           std::string_view(str)
   {}
 
   /* implicit */
   template<size_t size>
-  constexpr zview(const char (&literal)[size]) :
+  constexpr zview(char const (&literal)[size]) :
           zview(literal, size - 1)
   {}
 

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -55,10 +55,16 @@ public:
   explicit constexpr zview(Args &&... args) :
           std::string_view(std::forward<Args>(args)...)
   {}
-  
+
   /* implicit */
-  zview (const std::string& str) :
-  	      std::string_view(str)
+  zview(const std::string& str) :
+          std::string_view(str)
+  {}
+
+  /* implicit */
+  template<size_t size>
+  constexpr zview(const char (&literal)[size]) :
+          zview(literal, size - 1)
   {}
 
   /// Either a null pointer, or a zero-terminated text buffer.

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -55,6 +55,11 @@ public:
   explicit constexpr zview(Args &&... args) :
           std::string_view(std::forward<Args>(args)...)
   {}
+  
+  /* implicit */
+  zview (const std::string& str) :
+  	      std::string_view(str)
+  {}
 
   /// Either a null pointer, or a zero-terminated text buffer.
   [[nodiscard]] constexpr char const *c_str() const noexcept { return data(); }

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -253,7 +253,7 @@ pqxx::result pqxx::transaction_base::exec_n(
 
 
 void pqxx::transaction_base::check_rowcount_prepared(
-  std::string const &statement, result::size_type expected_rows,
+  zview statement, result::size_type expected_rows,
   result::size_type actual_rows)
 {
   if (actual_rows != expected_rows)
@@ -262,7 +262,7 @@ void pqxx::transaction_base::check_rowcount_prepared(
       "Expected " + to_string(expected_rows) +
       " row(s) of data "
       "from prepared statement '" +
-      statement + "', got " + to_string(actual_rows) + "."};
+      std::string{statement} + "', got " + to_string(actual_rows) + "."};
   }
 }
 


### PR DESCRIPTION
According to the standard, std::string always holds null-terminated values, so it should be safe 

This ctor makes implementation of unescapeBytea method simple

```c++
std::string unescapeBytea(pqxx::zview escapedValue) {
    size_t size;
    auto result = PQunescapeBytea(reinterpret_cast<const unsigned char*>(escapedValue.c_str()), &size));
    //this is pseudocode, result must be free'd afterwards
    return std::string(reinterpret_cast<const char*>(result, size);
}
```

ctor from string literal allows changes described in #366