### PR TITLE
Get Windows tests working & passing.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,7 @@
  - Fix `placeholders` documentation.  (#557)
  - Strip `const` and references from `value_type`. (#558)
  - Get tests running on appveyor. (#560)
- - Fix broken nonblocking connection on Windows.
+ - Fix broken nonblocking connection on Windows. (#560)
 7.7.2
  - Fix up damage done by auto-formatting.
 7.7.1

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@
  - Deprecate `exec` functions' `desc` parameter.
  - Fix `placeholders` documentation.  (#557)
  - Strip `const` and references from `value_type`. (#558)
+ - Get tests running on appveyor. (#560)
+ - Fix broken nonblocking connection on Windows.
 7.7.2
  - Fix up damage done by auto-formatting.
 7.7.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ build_script:
     cd ..
     mkdir build
     cd build
-    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
+    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20 --config Release
     msbuild -m libpqxx.sln
 test_script:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ before_build:
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 
     cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
+
+    dir
 configuration: Release
 build:
   parallel: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ before_build:
 - cmd: >-
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-    cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
+    cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=23
 configuration: Release
 build:
   parallel: true
@@ -21,8 +21,6 @@ test_script:
     .\test\Release\runner.exe
 notifications:
 - provider: Email
-  to:
-  - jtvjtv@gmail.com
   subject: 'libpqxx: AppVeyor build failure'
   message: The libpqxx AppVeyor build has failed.
   on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,7 @@ test_script:
 
     $env:PGPASSWORD = "Password12!"
 
-    dir
-
-    dir src\Release
-
-    dir "C:\Program Files\PostgreSQL"
+    dir "C:\Program Files\PostgreSQL\12"
 
     .\test\Release\runner.exe
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,12 @@
 version: 1.0.{build}
 image: Visual Studio 2022
 services: postgresql12
-build_script:
-- cmd: >-
-    set "SOURCE=%cd%"
-    dir "C:\Program Files\Microsoft Visual Studio\2022\Community\VC"
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-    cd ..
-    mkdir build
-    cd build
-    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20 --config Release
-    msbuild -m libpqxx.sln
+build:
+  parallel: true
+configuration: Release
 test_script:
 - ps: >-
-    $env:Path += ";.\src/Release"
+    $env:Path += ";.\src\Release"
     .\test\Debug\runner.exe
 notifications:
 - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,9 @@ test_script:
 
     dir
 
-    dir src
+    dir src\Release
+
+    dir "C:\Program Files\PostgreSQL"
 
     .\test\Release\runner.exe
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ test_script:
 
     $env:PGPASSWORD = "Password12!"
 
-    .\test\Debug\runner.exe
+    .\test\Release\runner.exe
 notifications:
 - provider: Email
   to:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,10 @@ before_build:
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 
     cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
-
-    dir
 configuration: Release
 build:
   parallel: true
+  project: libpqxx.sln
 test_script:
 - ps: >-
     $env:Path += ";.\src\Release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ services: postgresql12
 before_build:
 - cmd: >-
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+
     cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
 configuration: Release
 build:
@@ -11,6 +12,11 @@ build:
 test_script:
 - ps: >-
     $env:Path += ";.\src\Release"
+
+    $env:PGUSER = "postgres"
+
+    $env:PGPASSWORD = "Password12!"
+
     .\test\Debug\runner.exe
 notifications:
 - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,8 @@ before_build:
 - cmd: >-
     set "SOURCE=%cd%"
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20 --config Release
+    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
+configuration: Release
 build:
   parallel: true
   project: libpqxx.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,11 @@ image: Visual Studio 2022
 services: postgresql12
 before_build:
 - cmd: >-
-    set "SOURCE=%cd%"
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
+    cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
 configuration: Release
 build:
   parallel: true
-  project: libpqxx.sln
 test_script:
 - ps: >-
     $env:Path += ";.\src\Release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ test_script:
 
     $env:PGPASSWORD = "Password12!"
 
-    dir "C:\Program Files\PostgreSQL\12"
+    dir "C:\Program Files\PostgreSQL\12\bin"
 
     .\test\Release\runner.exe
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,15 @@
 version: 1.0.{build}
 image: Visual Studio 2022
 services: postgresql12
+configuration: Release
+before_build:
+- cmd: >-
+    set "SOURCE=%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20 --config Release
 build:
   parallel: true
-configuration: Release
+  project: libpqxx.sln
 test_script:
 - ps: >-
     $env:Path += ";.\src\Release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,8 @@ build_script:
     msbuild -m libpqxx.sln
 test_script:
 - ps: >-
-    # $env:Path += ";.\src/Debug"
-    # Fails with code -1073741515.  No output.
-    # .\test\Debug\runner.exe
+    $env:Path += ";.\src/Release"
+    .\test\Debug\runner.exe
 notifications:
 - provider: Email
   to:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 1.0.{build}
 image: Visual Studio 2022
 services: postgresql12
-configuration: Release
 before_build:
 - cmd: >-
     set "SOURCE=%cd%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.{build}
+image: Visual Studio 2022
+services: postgresql12
+build_script:
+- cmd: >-
+    set "SOURCE=%cd%"
+    dir "C:\Program Files\Microsoft Visual Studio\2022\Community\VC"
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+    cd ..
+    mkdir build
+    cd build
+    cmake %SOURCE% -DBUILD_SHARED_LIBS=1 -DCMAKE_CXX_STANDARD=20
+    msbuild -m libpqxx.sln
+test_script:
+- ps: >-
+    # $env:Path += ";.\src/Debug"
+    # Fails with code -1073741515.  No output.
+    # .\test\Debug\runner.exe
+notifications:
+- provider: Email
+  to:
+  - jtvjtv@gmail.com
+  subject: 'libpqxx: AppVeyor build failure'
+  message: The libpqxx AppVeyor build has failed.
+  on_build_success: false
+  on_build_failure: true
+  on_build_status_changed: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,12 @@ test_script:
 
     $env:PGPASSWORD = "Password12!"
 
+    dir
+
+    dir test
+
+    dir test\Release
+
     .\test\Release\runner.exe
 notifications:
 - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,11 @@ build:
   project: libpqxx.sln
 test_script:
 - ps: >-
-    $env:Path += ";.\src\Release"
+    $env:Path += ";.\src\Release;C:\Program Files\PostgreSQL\12\bin"
 
     $env:PGUSER = "postgres"
 
     $env:PGPASSWORD = "Password12!"
-
-    dir "C:\Program Files\PostgreSQL\12\bin"
 
     .\test\Release\runner.exe
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,7 @@ test_script:
 
     dir
 
-    dir test
-
-    dir test\Release
+    dir src
 
     .\test\Release\runner.exe
 notifications:

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -905,6 +905,10 @@ public:
 
 #if defined(_WIN32) || __has_include(<fcntl.h>)
   /// Set socket to blocking (true) or nonblocking (false).
+  /** @warning Do not use this unless you _really_ know what you're doing.
+   * @warning This function is available on most systems, but not necessarily
+   * all.
+   */
   void set_blocking(bool block) &;
 #endif // defined(_WIN32) || __has_include(<fcntl.h>)
 

--- a/src/wait.cxx
+++ b/src/wait.cxx
@@ -90,7 +90,7 @@ void pqxx::internal::wait_fd(
   short const events{static_cast<short>(
     (for_read ? POLLRDNORM : 0) | (for_write ? POLLWRNORM : 0))};
   WSAPOLLFD fdarray{SOCKET(fd), events, 0};
-  WSAPoll(&fdarray, 1, to_milli<unsigned>(seconds, microseconds));
+  WSAPoll(&fdarray, 1u, to_milli<unsigned>(seconds, microseconds));
   // TODO: Check for errors.
 #elif defined(PQXX_HAVE_POLL)
   auto const events{static_cast<short>(

--- a/test/unit/test_nonblocking_connect.cxx
+++ b/test/unit/test_nonblocking_connect.cxx
@@ -11,8 +11,9 @@ namespace
 {
 void test_nonblocking_connect()
 {
+  std::clog << "Start test...\n"; // XXX: DEBUG
   pqxx::connecting nbc;
-  std::clog << "  (connecting)"; // XXX: DEBUG
+  std::clog << "(connecting)\n"; // XXX: DEBUG
   while (not nbc.done())
   {
     std::clog<<"  (wait)"; // XXX: DEBUG

--- a/test/unit/test_nonblocking_connect.cxx
+++ b/test/unit/test_nonblocking_connect.cxx
@@ -1,3 +1,4 @@
+#include <iostream> // XXX: DEBUG
 #include <pqxx/connection>
 #include <pqxx/transaction>
 
@@ -11,12 +12,16 @@ namespace
 void test_nonblocking_connect()
 {
   pqxx::connecting nbc;
+  std::clog << "  (connecting)"; // XXX: DEBUG
   while (not nbc.done())
   {
+    std::clog<<"  (wait)"; // XXX: DEBUG
     pqxx::internal::wait_fd(
       nbc.sock(), nbc.wait_to_read(), nbc.wait_to_write());
+    std::clog<<"  (process)"; // XXX: DEBUG
     nbc.process();
   }
+  std::clog<<"  (connected)"; // XXX: DEBUG
 
   pqxx::connection conn{std::move(nbc).produce()};
   pqxx::work tx{conn};

--- a/test/unit/test_nonblocking_connect.cxx
+++ b/test/unit/test_nonblocking_connect.cxx
@@ -19,10 +19,10 @@ void test_nonblocking_connect()
     std::clog<<"  (wait)"; // XXX: DEBUG
     pqxx::internal::wait_fd(
       nbc.sock(), nbc.wait_to_read(), nbc.wait_to_write());
-    std::clog<<"  (process)"; // XXX: DEBUG
+    std::clog<<"  (process)\n"; // XXX: DEBUG
     nbc.process();
   }
-  std::clog<<"  (connected)"; // XXX: DEBUG
+  std::clog<<"  (connected)\n"; // XXX: DEBUG
 
   pqxx::connection conn{std::move(nbc).produce()};
   pqxx::work tx{conn};

--- a/test/unit/test_nonblocking_connect.cxx
+++ b/test/unit/test_nonblocking_connect.cxx
@@ -11,22 +11,21 @@ namespace
 {
 void test_nonblocking_connect()
 {
-  std::clog << "Start test...\n"; // XXX: DEBUG
   pqxx::connecting nbc;
-  std::clog << "(connecting)\n"; // XXX: DEBUG
   while (not nbc.done())
   {
-    std::clog<<"  (wait)"; // XXX: DEBUG
     pqxx::internal::wait_fd(
       nbc.sock(), nbc.wait_to_read(), nbc.wait_to_write());
-    std::clog<<"  (process)\n"; // XXX: DEBUG
     nbc.process();
   }
-  std::clog<<"  (connected)\n"; // XXX: DEBUG
 
+std::clog<<"Connected.\n"; // XXX: DEBUG
   pqxx::connection conn{std::move(nbc).produce()};
+std::clog<<"Produced.\n"; // XXX: DEBUG
   pqxx::work tx{conn};
+std::clog<<"Transacting.\n"; // XXX: DEBUG
   PQXX_CHECK_EQUAL(tx.query_value<int>("SELECT 10"), 10, "Bad value!?");
+std::clog<<"Done.\n"; // XXX: DEBUG
 }
 
 

--- a/test/unit/test_nonblocking_connect.cxx
+++ b/test/unit/test_nonblocking_connect.cxx
@@ -1,5 +1,3 @@
-#include <iostream> // XXX: DEBUG
-#include <pqxx/connection>
 #include <pqxx/transaction>
 
 #include <pqxx/internal/wait.hxx>
@@ -19,13 +17,9 @@ void test_nonblocking_connect()
     nbc.process();
   }
 
-std::clog<<"Connected.\n"; // XXX: DEBUG
   pqxx::connection conn{std::move(nbc).produce()};
-std::clog<<"Produced.\n"; // XXX: DEBUG
   pqxx::work tx{conn};
-std::clog<<"Transacting.\n"; // XXX: DEBUG
   PQXX_CHECK_EQUAL(tx.query_value<int>("SELECT 10"), 10, "Bad value!?");
-std::clog<<"Done.\n"; // XXX: DEBUG
 }
 
 


### PR DESCRIPTION
I added an `appveyor.yml`.  This should mean I no longer have to configure appveyor in the web UI.  And more of the test is set up automatically, without awkward scripting in various convoluted languages.

But it also gave me the opportunity to get the tests running on Windows.  And guess what?  They didn't all pass!  The test for asynchronous connection (using `pqxx::connecting`) would hang.  Turns out it was completely unnecessary for libpqxx to manage blocking/nonblocking mode on the socket.  So that's fixed now.