### PR TITLE
CMake: Require version 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.8)
 
 file(READ VERSION VER_FILE_CONTENT)
 string(STRIP ${VER_FILE_CONTENT} VER_FILE_CONTENT)


### PR DESCRIPTION
* libpqxx defaults CXX_STANDARD to C++17, which is only supported since 3.8.
* This sets CMP0067 to NEW, which fixes #434.