### PR TITLE
More `constexpr` and `noexcept`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@
  - Finally fix a long-standing silly warning in autogen.
  - Fix `digit_to_number` not being found on some comilers.  (#518, #519)
  - In audit mode, define `_FORTIFY_SOURCE` to enable some extra checks.
+ - Make more functions `constexpr`.  Nothing particularly useful though.
+ - Make more functions `noexcept`.
+ - Move constructor & assignment for `result`.
 7.7.0
  - Fix `stream_to` for differing table/client encodings.  (#473)
  - Use `[[likely]]` & `[[unlikely]]` only in C++20, to silence warnings.

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -58,7 +58,12 @@ public:
     done,
   };
 
+  // TODO: constexpr noexcept.  Breaks ABI.
   /// Constructor.  You don't need this; use @ref field::as_array instead.
+  /** The parser only remains valid while the data underlying the @ref result
+   * remains valid.  Once all `result` objects referring to that data have been
+   * destroyed, the parser will no longer refer to valid memory.
+   */
   explicit array_parser(
     std::string_view input,
     internal::encoding_group = internal::encoding_group::MONOBYTE);

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -80,7 +80,6 @@ public:
   blob &operator=(blob const &) = delete;
   ~blob();
 
-  // C++20: constinit.
   /// Maximum number of bytes that can be read or written at a time.
   /** The underlying protocol only supports reads and writes up to 2 GB
    * exclusive.

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -46,7 +46,6 @@ inline void parse_composite(
 
   here = next;
 
-  // C++20: constinit.
   constexpr auto num_fields{sizeof...(fields)};
   std::size_t index{0};
   (pqxx::internal::parse_composite_field(
@@ -78,7 +77,6 @@ inline void parse_composite(std::string_view text, T &...fields)
 
 namespace pqxx::internal
 {
-// C++20: constinit.
 constexpr char empty_composite_str[]{"()"};
 } // namespace pqxx::internal
 
@@ -92,7 +90,6 @@ template<typename... T>
 [[nodiscard]] inline std::size_t
 composite_size_buffer(T const &...fields) noexcept
 {
-  // C++20: constinit.
   constexpr auto num{sizeof...(fields)};
 
   // Size for a multi-field composite includes room for...
@@ -124,11 +121,9 @@ inline char *composite_into_buf(char *begin, char *end, T const &...fields)
     throw conversion_error{
       "Buffer space may not be enough to represent composite value."};
 
-  // C++20: constinit.
   constexpr auto num_fields{sizeof...(fields)};
   if constexpr (num_fields == 0)
   {
-    // C++20: constinit.
     constexpr char empty[]{"()"};
     std::memcpy(begin, empty, std::size(empty));
     return begin + std::size(empty);

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -563,6 +563,7 @@ public:
 
   //@}
 
+  // C++20: constexpr.  Breaks ABI.
   /// Suffix unique number to name to make it unique within session context.
   /** Used internally to generate identifiers for SQL objects (such as cursors
    * and nested transactions) based on a given human-readable base name.
@@ -1070,16 +1071,22 @@ public:
   [[nodiscard]] int sock() const &noexcept { return m_conn.sock(); }
 
   /// Should we currently wait to be able to _read_ from the socket?
-  [[nodiscard]] bool wait_to_read() const &noexcept { return m_reading; }
+  [[nodiscard]] constexpr bool wait_to_read() const &noexcept
+  {
+    return m_reading;
+  }
 
   /// Should we currently wait to be able to _write_ to the socket?
-  [[nodiscard]] bool wait_to_write() const &noexcept { return m_writing; }
+  [[nodiscard]] constexpr bool wait_to_write() const &noexcept
+  {
+    return m_writing;
+  }
 
   /// Progress towards completion (but don't block).
   void process() &;
 
   /// Is our connection finished?
-  [[nodiscard]] bool done() const &noexcept
+  [[nodiscard]] constexpr bool done() const &noexcept
   {
     return not m_reading and not m_writing;
   }

--- a/include/pqxx/cursor.hxx
+++ b/include/pqxx/cursor.hxx
@@ -97,6 +97,7 @@ public:
    */
   //@{
 
+  // TODO: Make constexpr inline (but breaks ABI).
   /// Special value: read until end.
   /** @return Maximum value for result::difference_type, so the cursor will
    * attempt to read the largest possible result set.
@@ -106,13 +107,17 @@ public:
   /// Special value: read one row only.
   /** @return Unsurprisingly, 1.
    */
-  [[nodiscard]] static difference_type next() noexcept { return 1; }
+  [[nodiscard]] static constexpr difference_type next() noexcept { return 1; }
 
   /// Special value: read backwards, one row only.
   /** @return Unsurprisingly, -1.
    */
-  [[nodiscard]] static difference_type prior() noexcept { return -1; }
+  [[nodiscard]] static constexpr difference_type prior() noexcept
+  {
+    return -1;
+  }
 
+  // TODO: Make constexpr inline (but breaks ABI).
   /// Special value: read backwards from current position back to origin.
   /** @return Minimum value for result::difference_type.
    */
@@ -126,7 +131,10 @@ public:
    * @warning Don't use this to access the SQL cursor directly without going
    * through the provided wrapper classes!
    */
-  [[nodiscard]] std::string const &name() const noexcept { return m_name; }
+  [[nodiscard]] constexpr std::string const &name() const noexcept
+  {
+    return m_name;
+  }
 
 protected:
   cursor_base(connection &, std::string_view Name, bool embellish_name = true);
@@ -220,7 +228,7 @@ public:
   }
 
   /// Return this cursor's name.
-  [[nodiscard]] std::string const &name() const noexcept
+  [[nodiscard]] constexpr std::string const &name() const noexcept
   {
     return m_cur.name();
   }
@@ -311,7 +319,7 @@ public:
     cursor_base::ownership_policy op = cursor_base::owned);
 
   /// Return `true` if this stream may still return more data.
-  operator bool() const &noexcept { return not m_done; }
+  constexpr operator bool() const &noexcept { return not m_done; }
 
   /// Read new value into given result object; same as operator `>>`.
   /** The result set may continue any number of rows from zero to the chosen
@@ -352,7 +360,10 @@ public:
    * @param stride Must be a positive number.
    */
   void set_stride(difference_type stride) &;
