### PR TITLE
New `blob::read(std::span<std::byte>)`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 7.4.2
  - Stop "aborting" nontransaction on closing.  (#419)
  - Silence an overzealous Visual C++ warning.  (#418)
+ - Starting support for C++20 `std::span`.
+ - New `blob::read()` using `std::span`.  (#429)
 7.4.1
  - Missing includes; broke macOS clang build.  (#416)
 7.4.0

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -125,7 +125,7 @@ public:
   template<typename ALLOC>
   std::basic_string_view<std::byte> read(std::vector<std::byte, ALLOC> buf)
   {
-    return std::basic_string_view<std::byte> { buf.data(), std::size(buf) }
+    return std::basic_string_view<std::byte>{buf.data(), std::size(buf)};
   }
 
 #endif // PQXX_HAVE_SPAN

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -88,7 +88,6 @@ runner_SOURCES = \
   unit/test_composite.cxx \
   unit/test_connection.cxx \
   unit/test_cursor.cxx \
-  unit/test_date.cxx \
   unit/test_encodings.cxx \
   unit/test_error_verbosity.cxx \
   unit/test_errorhandler.cxx \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -142,8 +142,7 @@ am_runner_OBJECTS = test00.$(OBJEXT) test01.$(OBJEXT) test02.$(OBJEXT) \
 	unit/test_binarystring.$(OBJEXT) unit/test_blob.$(OBJEXT) \
 	unit/test_cancel_query.$(OBJEXT) unit/test_column.$(OBJEXT) \
 	unit/test_composite.$(OBJEXT) unit/test_connection.$(OBJEXT) \
-	unit/test_cursor.$(OBJEXT) unit/test_date.$(OBJEXT) \
-	unit/test_encodings.$(OBJEXT) \
+	unit/test_cursor.$(OBJEXT) unit/test_encodings.$(OBJEXT) \
 	unit/test_error_verbosity.$(OBJEXT) \
 	unit/test_errorhandler.$(OBJEXT) unit/test_escape.$(OBJEXT) \
 	unit/test_exceptions.$(OBJEXT) unit/test_field.$(OBJEXT) \
@@ -216,8 +215,7 @@ am__depfiles_remade = ./$(DEPDIR)/runner.Po ./$(DEPDIR)/test00.Po \
 	unit/$(DEPDIR)/test_cancel_query.Po \
 	unit/$(DEPDIR)/test_column.Po unit/$(DEPDIR)/test_composite.Po \
 	unit/$(DEPDIR)/test_connection.Po \
-	unit/$(DEPDIR)/test_cursor.Po unit/$(DEPDIR)/test_date.Po \
-	unit/$(DEPDIR)/test_encodings.Po \
+	unit/$(DEPDIR)/test_cursor.Po unit/$(DEPDIR)/test_encodings.Po \
 	unit/$(DEPDIR)/test_error_verbosity.Po \
 	unit/$(DEPDIR)/test_errorhandler.Po \
 	unit/$(DEPDIR)/test_escape.Po \
@@ -520,7 +518,6 @@ runner_SOURCES = \
   unit/test_composite.cxx \
   unit/test_connection.cxx \
   unit/test_cursor.cxx \
-  unit/test_date.cxx \
   unit/test_encodings.cxx \
   unit/test_error_verbosity.cxx \
   unit/test_errorhandler.cxx \
@@ -619,8 +616,6 @@ unit/test_composite.$(OBJEXT): unit/$(am__dirstamp) \
 unit/test_connection.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
 unit/test_cursor.$(OBJEXT): unit/$(am__dirstamp) \
-	unit/$(DEPDIR)/$(am__dirstamp)
-unit/test_date.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
 unit/test_encodings.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
@@ -750,7 +745,6 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_composite.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_connection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_cursor.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_date.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_encodings.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_error_verbosity.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_errorhandler.Po@am__quote@ # am--include-marker
@@ -1096,7 +1090,6 @@ distclean: distclean-am
 	-rm -f unit/$(DEPDIR)/test_composite.Po
 	-rm -f unit/$(DEPDIR)/test_connection.Po
 	-rm -f unit/$(DEPDIR)/test_cursor.Po
-	-rm -f unit/$(DEPDIR)/test_date.Po
 	-rm -f unit/$(DEPDIR)/test_encodings.Po
 	-rm -f unit/$(DEPDIR)/test_error_verbosity.Po
 	-rm -f unit/$(DEPDIR)/test_errorhandler.Po
@@ -1226,7 +1219,6 @@ maintainer-clean: maintainer-clean-am
 	-rm -f unit/$(DEPDIR)/test_composite.Po
 	-rm -f unit/$(DEPDIR)/test_connection.Po
 	-rm -f unit/$(DEPDIR)/test_cursor.Po
-	-rm -f unit/$(DEPDIR)/test_date.Po
 	-rm -f unit/$(DEPDIR)/test_encodings.Po
 	-rm -f unit/$(DEPDIR)/test_error_verbosity.Po
 	-rm -f unit/$(DEPDIR)/test_errorhandler.Po


### PR DESCRIPTION
New overloads for `pqxx::blob::read()`.

In pre-C++20 environments, this takes a `std::vector` as proposed by @elelel in #429.  However, it returns a `std::basic_string_view<std::byte>` as a stepping stone towards the C++20 version.  Which doesn't make a lot of sense on its own, but I think the pieces come together nicely in C++20.

In C++20 environments, it takes a `std::span<std::byte>` and returns a sub-span of it.