### PR TITLE
Revert the path to the library symlink to be installed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ macro(library_target_setup tgt)
             VERBATIM
             COMMAND_EXPAND_LISTS
         )
-        install(FILES $<TARGET_FILE_DIR:${tgt}>/${library_prefix}${name}${library_suffix}
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${library_prefix}${name}${library_suffix}
             DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
     endif()


### PR DESCRIPTION
The CMake target property `TARGET_FILE_DIR` prints unexpected paths depending on the CMake configuration. It has been reverted to `CMAKE_CURRENT_BINARY_DIR` which used to work.