-  [[nodiscard]] difference_type stride() const noexcept { return m_stride; }
+  [[nodiscard]] constexpr difference_type stride() const noexcept
+  {
+    return m_stride;
+  }
 
 private:
   result fetchblock();

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -74,7 +74,6 @@ public:
   using iterator = result_iter<TYPE...>;
   explicit result_iteration(result const &home) : m_home{home}
   {
-    // C++20: constinit.
     constexpr auto tup_size{sizeof...(TYPE)};
     if (home.columns() != tup_size)
       throw usage_error{internal::concat(

--- a/include/pqxx/internal/statement_parameters.hxx
+++ b/include/pqxx/internal/statement_parameters.hxx
@@ -27,7 +27,6 @@
 namespace pqxx::internal
 {
 template<typename ITERATOR>
-// C++20: constinit.
 constexpr inline auto const iterator_identity{
   [](decltype(*std::declval<ITERATOR>()) x) { return x; }};
 

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -127,7 +127,6 @@ public:
 
   placeholders()
   {
-    // C++20: constinit.
     static constexpr auto initial{"$1\0"sv};
     initial.copy(std::data(m_buf), std::size(initial));
   }
@@ -136,7 +135,10 @@ public:
   /** @warning Changing the current placeholder number will overwrite this.
    * Use the view immediately, or lose it.
    */
-  zview view() const &noexcept { return zview{std::data(m_buf), m_len}; }
+  constexpr zview view() const &noexcept
+  {
+    return zview{std::data(m_buf), m_len};
+  }
 
   /// Read the current placeholder text, as a `std::string`.
   /** This will be slightly slower than converting to a `zview`.  With most
@@ -231,10 +233,11 @@ public:
    */
   void reserve(std::size_t n) &;
 
+  // C++20: constexpr.
   /// Get the number of parameters currently in this `params`.
   [[nodiscard]] auto size() const noexcept { return m_params.size(); }
 
-  // C++20: Use the vector's ssize() directly and go noexcept.
+  // C++20: Use the vector's ssize() directly and go noexcept+constexpr.
   /// Get the number of parameters (signed).
   /** Unlike `size()`, this is not yet `noexcept`.  That's because C++17's
    * `std::vector` does not have a `ssize()` member function.  These member
@@ -359,7 +362,7 @@ private:
   }
 
   /// Terminating case: append an empty parameter pack.  It's not hard BTW.
-  void append_pack() {}
+  constexpr void append_pack() noexcept {}
 
   // The way we store a parameter depends on whether it's binary or text
   // (most types are text), and whether we're responsible for storing the
@@ -369,7 +372,6 @@ private:
     std::basic_string<std::byte>>;
   std::vector<entry> m_params;
 
-  // C++20: constinit.
   static constexpr std::string_view s_overflow{
     "Statement parameter length overflow."sv};
 };

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -227,8 +227,7 @@ private:
    */
   internal::encoding_group m_encoding;
 
-  // C++20: constinit.
-  constexpr static std::string_view s_classname{"pipeline"};
+  static constexpr std::string_view s_classname{"pipeline"};
 };
 } // namespace pqxx
 #endif

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -42,14 +42,16 @@ public:
       throw argument_error{"Got null value as an inclusive range bound."};
   }
 
-  [[nodiscard]] TYPE const &get() const &noexcept { return m_value; }
+  [[nodiscard]] constexpr TYPE const &get() const &noexcept { return m_value; }
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   /// Would this bound, as a lower bound, include value?
   [[nodiscard]] bool extends_down_to(TYPE const &value) const
   {
     return not(value < m_value);
   }
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   /// Would this bound, as an upper bound, include value?
   [[nodiscard]] bool extends_up_to(TYPE const &value) const
   {
@@ -75,14 +77,16 @@ public:
       throw argument_error{"Got null value as an exclusive range bound."};
   }
 
-  [[nodiscard]] TYPE const &get() const &noexcept { return m_value; }
+  [[nodiscard]] constexpr TYPE const &get() const &noexcept { return m_value; }
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   /// Would this bound, as a lower bound, include value?
   [[nodiscard]] bool extends_down_to(TYPE const &value) const
   {
     return m_value < value;
   }
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   /// Would this bound, as an upper bound, include value?
   [[nodiscard]] bool extends_up_to(TYPE const &value) const
   {
@@ -102,12 +106,18 @@ template<typename TYPE> class range_bound
 {
 public:
   range_bound() = delete;
+  // TODO: constexpr and/or noexcept if underlying constructor supports it.
   range_bound(no_bound) : m_bound{} {}
+  // TODO: constexpr and/or noexcept if underlying constructor supports it.
   range_bound(inclusive_bound<TYPE> const &bound) : m_bound{bound} {}
+  // TODO: constexpr and/or noexcept if underlying constructor supports it.
   range_bound(exclusive_bound<TYPE> const &bound) : m_bound{bound} {}
+  // TODO: constexpr and/or noexcept if underlying constructor supports it.
   range_bound(range_bound const &) = default;
+  // TODO: constexpr and/or noexcept if underlying constructor supports it.
   range_bound(range_bound &&) = default;
 
+  // TODO: constexpr and/or noexcept if underlying operators support it.
   bool operator==(range_bound const &rhs) const
   {
     if (this->is_limited())
@@ -118,28 +128,30 @@ public:
       return not rhs.is_limited();
   }
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   bool operator!=(range_bound const &rhs) const { return not(*this == rhs); }
   range_bound &operator=(range_bound const &) = default;
   range_bound &operator=(range_bound &&) = default;
 
   /// Is this a finite bound?
-  bool is_limited() const noexcept
+  constexpr bool is_limited() const noexcept
   {
     return not std::holds_alternative<no_bound>(m_bound);
   }
 
   /// Is this boundary an inclusive one?
-  bool is_inclusive() const noexcept
+  constexpr bool is_inclusive() const noexcept
   {
     return std::holds_alternative<inclusive_bound<TYPE>>(m_bound);
   }
 
   /// Is this boundary an exclusive one?
-  bool is_exclusive() const noexcept
+  constexpr bool is_exclusive() const noexcept
   {
     return std::holds_alternative<exclusive_bound<TYPE>>(m_bound);
   }
 
+  // TODO: constexpr/noexcept if underlying function supports it.
   /// Would this bound, as a lower bound, include `value`?
   bool extends_down_to(TYPE const &value) const
   {
@@ -148,6 +160,7 @@ public:
       m_bound);
   }
 
+  // TODO: constexpr/noexcept if underlying function supports it.
   /// Would this bound, as an upper bound, include `value`?
   bool extends_up_to(TYPE const &value) const
   {
@@ -157,7 +170,7 @@ public:
   }
 
   /// Return bound value, or `nullptr` if it's not limited.
-  [[nodiscard]] TYPE const *value() const &noexcept
+  [[nodiscard]] constexpr TYPE const *value() const &noexcept
   {
     return std::visit(
       [](auto const &bound) noexcept {
@@ -214,6 +227,7 @@ public:
         ") is greater than its upper bound (", *upper.value(), ").")};
   }
 
+  // TODO: constexpr and/or noexcept if underlying constructor supports it.
   /// Create an empty range.
   /** SQL has a separate literal to denote an empty range, but any range which
    * encompasses no values is an empty range.
@@ -223,6 +237,7 @@ public:
           m_upper{exclusive_bound<TYPE>{TYPE{}}}
   {}
 
+  // TODO: constexpr and/or noexcept if underlying operators support it.
   bool operator==(range const &rhs) const
   {
     return (this->lower_bound() == rhs.lower_bound() and
@@ -230,6 +245,7 @@ public:
            (this->empty() and rhs.empty());
   }
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   bool operator!=(range const &rhs) const { return !(*this == rhs); }
 
   range(range const &) = default;
@@ -237,6 +253,7 @@ public:
   range &operator=(range const &) = default;
   range &operator=(range &&) = default;
 
+  // TODO: constexpr and/or noexcept if underlying operator supports it.
   /// Is this range clearly empty?
   /** An empty range encompasses no values.
    *
@@ -253,12 +270,14 @@ public:
            not(*m_lower.value() < *m_upper.value());
   }
 
+  // TODO: constexpr and/or noexcept if underlying functions support it.
   /// Does this range encompass `value`?
   bool contains(TYPE value) const
   {
     return m_lower.extends_down_to(value) and m_upper.extends_up_to(value);
   }
 
+  // TODO: constexpr and/or noexcept if underlying operators support it.
   /// Does this range encompass all of `other`?
   /** This function is not particularly smart.  It does not know, for example,
    * that integer ranges `[0,9]` and `[0,10)` contain the same values.
@@ -268,15 +287,18 @@ public:
     return (*this & other) == other;
   }
 
-  [[nodiscard]] range_bound<TYPE> const &lower_bound() const &noexcept
+  [[nodiscard]] constexpr range_bound<TYPE> const &
+  lower_bound() const &noexcept
   {
     return m_lower;
   }
-  [[nodiscard]] range_bound<TYPE> const &upper_bound() const &noexcept
+  [[nodiscard]] constexpr range_bound<TYPE> const &
+  upper_bound() const &noexcept
   {
     return m_upper;
   }
 
+  // TODO: constexpr and/or noexcept if underlying operators support it.
   /// Intersection of two ranges.
   /** Returns a range describing those values which are in both ranges.
    */
@@ -418,9 +440,8 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     // The field parser uses this to track which field it's parsing, and
     // when not to expect a field separator.
     std::size_t index{0};
-    // C++20: constinit.
     // The last field we expect to see.
-    constexpr std::size_t last{1};
+    static constexpr std::size_t last{1};
     // Current parsing position.  We skip the opening parenthesis or bracket.
     std::size_t pos{1};
     // The string may leave out either bound to indicate that it's unlimited.
@@ -456,7 +477,7 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     return {lower_bound, upper_bound};
   }
 
-  [[nodiscard]] static inline std::size_t
+  [[nodiscard]] static inline constexpr std::size_t
   size_buffer(range<TYPE> const &value) noexcept
   {
     TYPE const *lower{value.lower_bound().value()},
@@ -472,9 +493,7 @@ template<typename TYPE> struct string_traits<range<TYPE>>
   }
 
 private:
-  // C++20: constinit.
   static constexpr zview s_empty{"empty"_zv};
-  // C++20: constinit.
   static constexpr auto s_overrun{"Not enough space in buffer for range."_zv};
 
   /// Compose error message for invalid range input.

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -27,8 +27,9 @@
 
 namespace pqxx::internal
 {
+// TODO: Make noexcept (but breaks ABI).
 PQXX_LIBEXPORT void clear_result(pq::PGresult const *);
-}
+} // namespace pqxx::internal
 
 
 namespace pqxx::internal::gate
