### PR TITLE
Rework variables.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,10 @@
  - Make more functions `noexcept`.
  - Move constructor & assignment for `result`.
  - Support LGTM.com and Facebook "infer" static analysis.
+ - Deprecated `set_variable`/`get_variable` on `transaction_base`.
+ - (Design unearthed warts in SQL variables, which were then fixed.)
+ - Set/get session variables on `connection`: `set_session_var`/`get_var`.
+ - Set/get local variables: execute SQL statements.
 7.7.0
  - Fix `stream_to` for differing table/client encodings.  (#473)
  - Use `[[likely]]` & `[[unlikely]]` only in C++20, to silence warnings.

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -1004,7 +1004,7 @@ private:
   void PQXX_PRIVATE unregister_errorhandler(errorhandler *) noexcept;
 
   friend class internal::gate::connection_transaction;
-  result PQXX_PRIVATE exec(std::string_view, std::string_view = ""sv);
+  result exec(std::string_view, std::string_view = ""sv);
   result
     PQXX_PRIVATE exec(std::shared_ptr<std::string>, std::string_view = ""sv);
   void PQXX_PRIVATE register_transaction(transaction_base *);

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -367,30 +367,83 @@ public:
   //@}
 
   /// Set session variable, using SQL's `SET` command.
-  /** Set a session variable for this connection.  See the PostgreSQL
-   * documentation for a list of variables that can be set and their
-   * permissible values.
+  /** @deprecated To set a session variable, use @ref set_session_var.  To set
+   * a transaction-local variable, execute an SQL `SET` command.
    *
-   * If a transaction is currently in progress, aborting that transaction will
-   * normally discard the newly set value.  That is not true for nontransaction
-   * however, since it does not start a real backend transaction.
+   * @warning When setting a string value, you must escape and quote it first.
+   * Use the @ref quote() function to do that.
    *
    * @warning This executes an SQL query, so do not get or set variables while
    * a table stream or pipeline is active on the same connection.
    *
    * @param var Variable to set.
-   * @param value New value for Var: an identifier, a quoted string, or a
-   * number.
+   * @param value New value for Var.  This can be any SQL expression.  If it's
+   * a string, be sure that it's properly escaped and quoted.
    */
-  void set_variable(std::string_view var, std::string_view value) &;
+  [[deprecated("To set session variables, use set_session_var.")]] void
+  set_variable(std::string_view var, std::string_view value) &;
+
+  /// Set one of the session variables to a new value.
+  /** This executes SQL, so do not do it while a pipeline or stream is active
+   * on the connection.
+   *
+   * The value you set here will last for the rest of the connection's
+   * duration, or until you set a new value.
+   *
+   * If you set the value while in a @ref dbtransaction (i.e. any transaction
+   * that is not a @ref nontransaction), then rolling back the transaction will
+   * undo the change.
+   *
+   * All applies to setting _session_ variables.  You can also set the same
+   * variables as _local_ variables, in which case they will always revert to
+   * their previous value when the transaction ends (or when you overwrite them
+   * of course).  To set a local variable, simply execute an SQL statement
+   * along the lines of "`SET LOCAL var = 'value'`" inside your transaction.
+   *
+   * @param var The variable to set.
+   * @param value The new value for the variable.
+   * @throw @ref variable_set_to_null if the value is null; this is not
+   * allowed.
+   */
+  template<typename TYPE>
+  void set_session_var(std::string_view var, TYPE const &value) &
+  {
+    if constexpr (nullness<TYPE>::has_null)
+    {
+      if (nullness<TYPE>::is_null(value))
+        throw variable_set_to_null{
+          internal::concat("Attempted to set variable ", var, " to null.")};
+    }
+    exec(internal::concat("SET ", quote_name(var), "=", quote(value)));
+  }
 
   /// Read session variable, using SQL's `SHOW` command.
   /** @warning This executes an SQL query, so do not get or set variables while
    * a table stream or pipeline is active on the same connection.
    */
-  std::string get_variable(std::string_view);
-  //@}
+  [[deprecated("Use get_var instead.")]] std::string
+    get_variable(std::string_view);
 
+  /// Read currently applicable value of a variable.
+  /** This function executes an SQL statement, so it won't work while a
+   * @ref pipeline or query stream is active on the connection.
+   *
+   * @return a blank `std::optional` if the variable's value is null, or its
+   * string value otherwise.
+   */
+  std::string get_var(std::string_view var);
+
+  /// Read currently applicable value of a variable.
+  /** This function executes an SQL statement, so it won't work while a
+   * @ref pipeline or query stream is active on the connection.
+   *
+   * If there is any possibility that the variable is null, ensure that `TYPE`
+   * can represent null values.
+   */
+  template<typename TYPE> TYPE get_var_as(std::string_view var)
+  {
+    return from_string<TYPE>(get_var(var));
+  }
 
   /**
    * @name Notifications and Receivers

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -68,6 +68,14 @@ struct PQXX_LIBEXPORT broken_connection : failure
 };
 
 
+/// The caller attempted to set a variable to null, which is not allowed.
+struct PQXX_LIBEXPORT variable_set_to_null : failure
+{
+  variable_set_to_null();
+  explicit variable_set_to_null(std::string const &);
+};
+
+
 /// Exception class for failed queries.
 /** Carries, in addition to a regular error message, a copy of the failed query
  * and (if available) the SQLSTATE value accompanying the error.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -523,23 +523,31 @@ public:
   [[nodiscard]] constexpr connection &conn() const noexcept { return m_conn; }
 
   /// Set session variable using SQL "SET" command.
-  /** The new value is typically forgotten if the transaction aborts.
-   * Not for nontransaction though: in that case the set value will be kept
-   * regardless.
+  /** @deprecated To set a transaction-local variable, execute an SQL `SET`
+   * command.  To set a session variable, use the connection's
+   * @ref set_session_var function.
    *
-   * @warning This executes SQL.  Do not try to set or get variables while a
-   * pipeline or table stream is active.
+   * @warning When setting a string value, you must make sure that the string
+   * is "safe."  If you call @ref quote() on the string, it will return a
+   * safely escaped and quoted version for use as an SQL literal.
+   *
+   * @warning This function executes SQL.  Do not try to set or get variables
+   * while a pipeline or table stream is active.
    *
    * @param var The variable to set.
-   * @param value The new value to store in the variable.
+   * @param value The new value to store in the variable.  This can be any SQL
+   * expression.
    */
-  void set_variable(std::string_view var, std::string_view value);
+  [[deprecated(
+    "Set transaction-local variables using SQL SET statements.")]] void
+  set_variable(std::string_view var, std::string_view value);
 
   /// Read session variable using SQL "SHOW" command.
   /** @warning This executes SQL.  Do not try to set or get variables while a
    * pipeline or table stream is active.
    */
-  std::string get_variable(std::string_view);
+  [[deprecated("Read variables using SQL SHOW statements.")]] std::string
+    get_variable(std::string_view);
 
   // C++20: constexpr.
   /// Transaction name, if you passed one to the constructor; or empty string.

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -285,13 +285,24 @@ int PQXX_COLD pqxx::connection::server_version() const noexcept
 void pqxx::connection::set_variable(
   std::string_view var, std::string_view value) &
 {
-  exec(internal::concat("SET ", var, "=", value));
+  exec(internal::concat("SET ", quote_name(var), "=", value));
 }
 
 
 std::string pqxx::connection::get_variable(std::string_view var)
 {
-  return exec(internal::concat("SHOW ", var)).at(0).at(0).as(std::string{});
+  return exec(internal::concat("SHOW ", quote_name(var)))
+    .at(0)
+    .at(0)
+    .as(std::string{});
+}
+
+
+std::string pqxx::connection::get_var(std::string_view var)
+{
+  // (Variables can't be null, so far as I can make out.)
+  return exec(internal::concat("SHOW "sv, quote_name(var)))[0][0]
+    .as<std::string>();
 }
 
 

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -28,6 +28,17 @@ pqxx::broken_connection::broken_connection(std::string const &whatarg) :
 {}
 
 
+pqxx::variable_set_to_null::variable_set_to_null() :
+        variable_set_to_null{
+          "Attempt to set a variable to null.  This is not allowed."}
+{}
+
+
+pqxx::variable_set_to_null::variable_set_to_null(std::string const &whatarg) :
+        failure{whatarg}
+{}
+
+
 pqxx::sql_error::sql_error(
   std::string const &whatarg, std::string const &Q, char const sqlstate[]) :
         failure{whatarg}, m_query{Q}, m_sqlstate{sqlstate ? sqlstate : ""}

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -321,13 +321,17 @@ pqxx::result pqxx::transaction_base::internal_exec_params(
 void pqxx::transaction_base::set_variable(
   std::string_view var, std::string_view value)
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   conn().set_variable(var, value);
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 std::string pqxx::transaction_base::get_variable(std::string_view var)
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   return conn().get_variable(var);
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 

--- a/test/test61.cxx
+++ b/test/test61.cxx
@@ -12,13 +12,13 @@ namespace
 {
 std::string GetDatestyle(transaction_base &T)
 {
-  return T.get_variable("DATESTYLE");
+  return T.conn().get_var("DATESTYLE");
 }
 
 
 std::string SetDatestyle(transaction_base &T, std::string style)
 {
-  T.set_variable("DATESTYLE", style);
+  T.conn().set_session_var("DATESTYLE", style);
   std::string const fullname{GetDatestyle(T)};
   PQXX_CHECK(
     not std::empty(fullname),
@@ -52,7 +52,7 @@ void test_061()
   // Prove that setting an unknown variable causes an error, as expected
   quiet_errorhandler d(tx.conn());
   PQXX_CHECK_THROWS(
-    tx.set_variable("NONEXISTENT_VARIABLE_I_HOPE", "1"), sql_error,
+    conn.set_session_var("NONEXISTENT_VARIABLE_I_HOPE", 1), sql_error,
     "Setting unknown variable failed to fail.");
 }
 


### PR DESCRIPTION
This part was always messy.  The development of variables support in libpqxx
revealed some warts in how PostgreSQL handled variables at the time.  They
behaved transactionally in some scenarios, but not in others.  I believe this
was cleared up later, with a clear distinction between local variables and
session variables.  If memory serves, I updated the implementation in libpqxx
but did not re-work the design.

Now it's time to do that.  It closes off a possible route to SQL injections,
and reduces complexity by dropping support for local variables.  Session
variables rightly belong on the `connection`, and supporting them there
offers real convenience.  (To set a session variable outside a transaction
you might need to create a `nontransaction` otherwise.)  But a local variable
is about as easy to set through SQL as it is with a dedicated function.

Also, it looks as if a variable can't be null.  So I explicitly forbade
attempts to set one to null, with a specific new execption type.