### PR TITLE
CMake option to install test executor binary

### DIFF
--- a/BUILDING-cmake.md
+++ b/BUILDING-cmake.md
@@ -84,6 +84,7 @@ Here are some popular `cmake` options for libpqxx:
  * `-DBUILD_SHARED_LIBS=on` to build a shared library.
  * `-DBUILD_SHARED_LIBS=off` to build a static library.
  * `-DBUILD_DOC=on` to build documentation.
+ * `-DINSTALL_TEST=on` to install test executor binary.
 
 On Windows, I recommend building libpqxx as a shared library and bundling it
 with your application.  On other platforms I would prefer a static library.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,3 +14,7 @@ add_test(
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     COMMAND runner
 )
+
+if(INSTALL_TEST)
+	install(PROGRAMS runner TYPE BIN RENAME libpqxx-test-runner)
+endif()


### PR DESCRIPTION
Sometimes it's necessary to run tests against the compiled library on target (possibly cross-compiled) platform. This will add good confidence that a library is actually trustworthy on the specific platform+environment. Ultimately I'm going to port this library into _OpenWRT_ ecosystem.

So I'm adding a CMAKE option to copy the `runner` binary.

I don't add anything to `configure` since looks like it has not been updated for awhile and does not reflect all current options.