@@ -77,18 +78,22 @@ public:
   using reverse_iterator = const_reverse_iterator;
 
   result() noexcept :
-          m_data(make_data_pointer()),
-          m_query(),
-          m_encoding(internal::encoding_group::MONOBYTE)
+          m_data{make_data_pointer()},
+          m_query{},
+          m_encoding{internal::encoding_group::MONOBYTE}
   {}
 
   result(result const &rhs) noexcept = default;
+  result(result &&rhs) noexcept = default;
 
   /// Assign one result to another.
   /** Copying results is cheap: it copies only smart pointers, but the actual
    * data stays in the same place.
    */
   result &operator=(result const &rhs) noexcept = default;
+
+  /// Assign one result to another, invaliding the old one.
+  result &operator=(result &&rhs) noexcept = default;
 
   /**
    * @name Comparisons
@@ -238,7 +243,7 @@ private:
 
   /// Factory for data_pointer.
   static data_pointer
-  make_data_pointer(internal::pq::PGresult const *res = nullptr)
+  make_data_pointer(internal::pq::PGresult const *res = nullptr) noexcept
   {
     return {res, internal::clear_result};
   }
@@ -257,7 +262,9 @@ private:
   static std::string const s_empty_string;
 
   friend class pqxx::field;
+  // TODO: noexcept.  Breaks ABI.
   PQXX_PURE char const *get_value(size_type row, row_size_type col) const;
+  // TODO: noexcept.  Breaks ABI.
   PQXX_PURE bool get_is_null(size_type row, row_size_type col) const;
   PQXX_PURE
   field_size_type get_length(size_type, row_size_type) const noexcept;

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -51,11 +51,11 @@ public:
   using const_reverse_iterator = const_reverse_row_iterator;
   using reverse_iterator = const_reverse_iterator;
 
-  row() = default;
-  row(row &&) = default;
-  row(row const &) = default;
-  row &operator=(row const &) = default;
-  row &operator=(row &&) = default;
+  row() noexcept = default;
+  row(row &&) noexcept = default;
+  row(row const &) noexcept = default;
+  row &operator=(row const &) noexcept = default;
+  row &operator=(row &&) noexcept = default;
 
   /**
    * @name Comparison
@@ -80,9 +80,13 @@ public:
   [[nodiscard]] reference front() const noexcept;
   [[nodiscard]] reference back() const noexcept;
 
+  // TODO: noexcept.  Breaks ABI.
   [[nodiscard]] const_reverse_row_iterator rbegin() const;
+  // TODO: noexcept.  Breaks ABI.
   [[nodiscard]] const_reverse_row_iterator crbegin() const;
+  // TODO: noexcept.  Breaks ABI.
   [[nodiscard]] const_reverse_row_iterator rend() const;
+  // TODO: noexcept.  Breaks ABI.
   [[nodiscard]] const_reverse_row_iterator crend() const;
 
   [[nodiscard]] reference operator[](size_type) const noexcept;
@@ -97,12 +101,15 @@ public:
    */
   reference at(zview col_name) const;
 
