### PR TITLE
Reorganise query execution functions.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 7.7.4
+ - `transaction_base::for_each()` is now called `for_stream()`.
+ - New `transaction_base::for_query()` is similar, but non-streaming.
  - New ways to query a single row!  `query01()` and `query1()`.
+ - We now have 3 kinds of execution: "exec", "query", and "stream" functions.
  - Use C++23 `std::unreachable()` where available.
 7.7.3
  - Fix up more damage done by auto-formatting.

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,8 @@
 7.7.4
- - `transaction_base::for_each()` is now called `for_stream()`.
- - New `transaction_base::for_query()` is similar, but non-streaming.
- - New way to query data and iterate directly as client-side types: `query()`.
- - New ways to query a single row!  `query01()` and `query1()`.
+ - `transaction_base::for_each()` is now called `for_stream()`. (#580)
+ - New `transaction_base::for_query()` is similar, but non-streaming. (#580)
+ - Query data and iterate directly as client-side types: `query()`. (#580)
+ - New ways to query a single row!  `query01()` and `query1()`. (#580)
  - We now have 3 kinds of execution: "exec", "query", and "stream" functions.
  - Use C++23 `std::unreachable()` where available.
  - `result::iter()` return value now keeps its `result` alive.

--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,11 @@
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`.
  - New `transaction_base::for_query()` is similar, but non-streaming.
+ - New way to query data and iterate directly as client-side types: `query()`.
  - New ways to query a single row!  `query01()` and `query1()`.
  - We now have 3 kinds of execution: "exec", "query", and "stream" functions.
  - Use C++23 `std::unreachable()` where available.
+ - `result::iter()` return value now keeps its `result` alive.
 7.7.3
  - Fix up more damage done by auto-formatting.
  - New `result::for_each()`: simple iteration and conversion of rows.  (#528)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Here's an example with all the basics to get you going:
             // For large amounts of data, "streaming" the results is more
             // efficient.  It does not work for all types of queries though.
             //
-            // You can use std::string_view for a field here, which is not
+            // You can read fields as std::string_view here, which is not
             // something you can do in most places.  A string_view becomes
             // meaningless when the underlying string ceases to exist.  In this
             // one situation, you can convert a field to string_view and it

--- a/README.md
+++ b/README.md
@@ -92,12 +92,16 @@ in standard C++ style (as in `<iostream>` etc.), but an editor will still
 recognize them as files containing C++ code.
 
 Continuing the list of classes, you may also need the result class
-(`pqxx/result.hxx`).  In a nutshell, you create a `connection` based on a
-Postgres connection string (see below), create a `work` in the context of that
-connection, and run one or more queries on the work which return `result`
-objects.  The results are containers of rows of data, each of which you can
-treat as an array of strings: one for each field in the row.  But there are
-other ways to query the database.
+(`pqxx/result.hxx`).  In a nutshell, you create a pqxx::connection based on a
+Postgres connection string (see below), create a pqxx::work (a transaction
+object) in the context of that connection, and run one or more queries and/or
+SQL commands on that.
+
+Depending on how you execute a query, it can return a stream of `std::tuple`
+(each representing one row); or a pqxx::result object which holds both the
+result data and additional metadata: how many rows your query returned and/or
+modified, what the column names are, and so on.  A pqxx::result is a container
+of pqxx::row, and a pqxx::row is a container of pqxx::field.
 
 Here's an example with all the basics to get you going:
 
@@ -111,52 +115,50 @@ Here's an example with all the basics to get you going:
         {
             // Connect to the database.  You can have multiple connections open
             // at the same time, even to the same database.
-            pqxx::connection C;
-            std::cout << "Connected to " << C.dbname() << '\n';
+            pqxx::connection c;
+            std::cout << "Connected to " << c.dbname() << '\n';
 
             // Start a transaction.  A connection can only have one transaction
             // open at the same time, but after you finish a transaction, you
             // can start a new one on the same connection.
-            pqxx::work W{C};
+            pqxx::work tx{c};
 
-            // Perform a query and retrieve all results.
-            pqxx::result R{W.exec("SELECT name FROM employee")};
-
-            // Iterate over results.
-            std::cout << "Found " << R.size() << "employees:\n";
-            for (auto row: R)
-                std::cout << row[0].c_str() << '\n';
+            // Query data of two columns, converting them to std::string and
+            // int respectively.  Iterate the rows.
+            for (auto [name, salary] : tx.query<std::string, int>(
+                "SELECT name, salary FROM employee ORDER BY name"))
+            {
+                std::cout << name << " earns " << salary << ".\n";
+            }
 
             // For large amounts of data, "streaming" the results is more
             // efficient.  It does not work for all types of queries though.
-            // What's really nice is that you don't need to iterate result
-            // objects.  This just converts the fields straight to the C++
-            // types you need.
             //
-            // You can use std::string_view for fields here, which is not
+            // You can use std::string_view for a field here, which is not
             // something you can do in most places.  A string_view becomes
             // meaningless when the underlying string ceases to exist.  In this
             // one situation, you can convert a field to string_view and it
             // will be valid for just that one iteration of the loop.  The next
             // iteration may overwrite or deallocate its buffer space.
-            for (auto [name, salary] : W.stream<std::string_view, int>(
+            for (auto [name, salary] : tx.stream<std::string_view, int>(
                 "SELECT name, salary FROM employee"))
             {
                 std::cout << name << " earns " << salary << ".\n";
             }
 
-            // Execute a statement (and check that it returns 0 rows of data).
+            // Execute a statement, and check that it returns 0 rows of data.
+            // This will throw pqxx::unexpected_rows if the query returns rows.
             std::cout << "Doubling all employees' salaries...\n";
-            W.exec0("UPDATE employee SET salary = salary*2");
+            tx.exec0("UPDATE employee SET salary = salary*2");
 
-            // Easy way to query a value from the database.
-            int my_salary = W.query_value<int>(
+            // Shorthand: conveniently query a single value from the database.
+            int my_salary = tx.query_value<int>(
                 "SELECT salary FROM employee WHERE name = 'Me'");
             std::cout << "I now earn " << my_salary << ".\n";
 
-            // Or, query one whole row.  This will throw an exception unless
-            // the result contains exactly 1 row.
-            auto [top_name, top_salary] = W.query1<std::string, int>(
+            // Or, query one whole row.  This function will throw an exception
+            // unless the result contains exactly 1 row.
+            auto [top_name, top_salary] = tx.query1<std::string, int>(
                 R"(
                     SELECT salary
                     FROM employee
@@ -166,14 +168,23 @@ Here's an example with all the basics to get you going:
             std::cout << "Top earner is " << top_name << " with a salary of "
                       << top_salary << ".\n";
 
-            // Commit the transaction.
+            // If you need to access the result metadata, not just the actual
+            // field values, use the "exec" functions.  Most of them return
+            // pqxx::result objects.
+            pqxx::result res = tx.exec("SELECT * FROM employee");
+            std::cout << "Columns:\n";
+            for (pqxx::row_size col = 0; col < res.columns(); ++col)
+                std::cout << res.column_name(col) << '\n';
+
+            // Commit the transaction.  If you don't do this, the database will
+            // undo any changes you made in the transaction.
             std::cout << "Making changes definite: ";
-            W.commit();
+            tx.commit();
             std::cout << "OK.\n";
         }
         catch (std::exception const &e)
         {
-            std::cerr << e.what() << '\n';
+            std::cerr << "ERROR: " << e.what() << '\n';
             return 1;
         }
         return 0;

--- a/include/pqxx/doc/accessing-results.md
+++ b/include/pqxx/doc/accessing-results.md
@@ -1,30 +1,111 @@
 Accessing results and result rows                   {#accessing-results}
 =================================
 
-When you execute a query using one of the transaction "exec*" functions, you
-normally get a `result` object back.  A `result` is a container of `row`s.
+A query produces a result set consisting of rows, and each row consists of
+fields.  There are several ways to receive this data.
 
-(There are exceptions: `exec1` expects exactly one row of data, so it returns
-just a `row`, not a full `result`.  And `exec0` expects no data at all, so it
-returns nothing.)
+The fields are "untyped."  That is to say, libpqxx has no opinion on what their
+types are.  The database sends the data in a very flexible textual format.
+When you read a field, you specify what type you want it to be, and libpqxx
+converts the text format to that type for you.
 
-Result objects are an all-or-nothing affair.  An `exec*` function waits until
-it's received all the result data, and only then will it return.  _(There is a
-faster, easier way of executing queries with large result sets, so see
-"streaming rows" below as well.)_
+If a value does not conform to the format for the type you specify, the
+conversion fails.  For example, if you have strings that all happen to contain
+numbers, you can read them as `int`.  But if any of the values is empty, or
+it's null (for a type that doesn't support null), or it's some string that does
+not look like an integer, or it's too large, you can't convert it to `int`.
+
+So usually, reading result data from the database means not just retrieving the
+data; it also means converting it to some target type.
+
+
+Querying rows of data
+---------------------
+
+The simplest way to query rows of data is to call one of a transaction's
+"query" functions, passing as template arguments the types of columns you want
+to get back (e.g. `int`, `std::string`, `double`, and so on) and as a regular
+argument the query itself.
+
+You can then iterate over the result to go over the rows of data:
+
+```cxx
+    for (auto [id, value] :
+        tx.query<int, std::string>("SELECT id, name FROM item"))
+    {
+        std::cout << id << '\t' << value << '\n';
+    }
+```
+
+The "query" functions execute your query, load the complete result data from
+the database, and then as you iterate, convert each row it received to a tuple
+of C++ types that you indicated.
+
+There are different query functions for querying any number of rows (`query()`);
+querying just one row of data as a `std::tuple` and throwing an error if there's
+more than one row (`query1()`); or querying
+
+Streaming rows
+--------------
+
+There's another way to go through the rows coming out of a query.  It's
+usually easier and faster if there are a lot of rows, but there are drawbacks.
+
+**One,** you start getting rows before all the data has come in from the
+database.  That speeds things up, but what happens if you lose your network
+connection while transferring the data?  Your application may already have
+processed some of the data before finding out that the rest isn't coming.  If
+that is a problem for your application, streaming may not be the right choice.
+
+**Two,** streaming only works for some types of query.  The `stream()` function
+wraps your query in a PostgreSQL `COPY` command, and `COPY` only supports a few
+commands: `SELECT`, `VALUES`, or an `INSERT`, `UPDATE`, or `DELETE` with a
+`RETURNING` clause.  See the `COPY` documentation here:
+[
+    https://www.postgresql.org/docs/current/sql-copy.html
+](https://www.postgresql.org/docs/current/sql-copy.html).
+
+**Three,** when you convert a field to a "view" type (such as
+`std::string_view` or `std::basic_string_view<std::byte>`), the view points to
+underlying data which only stays valid until you iterate to the next row or
+exit the loop.  So if you want to use that data for longer than a single
+iteration of the streaming loop, you'll have to store it somewhere yourself.
+
+Now for the good news.  Streaming does make it very easy to query data and loop
+over it:
+
+```cxx
+    for (auto [id, name, x, y] :
+        tx.stream<int, std::string_view, float, float>(
+            "SELECT id, name, x, y FROM point"))
+      process(id + 1, "point-" + name, x * 10.0, y * 10.0);
+```
+
+The conversion to C++ types (here `int`, `std::string_view`, and two `float`s)
+is built into the function.  You never even see `row` objects, `field` objects,
+iterators, or conversion methods.  You just put in your query and you receive
+your data.
+
+
+
+Results with metadata
+---------------------
+
+Sometimes you want more from a query result than just rows of data.  You may
+need to know right away how many rows of result data you received, or how many
+rows your `UPDATE` statement has affected, or the names of the columns, etc.
+
+For that, use the transaction's "exec" query execution functions.  Apart from a
+few exceptions, these return a `pqxx::result` object.  A `result` is a container
+of `pqxx::row` objects, so you can iterate them as normal, or index them like
+you would index an array.  Each `row` in turn is a container of `pqxx::field`,
+Each `field` holds a value, but doesn't know its type.  You specify the type
+when you read the value.
 
 For example, your code might do:
 
 ```cxx
     pqxx::result r = tx.exec("SELECT * FROM mytable");
-```
-
-Now, how do you access the data inside `r`?
-
-Result sets act as standard C++ containers of rows.  Rows act as standard
-C++ containers of fields.  So the easiest way to go through them is:
-
-```cxx
     for (auto const &row: r)
     {
        for (auto const &field: row) std::cout << field.c_str() << '\t';
@@ -116,45 +197,3 @@ This becomes really helpful with the array-indexing operator.  With regular
 C++ iterators you would need ugly expressions like `(*row)[0]` or
 `row->operator[](0)`.  With the iterator types defined by the result and
 row classes you can simply say `row[0]`.
-
-
-Streaming rows
---------------
-
-There's another way to go through the rows coming out of a query.  It's
-usually easier and faster, but there are drawbacks.
-
-**One,** you start getting rows before all the data has come in from the
-database.  That speeds things up, but what happens if you lose your network
-connection while transferring the data?  Your application may already have
-processed some of the data before finding out that the rest isn't coming.  If
-that is a problem for your application, streaming may not be the right choice.
-
-**Two,** streaming only works for some types of query.  The `stream()` function
-wraps your query in a PostgreSQL `COPY` command, and `COPY` only supports a few
-commands: `SELECT`, `VALUES`, or an `INSERT`, `UPDATE`, or `DELETE` with a
-`RETURNING` clause.  See the `COPY` documentation here:
-[
-    https://www.postgresql.org/docs/current/sql-copy.html
-](https://www.postgresql.org/docs/current/sql-copy.html).
-
-**Three,** when you convert a field to a "view" type (such as
-`std::string_view` or `std::basic_string_view<std::byte>`), the view points to
-underlying data which only stays valid until you iterate to the next row or
-exit the loop.  So if you want to use that data for longer than a single
-iteration of the streaming loop, you'll have to store it somewhere yourself.
-
-Now for the good news.  Streaming does make it very easy to query data and loop
-over it:
-
-```cxx
-    for (auto [id, name, x, y] :
-        tx.stream<int, std::string_view, float, float>(
-            "SELECT id, name, x, y FROM point"))
-      process(id + 1, "point-" + name, x * 10.0, y * 10.0);
-```
-
-The conversion to C++ types (here `int`, `std::string_view`, and two `float`s)
-is built into the function.  You never even see `row` objects, `field` objects,
-iterators, or conversion methods.  You just put in your query and you receive
-your data.

--- a/include/pqxx/doc/streams.md
+++ b/include/pqxx/doc/streams.md
@@ -56,8 +56,8 @@ the client side while the server is still sending you the rest.
 
 You don't actually need to create a `stream_from` object yourself, though you
 can.  Two shorthand functions, @ref pqxx::transaction_base::stream
-and @ref pqxx::transaction_base::for_each, can create the streams for you with
-a minimum of overhead.
+and @ref pqxx::transaction_base::for_stream, can create the streams for you
+with a minimum of overhead.
 
 Not all kinds of queries will work in a stream.  Internally the streams make
 use of PostgreSQL's `COPY` command, so see the PostgreSQL documentation for

--- a/include/pqxx/doc/streams.md
+++ b/include/pqxx/doc/streams.md
@@ -55,9 +55,9 @@ then you begin processing.  With `stream_from` you can be processing data on
 the client side while the server is still sending you the rest.
 
 You don't actually need to create a `stream_from` object yourself, though you
-can.  Two shorthand functions, @ref pqxx::transaction_base::stream
-and @ref pqxx::transaction_base::for_stream, can create the streams for you
-with a minimum of overhead.
+can if you want to.  Two shorthand functions,
+@ref pqxx::transaction_base::stream and @ref pqxx::transaction_base::for_stream,
+can each create the streams for you with a minimum of overhead.
 
 Not all kinds of queries will work in a stream.  Internally the streams make
 use of PostgreSQL's `COPY` command, so see the PostgreSQL documentation for

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -91,7 +91,7 @@ public:
   iterator end() const { return {}; }
 
 private:
-  pqxx::result const &m_home;
+  pqxx::result const m_home;
 };
 } // namespace pqxx::internal
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -592,7 +592,7 @@ public:
    * @return Something you can iterate using "range `for`" syntax.  The actual
    * type details may change.
    */
-  template<typename... TYPE> auto query_n(std::size_type rows, zview query)
+  template<typename... TYPE> auto query_n(result::size_type rows, zview query)
   {
     return exec_n(rows, query).iter<TYPE...>();
   }

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -264,10 +264,10 @@ public:
    *   your query may have modified, and so on.
    *
    * Some of these functions also give you the option to specify how many rows
-   * of data you expect to get: `exec0()` fails if the query returns any data
-   * at all, `exec1()` expects a single row of data (and so returns a pqxx::row
-   * rather than a pqxx::result), `exec_n()` lets you specify the number of
-   * rows you expect, and so on.
+   * of data you expect to get: `exec0()` reports a failure if the query
+   * returns any rows of data at all, `exec1()` expects a single row of data
+   * (and so returns a pqxx::row rather than a pqxx::result), `exec_n()` lets
+   * you specify the number of rows you expect, and so on.
    */
   //@{
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -574,13 +574,28 @@ public:
    * the result, such as the number of rows in the result, or the number of
    * rows that your query updates, then you'll need to use
    * transaction_base::exec() instead.
+   *
+   * @return Something you can iterate using "range `for`" syntax.  The actual
+   * type details may change.
    */
   template<typename... TYPE> auto query(zview query)
   {
     return exec(query).iter<TYPE...>();
   }
 
-  // TODO: query_n().
+  /// Perform query, expect given number of rows, iterate results.
+  /** Works like @ref query, but checks that the result has exactly the
+   * expected number of rows.
+   *
+   * @throw unexpected_rows If the query returned the wrong number of rows.
+   *
+   * @return Something you can iterate using "range `for`" syntax.  The actual
+   * type details may change.
+   */
+  template<typename... TYPE> auto query_n(std::size_type rows, zview query)
+  {
+    return exec_n(rows, query).iter<TYPE...>();
+  }
 
   // C++20: Concept like std::invocable, but without specifying param types.
   /// Execute a query, load the full result, and perform `func` for each row.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -538,7 +538,7 @@ public:
   [[deprecated("pqxx::transaction_base::for_each is now called for_stream.")]]
   auto for_each(std::string_view query, CALLABLE &&func)
   {
-    return for_stream(query, std::forward(func));
+    return for_stream(query, std::forward<CALLABLE>(func));
   }
 
   // C++20: Concept like std::invocable, but without specifying param types.
@@ -554,7 +554,7 @@ public:
   template<typename CALLABLE>
   void for_query(zview query, CALLABLE &&func)
   {
-    exec(query).for_each(std::forward(func));
+    exec(query).for_each(std::forward<CALLABLE>(func));
   }
 
   /**

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -509,7 +509,7 @@ public:
    * object that supports the function call operator.  Of course `func` must
    * have an unambiguous signature; it can't be overloaded or generic.
    *
-   * The `for_each` function executes `query` in a stream using
+   * The `for_stream` function executes `query` in a stream using
    * @ref pqxx::stream_from.  Every time a row of data comes in from the
    * server, it converts the row's fields to the types of `func`'s respective
    * parameters, and calls `func` with those values.
@@ -521,7 +521,7 @@ public:
    *
    * Streaming a query like this is likely to be slower than the @ref exec()
    * functions for small result sets, but faster for large result sets.  So if
-   * performance matters, you'll want to use `for_each` if you query large
+   * performance matters, you'll want to use `for_stream` if you query large
    * amounts of data, but not if you do lots of queries with small outputs.
    */
   template<typename CALLABLE>

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -188,10 +188,34 @@ void test_transaction_query1()
 }
 
 
+void test_transaction_query_n()
+{
+  pqxx::connection c;
+  pqxx::work w{c};
+
+  std::tuple<int> x;
+  PQXX_CHECK_THROWS(
+    x = w.query_n<int>(5, "SELECT generate_series(1, 3)"),
+    pqxx::unexpected_rows, "No exception when query_n returns too few rows.");
+  PQXX_CHECK_THROWS(
+    x = w.query_n<int>(5, "SELECT generate_series(1, 10)"),
+    pqxx::unexpected_rows, "No exception when query_n returns too many rows.");
+  pqxx::ignore_unused(x);
+
+  std::vector<int> v;
+  for (auto [n] : w.query_n<int>(3, "SELECT generate_series(7, 9)"))
+    v.push_back(n);
+  PQXX_CHECK_EQUAL(std::size(v), 3, "Wrong number of rows.");
+  PQXX_CHECK_EQUAL(v[0], 7, "Wrong result data.");
+  PQXX_CHECK_EQUAL(v[2], 9, "Data started out right but went wrong.");
+}
+
+
 PQXX_REGISTER_TEST(test_transaction_base);
 PQXX_REGISTER_TEST(test_transaction_query);
 PQXX_REGISTER_TEST(test_transaction_for_query);
 PQXX_REGISTER_TEST(test_transaction_for_stream);
 PQXX_REGISTER_TEST(test_transaction_query01);
 PQXX_REGISTER_TEST(test_transaction_query1);
+PQXX_REGISTER_TEST(test_transaction_query_n);
 } // namespace

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -82,6 +82,30 @@ void test_transaction_base()
 }
 
 
+void test_transaction_query()
+{
+  pqxx::connection c;
+  pqxx::work tx{c};
+
+  std::vector<std::string> names;
+  std::vector<int> salaries;
+
+  for (auto [name, salary] : tx.query<std::string, int>(
+         "SELECT 'name' || i, i * 1000 FROM generate_series(1, 5) AS i"))
+  {
+    names.emplace_back(name);
+    salaries.emplace_back(salary);
+  }
+
+  PQXX_CHECK_EQUAL(std::size(names), 5u, "Wrong number of rows.");
+  PQXX_CHECK_EQUAL(std::size(salaries), 5u, "Mismatched number of salaries!");
+  PQXX_CHECK_EQUAL(names[0], "name1", "Names start out wrong.");
+  PQXX_CHECK_EQUAL(names[4], "name5", "Names end wrong.");
+  PQXX_CHECK_EQUAL(salaries[0], 1'000, "Salaries start out wrong.");
+  PQXX_CHECK_EQUAL(salaries[4], 5'000, "Salaries end wrong.");
+}
+
+
 void test_transaction_for_query()
 {
   constexpr auto query{
@@ -165,6 +189,7 @@ void test_transaction_query1()
 
 
 PQXX_REGISTER_TEST(test_transaction_base);
+PQXX_REGISTER_TEST(test_transaction_query);
 PQXX_REGISTER_TEST(test_transaction_for_query);
 PQXX_REGISTER_TEST(test_transaction_for_stream);
 PQXX_REGISTER_TEST(test_transaction_query01);

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -193,19 +193,17 @@ void test_transaction_query_n()
   pqxx::connection c;
   pqxx::work w{c};
 
-  std::tuple<int> x;
   PQXX_CHECK_THROWS(
-    x = w.query_n<int>(5, "SELECT generate_series(1, 3)"),
+    pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 3)")),
     pqxx::unexpected_rows, "No exception when query_n returns too few rows.");
   PQXX_CHECK_THROWS(
-    x = w.query_n<int>(5, "SELECT generate_series(1, 10)"),
+    pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 10)")),
     pqxx::unexpected_rows, "No exception when query_n returns too many rows.");
-  pqxx::ignore_unused(x);
 
   std::vector<int> v;
   for (auto [n] : w.query_n<int>(3, "SELECT generate_series(7, 9)"))
     v.push_back(n);
-  PQXX_CHECK_EQUAL(std::size(v), 3, "Wrong number of rows.");
+  PQXX_CHECK_EQUAL(std::size(v), 3u, "Wrong number of rows.");
   PQXX_CHECK_EQUAL(v[0], 7, "Wrong result data.");
   PQXX_CHECK_EQUAL(v[2], 9, "Data started out right but went wrong.");
 }


### PR DESCRIPTION
Puts all the various ways to execute an SQL command into 3 categories:
1. "exec" functions return `result` (or `row`, or `void`, depending).
2. "query" functions wrap "exec" ones, plus string conversion.
3. "stream" functions are like "query" ones, but stream the query.

To make these things fall into place, I'm renaming the recently added
`for_each()` to `for_stream()`, and providing a `for_query()` cousin.

If this works out, I hope to build a `query()` that works just like
`stream()` (but in non-streaming fashion).

Eventually, I hope `pqxx::result` can just _disappear_ from users'
consciousness.  The normal ways to execute a query will be...
* _exec0_ just for queries that return no data,
* _query_ functions for small result sets or exotic queries, and
* _stream_ functions for regular queries returning large result sets.

(As a separate effort, I would like to integrate use of parameterised
statements into the regular execution functions, so you just pass some
`pqxx::params` to those basic functions.  Un-parameterised statements
will be nothing but a hidden optimisation.)