### PR TITLE
WIP: When building DLL, export std types.

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -45,6 +45,7 @@ nobase_include_HEADERS= pqxx/pqxx \
 	pqxx/internal/conversions.hxx \
 	pqxx/internal/encoding_group.hxx \
 	pqxx/internal/encodings.hxx \
+	pqxx/internal/exports.hxx \
 	pqxx/internal/ignore-deprecated-post.hxx \
 	pqxx/internal/ignore-deprecated-pre.hxx \
 	pqxx/internal/libpq-forward.hxx \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -395,6 +395,7 @@ nobase_include_HEADERS = pqxx/pqxx \
 	pqxx/internal/conversions.hxx \
 	pqxx/internal/encoding_group.hxx \
 	pqxx/internal/encodings.hxx \
+	pqxx/internal/exports.hxx \
 	pqxx/internal/ignore-deprecated-post.hxx \
 	pqxx/internal/ignore-deprecated-pre.hxx \
 	pqxx/internal/libpq-forward.hxx \

--- a/include/pqxx/array
+++ b/include/pqxx/array
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/array.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/blob
+++ b/include/pqxx/blob
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/blob.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/composite
+++ b/include/pqxx/composite
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/composite.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/connection
+++ b/include/pqxx/connection
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/connection.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/cursor
+++ b/include/pqxx/cursor
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/cursor.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/dbtransaction
+++ b/include/pqxx/dbtransaction
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/dbtransaction.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/doc/mainpage.md.template
+++ b/include/pqxx/doc/mainpage.md.template
@@ -20,8 +20,8 @@ file.  The latest information can be found at http://pqxx.org/
 Some links that should help you find your bearings:
 * @ref getting-started
 * @ref thread-safety
-* @ref connection
-* @ref transaction
+* @ref connections
+* @ref transactions
 * @ref escaping
 * @ref performance
 * @ref transactor

--- a/include/pqxx/errorhandler
+++ b/include/pqxx/errorhandler
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/errorhandler.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/except
+++ b/include/pqxx/except
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/except.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/field
+++ b/include/pqxx/field
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/field.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/internal/compiler-public.hxx
+++ b/include/pqxx/internal/compiler-public.hxx
@@ -31,12 +31,17 @@
 // Workarounds for Windows
 #ifdef _WIN32
 
-/* For now, export DLL symbols if _DLL is defined.  This is done automatically
- * by the compiler when linking to the dynamic version of the runtime library,
+/* For now, export DLL symbols if _DLL is defined.  The compiler does this
+ * automatically when linking to the dynamic version of the runtime library,
  * according to "gzh"
  */
 #  if defined(PQXX_SHARED) && !defined(PQXX_LIBEXPORT)
 #    define PQXX_LIBEXPORT __declspec(dllimport)
+// PQXX_DLL_EXTERN is for declaring exported standard library items in a
+// DLL build.
+#    define PQXX_DLL_EXTERN extern
+# else // PQXX_SHARED && !PQXX_LIBEXPORT
+# define PQXX_DLL_EXTERN /**/
 #  endif // PQXX_SHARED && !PQXX_LIBEXPORT
 
 

--- a/include/pqxx/internal/exports.hxx
+++ b/include/pqxx/internal/exports.hxx
@@ -1,0 +1,37 @@
+/** Standard library symbols that we need to export for Windows DLL build.
+ *
+ * Apparently DLLs on Windows can't just throw or return standard library types
+ * such as @c std::string or @c std::runtime_error.  The library needs to
+ * export those explicitly.
+ */
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#  define PQXX_H_EXPORTS
+
+#  include <cstddef>
+#  include <memory>
+#  include <stdexcept>
+#  include <string>
+#  include <string_view>
+#  include <vector>
+
+#  include "pqxx/types.hxx"
+
+
+template class PQXX_LIBEXPORT
+  std::basic_string<char, std::char_traits<char>, std::allocator<char>>;
+template class PQXX_LIBEXPORT std::basic_string_view<char>;
+class PQXX_LIBEXPORT std::domain_error;
+class PQXX_LIBEXPORT std::invalid_argument;
+class PQXX_LIBEXPORT std::logic_error;
+class PQXX_LIBEXPORT std::out_of_range;
+class PQXX_LIBEXPORT std::runtime_error;
+template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
+template class PQXX_LIBEXPORT std::vector < pqxx::format,
+  std::allocator<pqxx::format>;
+template class PQXX_LIBEXPORT std::vector < char const *,
+  std::allocator<char const *>;
+template class PQXX_LIBEXPORT std::vector < int, std::allocator<int>;
+template class PQXX_LIBEXPORT std::vector < std::string_view,
+  std::allocator<std::string_view>;
+
+#endif