-  [[nodiscard]] size_type size() const noexcept { return m_end - m_begin; }
+  [[nodiscard]] constexpr size_type size() const noexcept
+  {
+    return m_end - m_begin;
+  }
 
   [[deprecated("Swap iterators, not rows.")]] void swap(row &) noexcept;
 
   /// Row number, assuming this is a real row and not end()/rend().
-  [[nodiscard]] result::size_type rownumber() const noexcept
+  [[nodiscard]] constexpr result::size_type rownumber() const noexcept
   {
     return m_index;
   }
@@ -149,7 +156,10 @@ public:
   }
   //@}
 
-  [[nodiscard]] result::size_type num() const { return rownumber(); }
+  [[nodiscard]] constexpr result::size_type num() const noexcept
+  {
+    return rownumber();
+  }
 
   /** Produce a slice of this row, containing the given range of columns.
    *
@@ -203,9 +213,7 @@ protected:
   /// Convert entire row to tuple fields, without checking row size.
   template<typename Tuple> void convert(Tuple &t) const
   {
-    // C++20: constinit.
-    constexpr auto tup_size{std::tuple_size_v<Tuple>};
-    extract_fields(t, std::make_index_sequence<tup_size>{});
+    extract_fields(t, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
   }
 
   friend class field;
@@ -269,43 +277,45 @@ public:
           field{t.m_result, t.m_index, c}
   {}
   const_row_iterator(field const &F) noexcept : field{F} {}
-  const_row_iterator(const_row_iterator const &) = default;
-  const_row_iterator(const_row_iterator &&) = default;
+  const_row_iterator(const_row_iterator const &) noexcept = default;
+  const_row_iterator(const_row_iterator &&) noexcept = default;
 
   /**
    * @name Dereferencing operators
    */
   //@{
-  [[nodiscard]] pointer operator->() const { return this; }
-  [[nodiscard]] reference operator*() const { return {*this}; }
+  [[nodiscard]] constexpr pointer operator->() const noexcept { return this; }
+  [[nodiscard]] reference operator*() const noexcept { return {*this}; }
   //@}
 
   /**
    * @name Manipulations
    */
   //@{
-  const_row_iterator &operator=(const_row_iterator const &) = default;
-  const_row_iterator &operator=(const_row_iterator &&) = default;
+  const_row_iterator &operator=(const_row_iterator const &) noexcept = default;
+  const_row_iterator &operator=(const_row_iterator &&) noexcept = default;
 
+  // TODO: noexcept.  Breaks ABI.
   const_row_iterator operator++(int);
-  const_row_iterator &operator++()
+  const_row_iterator &operator++() noexcept
   {
     ++m_col;
     return *this;
   }
+  // TODO: noexcept.  Breaks ABI.
   const_row_iterator operator--(int);
-  const_row_iterator &operator--()
+  const_row_iterator &operator--() noexcept
   {
     --m_col;
     return *this;
   }
 
-  const_row_iterator &operator+=(difference_type i)
+  const_row_iterator &operator+=(difference_type i) noexcept
   {
     m_col = size_type(difference_type(m_col) + i);
     return *this;
   }
-  const_row_iterator &operator-=(difference_type i)
+  const_row_iterator &operator-=(difference_type i) noexcept
   {
     m_col = size_type(difference_type(m_col) - i);
     return *this;
@@ -316,27 +326,33 @@ public:
    * @name Comparisons
    */
   //@{
-  [[nodiscard]] bool operator==(const_row_iterator const &i) const
+  [[nodiscard]] constexpr bool
+  operator==(const_row_iterator const &i) const noexcept
   {
     return col() == i.col();
   }
-  [[nodiscard]] bool operator!=(const_row_iterator const &i) const
+  [[nodiscard]] constexpr bool
+  operator!=(const_row_iterator const &i) const noexcept
   {
     return col() != i.col();
   }
-  [[nodiscard]] bool operator<(const_row_iterator const &i) const
+  [[nodiscard]] constexpr bool
+  operator<(const_row_iterator const &i) const noexcept
   {
     return col() < i.col();
   }
-  [[nodiscard]] bool operator<=(const_row_iterator const &i) const
+  [[nodiscard]] constexpr bool
+  operator<=(const_row_iterator const &i) const noexcept
   {
     return col() <= i.col();
   }
-  [[nodiscard]] bool operator>(const_row_iterator const &i) const
+  [[nodiscard]] constexpr bool
+  operator>(const_row_iterator const &i) const noexcept
   {
     return col() > i.col();
   }
-  [[nodiscard]] bool operator>=(const_row_iterator const &i) const
+  [[nodiscard]] constexpr bool
+  operator>=(const_row_iterator const &i) const noexcept
   {
     return col() >= i.col();
   }
@@ -346,14 +362,16 @@ public:
    * @name Arithmetic operators
    */
   //@{
-  [[nodiscard]] inline const_row_iterator operator+(difference_type) const;
+  [[nodiscard]] inline const_row_iterator
+  operator+(difference_type) const noexcept;
 
   friend const_row_iterator
-  operator+(difference_type, const_row_iterator const &);
+  operator+(difference_type, const_row_iterator const &) noexcept;
 
-  [[nodiscard]] inline const_row_iterator operator-(difference_type) const;
+  [[nodiscard]] inline const_row_iterator
+  operator-(difference_type) const noexcept;
   [[nodiscard]] inline difference_type
-  operator-(const_row_iterator const &) const;
+  operator-(const_row_iterator const &) const noexcept;
   //@}
 };
 
