### PR TITLE
Fix disconnect memory leak.

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -231,8 +231,20 @@ pqxx::result pqxx::connection::make_result(
     else
       throw broken_connection{"Lost connection to the database server."};
   }
+
+  int enc_id = 0;
+  try
+  {
+    enc_id = encoding_id();
+  }
+  catch(std::exception& e)
+  {
+    clear_result(pgr);
+    throw;
+  }
+
   auto const r{pqxx::internal::gate::result_creation::create(
-    pgr, query, internal::enc_group(encoding_id()))};
+    pgr, query, internal::enc_group(enc_id))};
   pqxx::internal::gate::result_creation{r}.check_status(desc);
   return r;
 }


### PR DESCRIPTION
I ran into a memory leak when encoding_id() throws on error and `pgr` would remain unfreed in that case.

I'm not sure this is the best way to fix it as I am not familiar with the code base, let me know if a better way is available. Thanks!