--- a/include/pqxx/internal/exports.hxx
+++ b/include/pqxx/internal/exports.hxx
@@ -17,21 +17,21 @@
 #  include "pqxx/types.hxx"
 
 
-template class PQXX_LIBEXPORT
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT
   std::basic_string<char, std::char_traits<char>, std::allocator<char>>;
-template class PQXX_LIBEXPORT std::basic_string_view<char>;
-class PQXX_LIBEXPORT std::domain_error;
-class PQXX_LIBEXPORT std::invalid_argument;
-class PQXX_LIBEXPORT std::logic_error;
-class PQXX_LIBEXPORT std::out_of_range;
-class PQXX_LIBEXPORT std::runtime_error;
-template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
-template class PQXX_LIBEXPORT std::vector < pqxx::format,
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::basic_string_view<char>;
+PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::domain_error;
+PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::invalid_argument;
+PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::logic_error;
+PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::out_of_range;
+PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::runtime_error;
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::vector < pqxx::format,
   std::allocator<pqxx::format>>;
-template class PQXX_LIBEXPORT std::vector < char const *,
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::vector < char const *,
   std::allocator<char const *>>;
-template class PQXX_LIBEXPORT std::vector < int, std::allocator<int>>;
-template class PQXX_LIBEXPORT std::vector < std::string_view,
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::vector < int, std::allocator<int>>;
+PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::vector < std::string_view,
   std::allocator<std::string_view>>;
 
 #endif

--- a/include/pqxx/internal/exports.hxx
+++ b/include/pqxx/internal/exports.hxx
@@ -27,7 +27,7 @@ class PQXX_LIBEXPORT std::out_of_range;
 class PQXX_LIBEXPORT std::runtime_error;
 template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
 template class PQXX_LIBEXPORT std::vector < pqxx::format,
-  std::allocator<pqxx::format>;
+  std::allocator<pqxx::format>>;
 template class PQXX_LIBEXPORT std::vector < char const *,
   std::allocator<char const *>>;
 template class PQXX_LIBEXPORT std::vector < int, std::allocator<int>>;

--- a/include/pqxx/internal/exports.hxx
+++ b/include/pqxx/internal/exports.hxx
@@ -20,11 +20,11 @@
 PQXX_DLL_EXTERN template class PQXX_LIBEXPORT
   std::basic_string<char, std::char_traits<char>, std::allocator<char>>;
 PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::basic_string_view<char>;
-PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::domain_error;
-PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::invalid_argument;
-PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::logic_error;
-PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::out_of_range;
-PQXX_DLL_EXTERN class PQXX_LIBEXPORT std::runtime_error;
+class PQXX_LIBEXPORT std::domain_error;
+class PQXX_LIBEXPORT std::invalid_argument;
+class PQXX_LIBEXPORT std::logic_error;
+class PQXX_LIBEXPORT std::out_of_range;
+class PQXX_LIBEXPORT std::runtime_error;
 PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
 PQXX_DLL_EXTERN template class PQXX_LIBEXPORT std::vector < pqxx::format,
   std::allocator<pqxx::format>>;

--- a/include/pqxx/internal/exports.hxx
+++ b/include/pqxx/internal/exports.hxx
@@ -29,9 +29,9 @@ template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
 template class PQXX_LIBEXPORT std::vector < pqxx::format,
   std::allocator<pqxx::format>;
 template class PQXX_LIBEXPORT std::vector < char const *,
-  std::allocator<char const *>;
-template class PQXX_LIBEXPORT std::vector < int, std::allocator<int>;
+  std::allocator<char const *>>;
+template class PQXX_LIBEXPORT std::vector < int, std::allocator<int>>;
 template class PQXX_LIBEXPORT std::vector < std::string_view,
-  std::allocator<std::string_view>;
+  std::allocator<std::string_view>>;
 
 #endif

--- a/include/pqxx/isolation
+++ b/include/pqxx/isolation
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/isolation.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/largeobject
+++ b/include/pqxx/largeobject
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/largeobject.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/nontransaction
+++ b/include/pqxx/nontransaction
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/nontransaction.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/notification
+++ b/include/pqxx/notification
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/notification.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/params
+++ b/include/pqxx/params
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/params.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/pipeline
+++ b/include/pqxx/pipeline
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/pipeline.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/prepared_statement
+++ b/include/pqxx/prepared_statement
@@ -1,3 +1,11 @@
 /// @deprecated Include @c <pqxx/params> instead.
