### PR TITLE
Tiny change

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -425,7 +425,7 @@ void pqxx::connection::cancel_query()
 {
   using pointer = std::unique_ptr<PGcancel, std::function<void(PGcancel *)>>;
   constexpr int buf_size{500};
-  std::array<char, buf_size> errbuf;
+  std::vector<char> errbuf(buf_size);
   pointer cancel{PQgetCancel(m_conn), PQfreeCancel};
   if (cancel == nullptr)
     throw std::bad_alloc{};


### PR DESCRIPTION
Can this change be done?

Building libpq (from sources) and libpqxx together using cmake results in such errors:
libpqxx/src/connection.cxx:428:30: error: implicit instantiation of undefined template 'std::__1::array<char, 500>'
  std::array<char, buf_size> errbuf;
And the reason for that is in building together with libpq sources. Changing to std::vector fixes everything. 