### PR TITLE
Disable `max` macro expanding

### DIFF
--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -124,7 +124,7 @@ template<typename COUNTER = unsigned int> class placeholders
 public:
   /// Maximum number of parameters we support.
   static inline constexpr unsigned int max_params{
-    std::numeric_limits<COUNTER>::max()};
+    (std::numeric_limits<COUNTER>::max)()};
 
   placeholders()
   {


### PR DESCRIPTION
MSVC will report "warning C4003: not enough actual parameters for macro 'max'" with the compile option `/WX`.
If the `windows.h` header file is included, it will be expanded as a `max` function macro, and the compilation will fail.
Prevent the macro from being expanded to avoid the problem.