### PR TITLE
Strip `const` and `&` from `value_type`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@
  - Disallow nesting of `ignore-deprecated` blocks.
  - Deprecate `exec` functions' `desc` parameter.
  - Fix `placeholders` documentation.  (#557)
+ - Strip `const` and references from `value_type`. (#558)
 7.7.2
  - Fix up damage done by auto-formatting.
 7.7.1

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -97,14 +97,14 @@ using strip_t = std::remove_cv_t<std::remove_reference_t<TYPE>>;
  * which we may or may not end up using for this.
  */
 template<std::ranges::range CONTAINER>
-using value_type = decltype(*std::begin(std::declval<CONTAINER>()));
+using value_type = strip_t<decltype(*std::begin(std::declval<CONTAINER>()))>;
 #else  // PQXX_HAVE_CONCEPTS
 /// The type of a container's elements.
 /** At the time of writing there's a similar thing in `std::experimental`,
  * which we may or may not end up using for this.
  */
 template<typename CONTAINER>
-using value_type = decltype(*std::begin(std::declval<CONTAINER>()));
+using value_type = strip_t<decltype(*std::begin(std::declval<CONTAINER>()))>;
 #endif // PQXX_HAVE_CONCEPTS
 
 


### PR DESCRIPTION
See #558.  MSVC in C++20 or C++23 mode complains without this.