@@ -370,9 +388,10 @@ public:
   using value_type = iterator_type::value_type;
   using reference = iterator_type::reference;
 
-  const_reverse_row_iterator() = default;
-  const_reverse_row_iterator(const_reverse_row_iterator const &) = default;
-  const_reverse_row_iterator(const_reverse_row_iterator &&) = default;
+  const_reverse_row_iterator() noexcept = default;
+  const_reverse_row_iterator(const_reverse_row_iterator const &) noexcept =
+    default;
+  const_reverse_row_iterator(const_reverse_row_iterator &&) noexcept = default;
 
   explicit const_reverse_row_iterator(super const &rhs) noexcept :
           const_row_iterator{rhs}
@@ -394,29 +413,32 @@ public:
    * @name Manipulations
    */
   //@{
-  const_reverse_row_iterator &operator=(const_reverse_row_iterator const &r)
+  const_reverse_row_iterator &
+  operator=(const_reverse_row_iterator const &r) noexcept
   {
     iterator_type::operator=(r);
     return *this;
   }
-  const_reverse_row_iterator operator++()
+  const_reverse_row_iterator operator++() noexcept
   {
     iterator_type::operator--();
     return *this;
   }
+  // TODO: noexcept.  Breaks ABI.
   const_reverse_row_iterator operator++(int);
-  const_reverse_row_iterator &operator--()
+  const_reverse_row_iterator &operator--() noexcept
   {
     iterator_type::operator++();
     return *this;
   }
   const_reverse_row_iterator operator--(int);
-  const_reverse_row_iterator &operator+=(difference_type i)
+  // TODO: noexcept.  Breaks ABI.
+  const_reverse_row_iterator &operator+=(difference_type i) noexcept
   {
     iterator_type::operator-=(i);
     return *this;
   }
-  const_reverse_row_iterator &operator-=(difference_type i)
+  const_reverse_row_iterator &operator-=(difference_type i) noexcept
   {
     iterator_type::operator+=(i);
     return *this;
@@ -427,16 +449,18 @@ public:
    * @name Arithmetic operators
    */
   //@{
-  [[nodiscard]] const_reverse_row_iterator operator+(difference_type i) const
+  [[nodiscard]] const_reverse_row_iterator
+  operator+(difference_type i) const noexcept
   {
     return const_reverse_row_iterator{base() - i};
   }
-  [[nodiscard]] const_reverse_row_iterator operator-(difference_type i)
+  [[nodiscard]] const_reverse_row_iterator
+  operator-(difference_type i) noexcept
   {
     return const_reverse_row_iterator{base() + i};
   }
   [[nodiscard]] difference_type
-  operator-(const_reverse_row_iterator const &rhs) const
+  operator-(const_reverse_row_iterator const &rhs) const noexcept
   {
     return rhs.const_row_iterator::operator-(*this);
   }
@@ -457,19 +481,23 @@ public:
     return !operator==(rhs);
   }
 
-  [[nodiscard]] bool operator<(const_reverse_row_iterator const &rhs) const
+  [[nodiscard]] constexpr bool
+  operator<(const_reverse_row_iterator const &rhs) const noexcept
   {
     return iterator_type::operator>(rhs);
   }
-  [[nodiscard]] bool operator<=(const_reverse_row_iterator const &rhs) const
+  [[nodiscard]] constexpr bool
+  operator<=(const_reverse_row_iterator const &rhs) const noexcept
   {
     return iterator_type::operator>=(rhs);
   }
-  [[nodiscard]] bool operator>(const_reverse_row_iterator const &rhs) const
+  [[nodiscard]] constexpr bool
+  operator>(const_reverse_row_iterator const &rhs) const noexcept
   {
     return iterator_type::operator<(rhs);
   }
-  [[nodiscard]] bool operator>=(const_reverse_row_iterator const &rhs) const
+  [[nodiscard]] constexpr bool
+  operator>=(const_reverse_row_iterator const &rhs) const noexcept
   {
     return iterator_type::operator<=(rhs);
   }
@@ -477,7 +505,8 @@ public:
 };
 
 
-const_row_iterator const_row_iterator::operator+(difference_type o) const
+const_row_iterator
+const_row_iterator::operator+(difference_type o) const noexcept
 {
   // TODO:: More direct route to home().columns()?
   return {
@@ -485,14 +514,14 @@ const_row_iterator const_row_iterator::operator+(difference_type o) const
     size_type(difference_type(col()) + o)};
 }
 
-inline const_row_iterator
-operator+(const_row_iterator::difference_type o, const_row_iterator const &i)
+inline const_row_iterator operator+(
+  const_row_iterator::difference_type o, const_row_iterator const &i) noexcept
 {
   return i + o;
 }
 
 inline const_row_iterator