+#include "pqxx/internal/compiler-internal-pre.hxx"
+#include "pqxx/internal/compiler-public.hxx"
+
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
 
 #include "params.hxx"
+
+#include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/range
+++ b/include/pqxx/range
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/range.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/result
+++ b/include/pqxx/result
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/result.hxx"
 
 // Now include some types which depend on result, but which the user will

--- a/include/pqxx/robusttransaction
+++ b/include/pqxx/robusttransaction
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/robusttransaction.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/row
+++ b/include/pqxx/row
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/result.hxx"
 #include "pqxx/row.hxx"
 

--- a/include/pqxx/separated_list
+++ b/include/pqxx/separated_list
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/separated_list.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/strconv
+++ b/include/pqxx/strconv
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/strconv.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/stream_from
+++ b/include/pqxx/stream_from
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/stream_from.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/stream_to
+++ b/include/pqxx/stream_to
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/stream_to.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/subtransaction
+++ b/include/pqxx/subtransaction
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/subtransaction.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/time
+++ b/include/pqxx/time
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/time.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/transaction
+++ b/include/pqxx/transaction
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/transaction.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/transaction_base
+++ b/include/pqxx/transaction_base
@@ -7,6 +7,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/transaction_base.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/transaction_focus
+++ b/include/pqxx/transaction_focus
@@ -5,6 +5,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/types.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/transactor
+++ b/include/pqxx/transactor
@@ -6,6 +6,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/transactor.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/types
+++ b/include/pqxx/types
@@ -5,5 +5,9 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/types.hxx"
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/util
+++ b/include/pqxx/util
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/util.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/version
+++ b/include/pqxx/version
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/version.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/include/pqxx/zview
+++ b/include/pqxx/zview
@@ -4,6 +4,10 @@
 #include "pqxx/internal/compiler-internal-pre.hxx"
 #include "pqxx/internal/compiler-public.hxx"
 
+#if !defined(PQXX_H_EXPORTS) && defined(_WIN32) && defined(PQXX_SHARED)
+#include "pqxx/internal/exports.hxx"
+#endif
+
 #include "pqxx/zview.hxx"
 
 #include "pqxx/internal/compiler-internal-post.hxx"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,7 @@ libpqxx_la_SOURCES = \
 	encodings.cxx \
 	errorhandler.cxx \
 	except.cxx \
+	exports.cxx \
 	field.cxx \
 	largeobject.cxx \
 	notification.cxx \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -134,11 +134,11 @@ am__installdirs = "$(DESTDIR)$(libdir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
 libpqxx_la_LIBADD =
 am_libpqxx_la_OBJECTS = array.lo binarystring.lo blob.lo connection.lo \
