### PR TITLE
Use size_t / zview as column indices

### DIFF
--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -144,19 +144,7 @@ public:
   [[nodiscard]] PQXX_PURE row_size_type columns() const noexcept;
 
   /// Number of given column (throws exception if it doesn't exist).
-  row_size_type column_number(char const col_name[]) const;
-
-  /// Number of given column (throws exception if it doesn't exist).
-  row_size_type column_number(std::string const &name) const
-  {
-    return column_number(name.c_str());
-  }
-
-  /// Number of given column (throws exception if it doesn't exist).
-  row_size_type column_number(zview name) const
-  {
-    return column_number(name.c_str());
-  }
+  row_size_type column_number(zview name) const;
 
   /// Name of column with this number (throws exception if it doesn't exist)
   [[nodiscard]] char const *column_name(row_size_type number) const;
@@ -165,7 +153,7 @@ public:
   [[nodiscard]] oid column_type(row_size_type col_num) const;
 
   /// Return column's type, as an OID from the system catalogue.
-  template<typename STRING>[[nodiscard]] oid column_type(STRING col_name) const
+  [[nodiscard]] oid column_type(zview col_name) const
   {
     return column_type(column_number(col_name));
   }
@@ -174,8 +162,7 @@ public:
   [[nodiscard]] oid column_table(row_size_type col_num) const;
 
   /// What table did this column come from?
-  template<typename STRING>
-  [[nodiscard]] oid column_table(STRING col_name) const
+  [[nodiscard]] oid column_table(zview col_name) const
   {
     return column_table(column_number(col_name));
   }
@@ -184,8 +171,7 @@ public:
   [[nodiscard]] row_size_type table_column(row_size_type col_num) const;
 
   /// What column in its table did this column come from?
-  template<typename STRING>
-  [[nodiscard]] row_size_type table_column(STRING col_name) const
+  row_size_type table_column(zview col_name) const
   {
     return table_column(column_number(col_name));
   }

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -90,25 +90,13 @@ public:
   /** Address field by name.
    * @warning This is much slower than indexing by number, or iterating.
    */
-  [[nodiscard]] reference operator[](char const[]) const;
-  /** Address field by name.
-   * @warning This is much slower than indexing by number, or iterating.
-   */
-  [[nodiscard]] reference operator[](std::string const &s) const
-  {
-    return (*this)[s.c_str()];
-  }
+  [[nodiscard]] reference operator[](zview col_name) const;
 
   reference at(size_type) const;
   /** Address field by name.
    * @warning This is much slower than indexing by number, or iterating.
    */
-  reference at(char const[]) const;
-  /** Address field by name.
-   * @warning This is much slower than indexing by number, or iterating.
-   */
-  reference at(std::string const &s) const { return at(s.c_str()); }
-  //@}
+  reference at(zview col_name) const;
 
   [[nodiscard]] size_type size() const noexcept { return m_end - m_begin; }
 
@@ -126,19 +114,13 @@ public:
    */
   //@{
   /// Number of given column (throws exception if it doesn't exist).
-  [[nodiscard]] size_type column_number(std::string const &col_name) const
-  {
-    return column_number(col_name.c_str());
-  }
-
-  /// Number of given column (throws exception if it doesn't exist).
-  size_type column_number(char const[]) const;
+  [[nodiscard]] size_type column_number(zview col_name) const;
 
   /// Return a column's type.
   [[nodiscard]] oid column_type(size_type) const;
 
   /// Return a column's type.
-  template<typename STRING> oid column_type(STRING col_name) const
+  oid column_type(zview col_name) const
   {
     return column_type(column_number(col_name));
   }
@@ -147,7 +129,7 @@ public:
   [[nodiscard]] oid column_table(size_type col_num) const;
 
   /// What table did this column come from?
-  template<typename STRING> oid column_table(STRING col_name) const
+  oid column_table(zview col_name) const
   {
     return column_table(column_number(col_name));
   }
@@ -163,7 +145,7 @@ public:
   [[nodiscard]] size_type table_column(size_type) const;
 
   /// What column number in its table did this result column come from?
-  template<typename STRING> size_type table_column(STRING col_name) const
+  size_type table_column(zview col_name) const
   {
     return table_column(column_number(col_name));
   }

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -363,10 +363,10 @@ pqxx::oid pqxx::result::column_type(row::size_type col_num) const
 }
 
 
-pqxx::row::size_type pqxx::result::column_number(char const col_name[]) const
+pqxx::row::size_type pqxx::result::column_number(zview col_name) const
 {
   auto const n{
-    PQfnumber(const_cast<internal::pq::PGresult *>(m_data.get()), col_name)};
+    PQfnumber(const_cast<internal::pq::PGresult *>(m_data.get()), col_name.c_str())};
   if (n == -1)
     throw argument_error{
       "Unknown column name: '" + std::string{col_name} + "'."};

--- a/src/row.cxx
+++ b/src/row.cxx
@@ -107,9 +107,9 @@ pqxx::row::reference pqxx::row::operator[](size_type i) const noexcept
 }
 
 
-pqxx::row::reference pqxx::row::operator[](char const f[]) const
+pqxx::row::reference pqxx::row::operator[](zview col_name) const
 {
-  return at(f);
+  return at(col_name);
 }
 
 
@@ -128,9 +128,9 @@ void pqxx::row::swap(row &rhs) noexcept
 }
 
 
-pqxx::field pqxx::row::at(char const f[]) const
+pqxx::field pqxx::row::at(zview col_name) const
 {
-  return field{*this, m_begin + column_number(f)};
+  return field{*this, m_begin + column_number(col_name)};
 }
 
 
@@ -161,7 +161,7 @@ pqxx::row::size_type pqxx::row::table_column(size_type col_num) const
 }
 
 
-pqxx::row::size_type pqxx::row::column_number(char const col_name[]) const
+pqxx::row::size_type pqxx::row::column_number(zview col_name) const
 {
   auto const n{m_result.column_number(col_name)};
   if (n >= m_end)


### PR DESCRIPTION
This PR continues the work started in #365.
As far, as I see, this is the only PR that does not allow easy switching pqxx::result::size_type back to size_t (the issue is #366)