-const_row_iterator::operator-(difference_type o) const
+const_row_iterator::operator-(difference_type o) const noexcept
 {
   // TODO:: More direct route to home().columns()?
   return {
@@ -501,7 +530,7 @@ const_row_iterator::operator-(difference_type o) const
 }
 
 inline const_row_iterator::difference_type
-const_row_iterator::operator-(const_row_iterator const &i) const
+const_row_iterator::operator-(const_row_iterator const &i) const noexcept
 {
   return difference_type(num() - i.num());
 }

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -109,7 +109,6 @@ template<typename TYPE, typename ENABLE = void> struct nullness
 /// Nullness traits describing a type which does not have a null value.
 template<typename TYPE> struct no_null
 {
-  // C++20: constinit.
   /// Does @c TYPE have a "built-in null value"?
   /** For example, a pointer can equal @c nullptr, which makes a very natural
    * representation of an SQL null value.  For such types, the code sometimes
@@ -123,7 +122,6 @@ template<typename TYPE> struct no_null
    */
   static constexpr bool has_null = false;
 
-  // C++20: constinit.
   /// Are all values of this type null?
   /** There are a few special C++ types which are always null - mainly
    * @c std::nullptr_t.
@@ -188,6 +186,7 @@ template<typename TYPE> struct string_traits
    */
   [[nodiscard]] static inline TYPE from_string(std::string_view text);
 
+  // C++20: Can we make these all constexpr?
   /// Estimate how much buffer space is needed to represent value.
   /** The estimate may be a little pessimistic, if it saves time.
    *
@@ -245,7 +244,7 @@ template<typename ENUM> struct enum_traits
 
 private:
   // C++23: Replace with std::to_underlying.
-  static impl_type to_underlying(ENUM const &value)
+  static constexpr impl_type to_underlying(ENUM const &value) noexcept
   {
     return static_cast<impl_type>(value);
   }
@@ -361,7 +360,7 @@ inline void into_string(TYPE const &value, std::string &out);
 
 /// Is @c value null?
 template<typename TYPE>
-[[nodiscard]] inline bool is_null(TYPE const &value) noexcept
+[[nodiscard]] inline constexpr bool is_null(TYPE const &value) noexcept
 {
   return nullness<strip_t<TYPE>>::is_null(value);
 }
@@ -378,7 +377,6 @@ template<typename... TYPE>
 }
 
 
-// C++20: constinit.
 /// Does this type translate to an SQL array?
 /** Specialisations may override this to be true for container types.
  *
@@ -389,7 +387,6 @@ template<typename... TYPE>
 template<typename TYPE> inline constexpr bool is_sql_array{false};
 
 
-// C++20: constinit.
 /// Can we use this type in arrays and composite types without quoting them?
 /** Define this as @c true only if values of @c TYPE can never contain any
  * special characters that might need escaping or confuse the parsing of array
@@ -406,7 +403,6 @@ template<typename TYPE> inline constexpr bool is_sql_array{false};
 template<typename TYPE> inline constexpr bool is_unquoted_safe{false};
 
 
-// C++20: constinit.
 /// Element separator between SQL array elements of this type.
 template<typename T> inline constexpr char array_separator{','};
 

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -31,12 +31,10 @@ namespace pqxx
 class transaction_base;
 
 
-// C++20: constinit.
 /// Pass this to a `stream_from` constructor to stream table contents.
 /** @deprecated Use @ref stream_from::table() instead.
  */
 constexpr from_table_t from_table;
-// C++20: constinit.
 /// Pass this to a `stream_from` constructor to stream query results.
 /** @deprecated Use stream_from::query() instead.
  */
@@ -183,9 +181,15 @@ public:
   ~stream_from() noexcept;
 
   /// May this stream still produce more data?
-  [[nodiscard]] operator bool() const noexcept { return not m_finished; }
+  [[nodiscard]] constexpr operator bool() const noexcept
+  {
+    return not m_finished;
+  }
   /// Has this stream produced all the data it is going to produce?
-  [[nodiscard]] bool operator!() const noexcept { return m_finished; }
+  [[nodiscard]] constexpr bool operator!() const noexcept
+  {
+    return m_finished;
+  }
 
   /// Finish this stream.  Call this before continuing to use the connection.
   /** Consumes all remaining lines, and closes the stream.
@@ -305,8 +309,7 @@ template<typename Tuple> inline stream_from &stream_from::operator>>(Tuple &t)
 {
   if (m_finished)
     return *this;
-  // C++20: constinit.
-  constexpr auto tup_size{std::tuple_size_v<Tuple>};
+  static constexpr auto tup_size{std::tuple_size_v<Tuple>};
   m_fields.reserve(tup_size);
   parse_line();
   if (m_finished)

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -188,9 +188,15 @@ public:
   ~stream_to() noexcept;
 
   /// Does this stream still need to @ref complete()?
-  [[nodiscard]] operator bool() const noexcept { return not m_finished; }
+  [[nodiscard]] constexpr operator bool() const noexcept
+  {
+    return not m_finished;
+  }
   /// Has this stream been through its concluding @c complete()?
-  [[nodiscard]] bool operator!() const noexcept { return m_finished; }
+  [[nodiscard]] constexpr bool operator!() const noexcept
+  {
+    return m_finished;
+  }
 
   /// Complete the operation, and check for errors.
   /** Always call this to close the stream in an orderly fashion, even after
@@ -271,7 +277,6 @@ private:
    */
   void write_buffer();
 
-  // C++20: constinit.
   /// COPY encoding for a null field, plus subsequent separator.
   static constexpr std::string_view null_field{"\\N\t"};
 
@@ -419,7 +424,6 @@ private:
     (..., append_to_buffer(fields));
   }
 
-  // C++20: constinit.
   constexpr static std::string_view s_classname{"stream_to"};
 };
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -520,7 +520,7 @@ public:
   //@}
 
   /// The connection in which this transaction lives.
-  [[nodiscard]] connection &conn() const { return m_conn; }
+  [[nodiscard]] constexpr connection &conn() const noexcept { return m_conn; }
 
   /// Set session variable using SQL "SET" command.
   /** The new value is typically forgotten if the transaction aborts.
@@ -541,6 +541,7 @@ public:
    */
   std::string get_variable(std::string_view);
 
+  // C++20: constexpr.
   /// Transaction name, if you passed one to the constructor; or empty string.
   [[nodiscard]] std::string_view name() const &noexcept { return m_name; }
 
@@ -603,12 +604,6 @@ private:
 
   PQXX_PRIVATE void check_pending_error();
 
-  template<typename T> bool parm_is_null(T *p) const noexcept
-  {
-    return p == nullptr;
-  }
-  template<typename T> bool parm_is_null(T) const noexcept { return false; }
-
   result
   internal_exec_prepared(zview statement, internal::c_params const &args);
 
@@ -648,7 +643,6 @@ private:
   /// SQL command for aborting this type of transaction.
   std::shared_ptr<std::string> m_rollback_cmd;
 
