### PR TITLE
Always add visibility declarations.

### DIFF
--- a/configitems
+++ b/configitems
@@ -9,7 +9,7 @@ PQXX_HAVE_CHARCONV_FLOAT	internal	compiler
 PQXX_HAVE_CONCEPTS	public	compiler
 PQXX_HAVE_CXA_DEMANGLE	internal	compiler
 PQXX_HAVE_GCC_PURE	public	compiler
-PQXX_HAVE_GCC_VISIBILITY	internal	compiler
+PQXX_HAVE_GCC_VISIBILITY	public	compiler
 PQXX_HAVE_POLL       internal        compiler
 PQXX_HAVE_PQENCRYPTPASSWORDCONN	internal	libpq
 PQXX_HAVE_STRNLEN       public        compiler

--- a/include/pqxx/compiler-public.hxx
+++ b/include/pqxx/compiler-public.hxx
@@ -91,7 +91,13 @@
 #    endif
 
 #  endif // _MSC_VER
-#endif   // _WIN32
+
+#elif defined(__GNUC__) && defined(PQXX_HAVE_GCC_VISIBILITY) // !_WIN32
+
+#  define PQXX_LIBEXPORT __attribute__((visibility("default")))
+#  define PQXX_PRIVATE __attribute__((visibility("hidden")))
+
+#endif // __GNUC__ && PQXX_HAVE_GCC_VISIBILITY
 
 
 #ifndef PQXX_LIBEXPORT


### PR DESCRIPTION
When linking statically to libpqxx, using clang++, and (automatically
detected) --visibility=hidden --visibility-inlines-hidden flags,
I got the "ld: warning: direct access in function 'int pqxx::check_cast
... from file <here is my compilation unit> to global weak symbol
typeinfo for pqxx::range_error ... means the weak symbol cannot
be overridden at runtime. This was likely caused by different
translation units being compiled with different visibility settings.

I have verified it, but I had the same compilation settings.

However, reading https://gcc.gnu.org/wiki/Visibility , we see:

"Problems with C++ exceptions (please read!) Exception catching of a user
defined type in a binary other than the one which threw the exception requires
a typeinfo lookup. Go back and read that last statement again. When exceptions
start mysteriously malfunctioning, the cause is exactly this one!..."

What I found is that the configuration system in libpqxx have
defined #define PQXX_HAVE_GCC_VISIBILITY 1 in
config-private-compiler.h for me, but not in config-public-compiler.h.

The private one in turn kicked in in pqxx-source.hxx, which have set
PXX_LIBEXPORT to default there, so things are declared "visibility default"
which are marked as PQXX_EXPORT in the library compilation unit -
so far so good.

However, given that in the config-public-compiler.h the
PQXX_HAVE_GCC_VISIBILITY was not present (nor would it have had any effect),
the result is that the (nowadays standard) --fvisibility=hidden
compilation option resulted in these symbols being force-default
in the library compilation unit, but hidden in the user compilation
unit.

Now, reading further the above writing from gcc, we find the following
sentence: "However, this isn't the full story - it gets harder. Symbol
visibility is "default" by default but if the linker encounters just one
definition with it hidden - just one - that typeinfo symbol becomes permanently
hidden"

So my guess is that nowadays we need the "default" visibility not just
for dll code, but also for static linking for exceptions.

This changelist simply adds the default attribute to all exported
symbols for static linking too, and it seems to work well for me.
While I've learned about this topic tonight way more as much I ever
wanted, I still don't feel that I understand every detail --- let
me know if you know what I was doing wrong.