-	cursor.lo encodings.lo errorhandler.lo except.lo field.lo \
-	largeobject.lo notification.lo params.lo pipeline.lo result.lo \
-	robusttransaction.lo sql_cursor.lo strconv.lo stream_from.lo \
-	stream_to.lo subtransaction.lo time.lo transaction.lo \
-	transaction_base.lo row.lo util.lo version.lo
+	cursor.lo encodings.lo errorhandler.lo except.lo exports.lo \
+	field.lo largeobject.lo notification.lo params.lo pipeline.lo \
+	result.lo robusttransaction.lo sql_cursor.lo strconv.lo \
+	stream_from.lo stream_to.lo subtransaction.lo time.lo \
+	transaction.lo transaction_base.lo row.lo util.lo version.lo
 libpqxx_la_OBJECTS = $(am_libpqxx_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -165,16 +165,16 @@ am__depfiles_remade = ./$(DEPDIR)/array.Plo \
 	./$(DEPDIR)/binarystring.Plo ./$(DEPDIR)/blob.Plo \
 	./$(DEPDIR)/connection.Plo ./$(DEPDIR)/cursor.Plo \
 	./$(DEPDIR)/encodings.Plo ./$(DEPDIR)/errorhandler.Plo \
-	./$(DEPDIR)/except.Plo ./$(DEPDIR)/field.Plo \
-	./$(DEPDIR)/largeobject.Plo ./$(DEPDIR)/notification.Plo \
-	./$(DEPDIR)/params.Plo ./$(DEPDIR)/pipeline.Plo \
-	./$(DEPDIR)/result.Plo ./$(DEPDIR)/robusttransaction.Plo \
-	./$(DEPDIR)/row.Plo ./$(DEPDIR)/sql_cursor.Plo \
-	./$(DEPDIR)/strconv.Plo ./$(DEPDIR)/stream_from.Plo \
-	./$(DEPDIR)/stream_to.Plo ./$(DEPDIR)/subtransaction.Plo \
-	./$(DEPDIR)/time.Plo ./$(DEPDIR)/transaction.Plo \
-	./$(DEPDIR)/transaction_base.Plo ./$(DEPDIR)/util.Plo \
-	./$(DEPDIR)/version.Plo
+	./$(DEPDIR)/except.Plo ./$(DEPDIR)/exports.Plo \
+	./$(DEPDIR)/field.Plo ./$(DEPDIR)/largeobject.Plo \
+	./$(DEPDIR)/notification.Plo ./$(DEPDIR)/params.Plo \
+	./$(DEPDIR)/pipeline.Plo ./$(DEPDIR)/result.Plo \
+	./$(DEPDIR)/robusttransaction.Plo ./$(DEPDIR)/row.Plo \
+	./$(DEPDIR)/sql_cursor.Plo ./$(DEPDIR)/strconv.Plo \
+	./$(DEPDIR)/stream_from.Plo ./$(DEPDIR)/stream_to.Plo \
+	./$(DEPDIR)/subtransaction.Plo ./$(DEPDIR)/time.Plo \
+	./$(DEPDIR)/transaction.Plo ./$(DEPDIR)/transaction_base.Plo \
+	./$(DEPDIR)/util.Plo ./$(DEPDIR)/version.Plo
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -366,6 +366,7 @@ libpqxx_la_SOURCES = \
 	encodings.cxx \
 	errorhandler.cxx \
 	except.cxx \
+	exports.cxx \
 	field.cxx \
 	largeobject.cxx \
 	notification.cxx \
@@ -484,6 +485,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/encodings.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/errorhandler.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/except.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/exports.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/field.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/largeobject.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/notification.Plo@am__quote@ # am--include-marker
@@ -675,6 +677,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/encodings.Plo
 	-rm -f ./$(DEPDIR)/errorhandler.Plo
 	-rm -f ./$(DEPDIR)/except.Plo
+	-rm -f ./$(DEPDIR)/exports.Plo
 	-rm -f ./$(DEPDIR)/field.Plo
 	-rm -f ./$(DEPDIR)/largeobject.Plo
 	-rm -f ./$(DEPDIR)/notification.Plo
@@ -746,6 +749,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/encodings.Plo
 	-rm -f ./$(DEPDIR)/errorhandler.Plo
 	-rm -f ./$(DEPDIR)/except.Plo
+	-rm -f ./$(DEPDIR)/exports.Plo
 	-rm -f ./$(DEPDIR)/field.Plo
 	-rm -f ./$(DEPDIR)/largeobject.Plo
 	-rm -f ./$(DEPDIR)/notification.Plo

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -8,14 +8,25 @@
 
 #if defined(_WIN32) && defined(PQXX_SHARED)
 #include <cstddef>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
 
-template class PQXX_LIBEXPORT std::basic_string<char>;
-//template class PQXX_LIBEXPORT std::basic_string<std::byte>;
+#include "pqxx/types.hxx"
+
+
+template class PQXX_LIBEXPORT std::basic_string<char,std::char_traits<char>,std::allocator<char>>;
 template class PQXX_LIBEXPORT std::basic_string_view<char>;
-//template class PQXX_LIBEXPORT std::basic_string_view<std::byte>;
-template class PQXX_LIBEXPORT std::vector<std::string_view>;
+class PQXX_LIBEXPORT std::domain_error;
+class PQXX_LIBEXPORT std::invalid_argument;
+class PQXX_LIBEXPORT std::logic_error;
+class PQXX_LIBEXPORT std::out_of_range;
+class PQXX_LIBEXPORT std::runtime_error;
+template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
+template class PQXX_LIBEXPORT std::vector<pqxx::format,std::allocator<pqxx::format>;
+template class PQXX_LIBEXPORT std::vector<char const *,std::allocator<char const *>;
+template class PQXX_LIBEXPORT std::vector<int,std::allocator<int>;
+template class PQXX_LIBEXPORT std::vector<std::string_view,std::allocator<std::string_view>;
 
 #endif

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -7,12 +7,15 @@
 #include "pqxx-source.hxx"
 
 #if defined(_WIN32) && defined(PQXX_SHARED)
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <vector>
 
-template class PQXX_LIBEXPORT std::string<>;
-template class PQXX_LIBEXPORT std::string_view<>;
+template class PQXX_LIBEXPORT std::basic_string<char>;
+template class PQXX_LIBEXPORT std::basic_string<std::byte>;
+template class PQXX_LIBEXPORT std::basic_string_view<char>;
+template class PQXX_LIBEXPORT std::basic_string_view<std::byte>;
 template class PQXX_LIBEXPORT std::vector<std::string_view>;
 
 #endif

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -12,11 +12,9 @@
 
 
 #if defined(_WIN32) && defined(PQXX_SHARED)
-#  define PQXX_EXPORT_TYPE(type) template class PQXX_LIBEXPORT type
 
-PQXX_EXPORT_STD(std::string);
-PQXX_EXPORT_STD(std::string_view);
-PQXX_EXPORT_STD(std::vector<std::string_view>);
+template class PQXX_LIBEXPORT std::string;
+template class PQXX_LIBEXPORT std::string_view;
+template class PQXX_LIBEXPORT std::vector;
 
-#  undef PQXX_EXPORT_TYPE
 #endif

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -13,9 +13,9 @@
 #include <vector>
 
 template class PQXX_LIBEXPORT std::basic_string<char>;
-template class PQXX_LIBEXPORT std::basic_string<std::byte>;
+//template class PQXX_LIBEXPORT std::basic_string<std::byte>;
 template class PQXX_LIBEXPORT std::basic_string_view<char>;
-template class PQXX_LIBEXPORT std::basic_string_view<std::byte>;
+//template class PQXX_LIBEXPORT std::basic_string_view<std::byte>;
 template class PQXX_LIBEXPORT std::vector<std::string_view>;
 
 #endif

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -1,0 +1,22 @@
+/** Standard library symbols that we need to export for Windows DLL build.
+ *
+ * Apparently DLLs on Windows can't just throw or return standard library types
+ * such as @c std::string or @c std::runtime_error.  The library needs to
+ * export those explicitly.
+ */
+#include "pqxx-source.hxx"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+
+#if defined(_WIN32) && defined(PQXX_SHARED)
+#  define PQXX_EXPORT_TYPE(type) template class PQXX_LIBEXPORT type
+
+PQXX_EXPORT_STD(std::string);
+PQXX_EXPORT_STD(std::string_view);
+PQXX_EXPORT_STD(std::vector<std::string_view>);
+
+#  undef PQXX_EXPORT_TYPE
+#endif

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -6,15 +6,13 @@
  */
 #include "pqxx-source.hxx"
 
+#if defined(_WIN32) && defined(PQXX_SHARED)
 #include <string>
 #include <string_view>
 #include <vector>
 
-
-#if defined(_WIN32) && defined(PQXX_SHARED)
-
-template class PQXX_LIBEXPORT std::string;
-template class PQXX_LIBEXPORT std::string_view;
-template class PQXX_LIBEXPORT std::vector;
+template class PQXX_LIBEXPORT std::string<>;
+template class PQXX_LIBEXPORT std::string_view<>;
+template class PQXX_LIBEXPORT std::vector<std::string_view>;
 
 #endif

--- a/src/exports.cxx
+++ b/src/exports.cxx
@@ -7,26 +7,5 @@
 #include "pqxx-source.hxx"
 
 #if defined(_WIN32) && defined(PQXX_SHARED)
-#include <cstddef>
-#include <stdexcept>
-#include <string>
-#include <string_view>
-#include <vector>
-
-#include "pqxx/types.hxx"
-
-
-template class PQXX_LIBEXPORT std::basic_string<char,std::char_traits<char>,std::allocator<char>>;
-template class PQXX_LIBEXPORT std::basic_string_view<char>;
-class PQXX_LIBEXPORT std::domain_error;
-class PQXX_LIBEXPORT std::invalid_argument;
-class PQXX_LIBEXPORT std::logic_error;
-class PQXX_LIBEXPORT std::out_of_range;
-class PQXX_LIBEXPORT std::runtime_error;
-template class PQXX_LIBEXPORT std::shared_ptr<std::string>;
-template class PQXX_LIBEXPORT std::vector<pqxx::format,std::allocator<pqxx::format>;
-template class PQXX_LIBEXPORT std::vector<char const *,std::allocator<char const *>;
-template class PQXX_LIBEXPORT std::vector<int,std::allocator<int>;
-template class PQXX_LIBEXPORT std::vector<std::string_view,std::allocator<std::string_view>;
-
+#  include "pqxx/internal/exports.hxx"
 #endif


### PR DESCRIPTION
The Visual Studio build has been complaining: Whenever we expose standard types like `std::string` or `std::runtime_error` in the library's ABI, we must explicitly export those.