-  // C++20: constinit.
   static constexpr std::string_view s_type_name{"transaction"sv};
 };
 
@@ -672,7 +666,6 @@ namespace pqxx::internal
 template<pqxx::isolation_level isolation, pqxx::write_policy rw>
 extern const zview begin_cmd;
 
-// C++20: constinit.
 // These are not static members, so "constexpr" does not imply "inline".
 template<>
 inline constexpr zview begin_cmd<read_committed, write_policy::read_write>{

--- a/include/pqxx/transaction_focus.hxx
+++ b/include/pqxx/transaction_focus.hxx
@@ -43,7 +43,7 @@ public:
   transaction_focus &operator=(transaction_focus const &) = delete;
 
   /// Class name, for human consumption.
-  [[nodiscard]] std::string_view classname() const noexcept
+  [[nodiscard]] constexpr std::string_view classname() const noexcept
   {
     return m_classname;
   }

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -47,10 +47,10 @@ namespace pqxx::internal
 {
 
 
-// C++20: Use concept to express LEFT and RIGHT must be integral types.
+// C++20: Use concept to express that LEFT and RIGHT must be integral types.
 /// C++20 std::cmp_less, or workaround if not available.
 template<typename LEFT, typename RIGHT>
-inline constexpr bool cmp_less(LEFT lhs, RIGHT rhs)
+inline constexpr bool cmp_less(LEFT lhs, RIGHT rhs) noexcept
 {
 #if defined(PQXX_HAVE_CMP)
   return std::cmp_less(lhs, rhs);
@@ -65,10 +65,10 @@ inline constexpr bool cmp_less(LEFT lhs, RIGHT rhs)
 }
 
 
-// C++20: Use concept to express LEFT and RIGHT must be integral types.
+// C++20: Use concept to express that LEFT and RIGHT must be integral types.
 /// C++20 std::cmp_greater, or workaround if not available.
 template<typename LEFT, typename RIGHT>
-inline constexpr bool cmp_greater(LEFT lhs, RIGHT rhs)
+inline constexpr bool cmp_greater(LEFT lhs, RIGHT rhs) noexcept
 {
 #if defined(PQXX_HAVE_CMP)
   return std::cmp_greater(lhs, rhs);
@@ -78,10 +78,10 @@ inline constexpr bool cmp_greater(LEFT lhs, RIGHT rhs)
 }
 
 
-// C++20: Use concept to express LEFT and RIGHT must be integral types.
+// C++20: Use concept to express that LEFT and RIGHT must be integral types.
 /// C++20 std::cmp_less_equal, or workaround if not available.
 template<typename LEFT, typename RIGHT>
-inline constexpr bool cmp_less_equal(LEFT lhs, RIGHT rhs)
+inline constexpr bool cmp_less_equal(LEFT lhs, RIGHT rhs) noexcept
 {
 #if defined(PQXX_HAVE_CMP)
   return std::cmp_less_equal(lhs, rhs);
@@ -91,10 +91,10 @@ inline constexpr bool cmp_less_equal(LEFT lhs, RIGHT rhs)
 }
 
 
-// C++20: Use concept to express LEFT and RIGHT must be integral types.
+// C++20: Use concept to express that LEFT and RIGHT must be integral types.
 /// C++20 std::cmp_greater_equal, or workaround if not available.
 template<typename LEFT, typename RIGHT>
-inline constexpr bool cmp_greater_equal(LEFT lhs, RIGHT rhs)
+inline constexpr bool cmp_greater_equal(LEFT lhs, RIGHT rhs) noexcept
 {
 #if defined(PQXX_HAVE_CMP)
   return std::cmp_greater_equal(lhs, rhs);
@@ -125,7 +125,8 @@ namespace pqxx
 using namespace std::literals;
 
 /// Suppress compiler warning about an unused item.
-template<typename... T> inline void ignore_unused(T &&...) {}
+template<typename... T> inline constexpr void ignore_unused(T &&...) noexcept
+{}
 
 
 /// Cast a numeric value to another type, or throw if it underflows/overflows.
@@ -177,9 +178,7 @@ inline TO check_cast(FROM value, std::string_view description)
   {
     using unsigned_from = std::make_unsigned_t<FROM>;
     using unsigned_to = std::make_unsigned_t<TO>;
-    // C++20: constinit.
     constexpr auto from_max{static_cast<unsigned_from>((from_limits::max)())};
-    // C++20: constinit.
     constexpr auto to_max{static_cast<unsigned_to>((to_limits::max)())};
     if constexpr (from_max > to_max)
     {
@@ -218,7 +217,7 @@ inline TO check_cast(FROM value, std::string_view description)
  * There will be a definition, but the version in the parameter values will
  * be different.
  */
-inline PQXX_PRIVATE void check_version()
+inline PQXX_PRIVATE void check_version() noexcept
 {
   // There is no particular reason to do this here in @ref connection, except
   // to ensure that every meaningful libpqxx client will execute it.  The call
@@ -266,6 +265,7 @@ struct PQXX_LIBEXPORT thread_safety_model
 #else
 #  define PQXX_POTENTIAL_BINARY_ARG typename
 #endif
+
 
 /// Cast binary data to a type that libpqxx will recognise as binary.
 /** There are many different formats for storing binary data in memory.  You
@@ -323,7 +323,6 @@ std::basic_string_view<std::byte> binary_cast(CHAR const *data, SIZE size)
 }
 
 
-// C++20: constinit.
 /// The "null" oid.
 constexpr oid oid_none{0};
 } // namespace pqxx
@@ -349,7 +348,7 @@ using namespace std::literals;
  * `int`, but requires it to be nonnegative.  Which means it's an outright
  * liability on systems where `char` is signed.
  */
-template<typename CHAR> bool is_digit(CHAR c)
+template<typename CHAR> inline constexpr bool is_digit(CHAR c) noexcept
 {
   return (c >= '0') and (c <= '9');
 }
@@ -394,7 +393,7 @@ void check_unique_unregister(
 /** This uses the hex-escaping format.  The return value includes room for the
  * "\x" prefix.
  */
-constexpr std::size_t size_esc_bin(std::size_t binary_bytes) noexcept
+inline constexpr std::size_t size_esc_bin(std::size_t binary_bytes) noexcept
 {
   return 2 + (2 * binary_bytes) + 1;
 }
@@ -403,7 +402,7 @@ constexpr std::size_t size_esc_bin(std::size_t binary_bytes) noexcept
 /// Compute binary size from the size of its escaped version.
 /** Do not include a terminating zero in `escaped_bytes`.
  */
-constexpr std::size_t size_unesc_bin(std::size_t escaped_bytes) noexcept
+inline constexpr std::size_t size_unesc_bin(std::size_t escaped_bytes) noexcept
 {
   return (escaped_bytes - 2) / 2;
 }

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -55,7 +55,13 @@ inline constexpr bool cmp_less(LEFT lhs, RIGHT rhs) noexcept
 #if defined(PQXX_HAVE_CMP)
   return std::cmp_less(lhs, rhs);
 #else
-  if constexpr (std::is_signed_v<LEFT> == std::is_signed_v<RIGHT>)
+
+  // We need these variables just because lgtm.com gives off a false positive
+  // warning when we compare the values directly.  It considers that a
+  // "self-comparison."
+  constexpr bool left_signed{std::is_signed_v<LEFT>},
+    right_signed{std::is_signed_v<RIGHT>};
+  if constexpr (left_signed == right_signed)
     return lhs < rhs;
   else if constexpr (std::is_signed_v<LEFT>)
     return (lhs <= 0) ? true : (std::make_unsigned_t<LEFT>(lhs) < rhs);

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -49,6 +49,11 @@ public:
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
+  /// Explicitly promote a `string_view` to a `zview`.
+  explicit constexpr zview(std::string_view other) noexcept :
+          std::string_view{other}
+  {}
+
   /// Construct from any initialiser you might use for `std::string_view`.
   /** @warning Only do this if you are sure that the string is zero-terminated.
    */
@@ -57,8 +62,10 @@ public:
           std::string_view(std::forward<Args>(args)...)
   {}
 
+  // C++20: constexpr.
   /// @warning There's an implicit conversion from `std::string`.
-  zview(std::string const &str) : std::string_view{str.c_str(), std::size(str)}
+  zview(std::string const &str) noexcept :
+          std::string_view{str.c_str(), str.size()}
   {}
 
   /// Construct a `zview` from a C-style string.
@@ -105,12 +112,10 @@ constexpr zview operator"" _zv(char const str[], std::size_t len) noexcept
 
 
 #if defined(PQXX_HAVE_CONCEPTS)
-// C++20: constinit.
 /// A zview is a view.
 template<> inline constexpr bool std::ranges::enable_view<pqxx::zview>{true};
 
 
-// C++20: constinit.
 /// A zview is a borrowed range.
 template<>
 inline constexpr bool std::ranges::enable_borrowed_range<pqxx::zview>{true};

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -16,7 +16,6 @@
 
 namespace
 {
-// C++20: constinit.
 constexpr int INV_WRITE{0x00020000}, INV_READ{0x00040000};
 } // namespace
 

--- a/src/largeobject.cxx
+++ b/src/largeobject.cxx
@@ -30,7 +30,6 @@ namespace
 {
 constexpr inline int PQXX_COLD std_mode_to_pq_mode(std::ios::openmode mode)
 {
-  // C++20: constinit.
   /// Mode bits, copied from libpq-fs.h so that we no longer need that header.
   constexpr int INV_WRITE{0x00020000}, INV_READ{0x00040000};
 

--- a/src/robusttransaction.cxx
+++ b/src/robusttransaction.cxx
@@ -42,7 +42,6 @@ enum tx_stat
 };
 
 
-// C++20: constinit.
 constexpr auto committed{"committed"_zv}, aborted{"aborted"_zv},
   in_progress{"in progress"_zv};
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -29,7 +29,6 @@
 namespace
 {
 #if !defined(PQXX_HAVE_CHARCONV_FLOAT)
-// C++20: constinit.
 /// Do we have fully functional thread_local support?
 /** When building with libcxxrt on clang, you can't create thread_local objects
  * of non-POD types.  Any attempt will result in a link error.
@@ -52,11 +51,9 @@ constexpr inline bool equal(std::string_view lhs, std::string_view rhs)
 }
 
 
-// C++20: constinit.
 /// The lowest possible value of integral type T.
 template<typename T> constexpr T bottom{std::numeric_limits<T>::min()};
 
-// C++20: constinit.
 /// The highest possible value of integral type T.
 template<typename T> constexpr T top{std::numeric_limits<T>::max()};
 
@@ -330,20 +327,17 @@ namespace
 
 template<typename T> struct numeric_ten
 {
-  // C++20: constinit.
   static inline constexpr T value = 10;
 };
 
 template<typename T> struct numeric_high_threshold
 {
-  // C++20: constinit?
   static inline constexpr T value =
     (std::numeric_limits<T>::max)() / numeric_ten<T>::value;
 };
 
 template<typename T> struct numeric_low_threshold
 {
-  // C++20: constinit?
   static inline constexpr T value =
     (std::numeric_limits<T>::min)() / numeric_ten<T>::value;
 };
@@ -669,7 +663,6 @@ template<typename T> std::string to_string_float(T value)
 {
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
   {
-    // C++20: constinit.
     static constexpr auto space{float_traits<T>::size_buffer(value)};
     std::string buf;
     buf.resize(space);

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -29,7 +29,6 @@ get_scanner(pqxx::transaction_base const &tx)
 }
 
 
-// C++20: constinit.
 constexpr std::string_view class_name{"stream_from"};
 } // namespace
 

--- a/src/subtransaction.cxx
+++ b/src/subtransaction.cxx
@@ -21,7 +21,6 @@
 
 namespace
 {
-// C++20: constinit.
 using namespace std::literals;
 constexpr std::string_view class_name{"subtransaction"sv};
 } // namespace

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -120,7 +120,6 @@ void pqxx::internal::check_unique_unregister(
 
 namespace
 {
-// C++20: constinit.
 constexpr char hex_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7',
                                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 


### PR DESCRIPTION
Trying not to break the ABI here; let's do that at the next major
release.

Also, remove those silly `constinit` suggestions.