### PR TITLE
Check for the right `#include` style.

### DIFF
--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_ARRAY
 #define PQXX_H_ARRAY
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/internal/encoding_group.hxx"
 #include "pqxx/internal/encodings.hxx"
 

--- a/include/pqxx/binarystring.hxx
+++ b/include/pqxx/binarystring.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_BINARYSTRING
 #define PQXX_H_BINARYSTRING
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <memory>
 #include <string>
 #include <string_view>

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_BLOB
 #define PQXX_H_BLOB
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <cstdint>
 
 #if defined(PQXX_HAVE_PATH)

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -1,6 +1,10 @@
 #ifndef PQXX_H_COMPOSITE
 #define PQXX_H_COMPOSITE
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/internal/array-composite.hxx"
 #include "pqxx/internal/concat.hxx"
 #include "pqxx/util.hxx"

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_CONNECTION
 #define PQXX_H_CONNECTION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <cstddef>
 #include <ctime>
 #include <functional>

--- a/include/pqxx/cursor.hxx
+++ b/include/pqxx/cursor.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_CURSOR
 #define PQXX_H_CURSOR
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <limits>
 #include <stdexcept>
 

--- a/include/pqxx/dbtransaction.hxx
+++ b/include/pqxx/dbtransaction.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_DBTRANSACTION
 #define PQXX_H_DBTRANSACTION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/transaction_base.hxx"
 
 namespace pqxx

--- a/include/pqxx/errorhandler.hxx
+++ b/include/pqxx/errorhandler.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_ERRORHANDLER
 #define PQXX_H_ERRORHANDLER
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/types.hxx"
 
 

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_EXCEPT
 #define PQXX_H_EXCEPT
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <stdexcept>
 #include <string>
 

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_FIELD
 #define PQXX_H_FIELD
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <optional>
 
 #include "pqxx/array.hxx"

--- a/include/pqxx/isolation.hxx
+++ b/include/pqxx/isolation.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_ISOLATION
 #define PQXX_H_ISOLATION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/util.hxx"
 
 namespace pqxx

--- a/include/pqxx/largeobject.hxx
+++ b/include/pqxx/largeobject.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_LARGEOBJECT
 #define PQXX_H_LARGEOBJECT
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <streambuf>
 
 #include "pqxx/dbtransaction.hxx"

--- a/include/pqxx/nontransaction.hxx
+++ b/include/pqxx/nontransaction.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_NONTRANSACTION
 #define PQXX_H_NONTRANSACTION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/connection.hxx"
 #include "pqxx/result.hxx"
 #include "pqxx/transaction.hxx"

--- a/include/pqxx/notification.hxx
+++ b/include/pqxx/notification.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_NOTIFICATION
 #define PQXX_H_NOTIFICATION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <string>
 
 #include "pqxx/types.hxx"

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_PARAMS
 #define PQXX_H_PARAMS
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <array>
 
 #include "pqxx/internal/concat.hxx"

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_PIPELINE
 #define PQXX_H_PIPELINE
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <limits>
 #include <map>
 #include <string>

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -1,6 +1,10 @@
 #ifndef PQXX_H_RANGE
 #define PQXX_H_RANGE
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <variant>
 
 #include "pqxx/internal/array-composite.hxx"

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_RESULT
 #define PQXX_H_RESULT
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <ios>
 #include <memory>
 #include <stdexcept>

--- a/include/pqxx/robusttransaction.hxx
+++ b/include/pqxx/robusttransaction.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_ROBUSTTRANSACTION
 #define PQXX_H_ROBUSTTRANSACTION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/dbtransaction.hxx"
 
 namespace pqxx::internal

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_ROW
 #define PQXX_H_ROW
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/except.hxx"
 #include "pqxx/field.hxx"
 #include "pqxx/result.hxx"

--- a/include/pqxx/separated_list.hxx
+++ b/include/pqxx/separated_list.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_SEPARATED_LIST
 #define PQXX_H_SEPARATED_LIST
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <algorithm>
 #include <numeric>
 

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_STRCONV
 #define PQXX_H_STRCONV
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <algorithm>
 #include <cstring>
 #include <limits>

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_STREAM_FROM
 #define PQXX_H_STREAM_FROM
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <cassert>
 #include <functional>
 #include <variant>

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_STREAM_TO
 #define PQXX_H_STREAM_TO
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/separated_list.hxx"
 #include "pqxx/transaction_base.hxx"
 

--- a/include/pqxx/subtransaction.hxx
+++ b/include/pqxx/subtransaction.hxx
@@ -13,6 +13,10 @@
 #ifndef PQXX_H_SUBTRANSACTION
 #define PQXX_H_SUBTRANSACTION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/dbtransaction.hxx"
 
 namespace pqxx

--- a/include/pqxx/time.hxx
+++ b/include/pqxx/time.hxx
@@ -5,6 +5,10 @@
 #ifndef PQXX_H_TIME
 #define PQXX_H_TIME
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <chrono>
 #include <cstdlib>
 

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -12,6 +12,10 @@
 #ifndef PQXX_H_TRANSACTION
 #define PQXX_H_TRANSACTION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/dbtransaction.hxx"
 
 namespace pqxx::internal

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -14,6 +14,10 @@
 #ifndef PQXX_H_TRANSACTION_BASE
 #define PQXX_H_TRANSACTION_BASE
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <string_view>
 #include <utility>
 

--- a/include/pqxx/transaction_focus.hxx
+++ b/include/pqxx/transaction_focus.hxx
@@ -9,6 +9,10 @@
 #ifndef PQXX_H_TRANSACTION_FOCUS
 #define PQXX_H_TRANSACTION_FOCUS
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include "pqxx/util.hxx"
 
 namespace pqxx

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_TRANSACTOR
 #define PQXX_H_TRANSACTOR
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <functional>
 #include <type_traits>
 

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -9,6 +9,10 @@
 #ifndef PQXX_H_TYPES
 #define PQXX_H_TYPES
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <cstddef>
 #include <cstdint>
 #include <iterator>

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -11,6 +11,10 @@
 #ifndef PQXX_H_UTIL
 #define PQXX_H_UTIL
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 #include <cctype>
 #include <cstdio>
 #include <functional>

--- a/include/pqxx/version.hxx
+++ b/include/pqxx/version.hxx
@@ -10,6 +10,10 @@
  */
 #ifndef PQXX_H_VERSION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 /// Full libpqxx version string.
 #  define PQXX_VERSION "7.7.1"
 /// Library ABI version.

--- a/include/pqxx/version.hxx.template
+++ b/include/pqxx/version.hxx.template
@@ -10,6 +10,10 @@
  */
 #ifndef PQXX_H_VERSION
 
+#if !defined(PQXX_H_COMPILER_PUBLIC)
+#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#endif
+
 /// Full libpqxx version string.
 #  define PQXX_VERSION "@PQXXVERSION@"
 /// Library ABI version.


### PR DESCRIPTION
Fixes: #530.

Fail with a clear error if an application includes the ".hxx" headers
directly.  That style of include was never supported, and the
documentation has always warned about it, but we can't expect people
to read everything.