### PR TITLE
Markdown lint

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,0 +1,22 @@
+all
+
+# Allow mixing of header styles, within reason.
+# I use "setext" style when I can, but have to switch to "atx" (hash marks)
+# for the more fine-grained sections which setext does not support.
+rule 'MD003', :style => :setext_with_atx
+
+# Multiple consecutive blank lines.  Sorry, but I want my Markdown to look
+# nice.  And there does not seem to be an option for "allow a maximum of 2."
+exclude_rule 'MD012'
+
+# What joker came up with this?  There may be some sense to warning about
+# trailing punctuation, but not when it's a question mark or exclamantion mark!
+rule 'MD026', :punctuation => '.,;:'
+
+# In an ordered list, I like to start each item with the right number, not with
+# "1."
+rule 'MD029', :style => :ordered
+
+# Allow bare URLs.  Hate to have to disable this, but mainpage.md has some
+# special syntax which requires bare URLs.
+exclude_rule 'MD034'

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,4 @@
+# Markdownlint config.  Basically it's code, not config.  :-(
+# Also, it seems all we can really do in this file is point to another file
+# containing our actual configuration.
+style '.mdl_style.rb'

--- a/BUILDING-cmake.md
+++ b/BUILDING-cmake.md
@@ -161,6 +161,7 @@ Stages
 
 I'll explain the main build steps in more detail below, but here's a quick
 rundown:
+
 1. Configure
 2. Compile
 3. Test
@@ -202,6 +203,7 @@ explain the two directories.
 ### Cheat sheet
 
 Here are some popular `cmake` options for libpqxx:
+
 * `-DSKIP_BUILD_TEST=on` skips compiling libpqxx's tests.
 * `-DBUILD_SHARED_LIBS=on` to build a shared library.
 * `-DBUILD_SHARED_LIBS=off` to build a static library.
@@ -341,11 +343,14 @@ other way.)
 * `PGUSER` — user name under which you wish to log in on the database.
 * `PGPASSWORD` — user name's password for accessing the database.
 
-See the full list at https://www.postgresql.org/docs/current/libpq-envars.html
+See the full list at [
+    https://www.postgresql.org/docs/current/libpq-envars.html
+](https://www.postgresql.org/docs/current/libpq-envars.html)
 
 **Be careful with passwords,** by the way.  Depending on your operating system
 and configuration, an attacker with access to your machine could try to read
 your password if you set it on the command line:
+
 * Your shell may keep a log of the commands you have entered.
 * Environment variables may be visible to other users on the system.
 

--- a/BUILDING-configure.md
+++ b/BUILDING-configure.md
@@ -29,6 +29,7 @@ Stages
 
 I'll explain the main build steps in more detail below, but here's a quick
 overview:
+
 1. Configure
 2. Compile
 3. Test
@@ -70,6 +71,7 @@ the output of `configure --help`.  I'll also explain the two directories.
 ### Cheat sheet
 
 Here are some popular `configure` options:
+
 * `--disable-documentation` skips building of the documentation.
 * `CXXFLAGS=-O0` disables optimisation.  Slower code, but faster build.
 * `CXXFLAGS=-O3` asks for _more_ optimisation.  Faster code, slower build.
@@ -107,6 +109,7 @@ of mistakes in the code, such as occasionally-unused variables.)
 
 One of `configure`'s most important jobs in the libpqxx build is to find the
 headers and library for libpq.  It has three ways of finding those:
+
 1. Asking a popular tool called `pkg-config`, if installed.
 2. Asking postgres' deprecated `pg_config` tool, if installed.
 3. Through explicit command-line options to `configure`.
@@ -217,6 +220,7 @@ You can set these parameters for the test suite, or for any other libpq-based
 application, using the following environment variables.  (They only set default
 values, so they won't override parameters that the application sets in some
 other way.)
+
 * `PGHOST` — the IP address where we can contact the database's socket.  Or
   for a Unix domain socket, its absolute path on the filesystem.
 * `PGPORT` —
@@ -224,11 +228,14 @@ other way.)
 * `PGUSER` — user name under which you wish to log in on the database.
 * `PGPASSWORD` — user name's password for accessing the database.
 
-See the full list at https://www.postgresql.org/docs/current/libpq-envars.html
+See the full list at [
+    https://www.postgresql.org/docs/current/libpq-envars.html
+](https://www.postgresql.org/docs/current/libpq-envars.html).
 
 **Be careful with passwords,** by the way.  Depending on your operating system
 and configuration, an attacker with access to your machine could try to read
 your password if you set it on the command line:
+
 * Your shell may keep a log of the commands you have entered.
 * Environment variables may be visible to other users on the system.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,17 @@ libpqxx
 
 Welcome to libpqxx, the C++ API to the PostgreSQL database management system.
 
-Home page: http://pqxx.org/development/libpqxx/
+Home page: [
+    http://pqxx.org/development/libpqxx
+](http://pqxx.org/development/libpqxx/)
 
-Find libpqxx on Github: https://github.com/jtv/libpqxx
+Find libpqxx on Github: [
+    https://github.com/jtv/libpqxx
+](https://github.com/jtv/libpqxx)
 
-Documentation on Read The Docs: https://libpqxx.readthedocs.io
+Documentation on Read The Docs: [
+    https://libpqxx.readthedocs.io
+](https://libpqxx.readthedocs.io)
 
 Compiling this package requires PostgreSQL to be installed -- or at least the C
 headers and library for client development.  The library builds on top of
@@ -17,7 +23,9 @@ If you're getting the code straight from the Git repo, the head of the `master`
 branch represents the current _development version._  Releases are tags on
 commits in `master`.  For example, to get version 7.1.1:
 
+```sh
     git checkout 7.1.1
+```
 
 
 Upgrade notes
@@ -27,6 +35,7 @@ Upgrade notes
 date.  For libpqxx 8.x you will need at least C++20.
 
 Also, **7.0 makes some breaking changes in rarely used APIs:**
+
 * There is just a single `connection` class.  It connects immediately.
 * Custom `connection` classes are no longer supported.
 * It's no longer possible to reactivate a connection once it's been closed.
@@ -40,6 +49,7 @@ Building libpqxx
 ----------------
 
 There are two different ways of building libpqxx from the command line:
+
 1. Using CMake, on any system which supports it.
 2. On Unix-like systems, using a `configure` script.
 
@@ -184,6 +194,7 @@ PostgreSQL documentation for authoritative information.
 
 The connection string consists of attribute=value pairs separated by spaces,
 e.g. "user=john password=1x2y3z4".  The valid attributes include:
+
 * `host` —
   Name of server to connect to, or the full file path (beginning with a
   slash) to a Unix-domain socket on the local machine.  Defaults to
@@ -218,7 +229,9 @@ To link your final program, make sure you link to both the C-level libpq library
 and the actual C++ library, libpqxx.  With most Unix-style compilers, you'd do
 this using the options
 
+```
     -lpqxx -lpq
+```
 
 while linking.  Both libraries must be in your link path, so the linker knows
 where to find them.  Any dynamic libraries you use must also be in a place

--- a/README.md
+++ b/README.md
@@ -227,11 +227,7 @@ Linking with libpqxx
 
 To link your final program, make sure you link to both the C-level libpq library
 and the actual C++ library, libpqxx.  With most Unix-style compilers, you'd do
-this using the options
-
-```
-    -lpqxx -lpq
-```
+this using these options: `-lpqxx -lpq`
 
 while linking.  Both libraries must be in your link path, so the linker knows
 where to find them.  Any dynamic libraries you use must also be in a place

--- a/include/pqxx/doc/accessing-results.md
+++ b/include/pqxx/doc/accessing-results.md
@@ -1,5 +1,5 @@
 Accessing results and result rows                   {#accessing-results}
----------------------------------
+=================================
 
 When you execute a query using one of the transaction "exec*" functions, you
 normally get a `result` object back.  A `result` is a container of `row`s.

--- a/include/pqxx/doc/accessing-results.md
+++ b/include/pqxx/doc/accessing-results.md
@@ -1,7 +1,7 @@
 Accessing results and result rows                   {#accessing-results}
 ---------------------------------
 
-When you execute a query using one of the transaction `exec*` functions, you
+When you execute a query using one of the transaction "exec*" functions, you
 normally get a `result` object back.  A `result` is a container of `row`s.
 
 (There are exceptions: `exec1` expects exactly one row of data, so it returns
@@ -86,8 +86,8 @@ For C++23 or better, there's also a two-dimensional array access operator:
     for (std::size_t rownum=0u; rownum < num_rows; ++rownum)
     {
         for (std::size_t colnum=0u; colnum < num_cols; ++colnum)
-	    std::cout result[rownum, colnum].c_str() << '\t';
-	std::cout << '\n';
+            std::cout result[rownum, colnum].c_str() << '\t';
+        std::cout << '\n';
     }
 ```
 
@@ -132,9 +132,11 @@ that is a problem for your application, streaming may not be the right choice.
 
 **Two,** streaming only works for some types of query.  The `stream()` function
 wraps your query in a PostgreSQL `COPY` command, and `COPY` only supports a few
-commands: `SELECT`, `VALUES`, `or an `INSERT`, `UPDATE`, or `DELETE` with a
+commands: `SELECT`, `VALUES`, or an `INSERT`, `UPDATE`, or `DELETE` with a
 `RETURNING` clause.  See the `COPY` documentation here:
-https://www.postgresql.org/docs/current/sql-copy.html
+[
+    https://www.postgresql.org/docs/current/sql-copy.html
+](https://www.postgresql.org/docs/current/sql-copy.html).
 
 **Three,** when you convert a field to a "view" type (such as
 `std::string_view` or `std::basic_string_view<std::byte>`), the view points to

--- a/include/pqxx/doc/binary-data.md
+++ b/include/pqxx/doc/binary-data.md
@@ -29,14 +29,18 @@ So long as it's _basically_ still a block of bytes though, you can use
 There are two forms of `binary_cast`.  One takes a single argument that must
 support `std::data()` and `std::size()`:
 
+```cxx
     std::string hi{"Hello binary world"};
     my_blob.write(pqxx::binary_cast(hi);
+```
 
 The other takes a pointer and a size:
 
+```cxx
     char const greeting[] = "Hello binary world";
     char const *hi = greeting;
     my_blob.write(pqxx::binary_cast(hi, sizeof(greeting)));
+```
 
 
 Caveats

--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -36,11 +36,15 @@ conversion is the actual value, and the type.
 In some cases the templates for these conversions can tell the type from the
 arguments you pass them:
 
+```cxx
     auto x = to_string(99);
+```
 
 In other cases you may need to instantiate template explicitly:
 
+```cxx
     auto y = from_string<int>("99");
+```
 
 
 Supporting a new type
@@ -108,10 +112,12 @@ To tell libpqxx the name of each type, there's a template variable called
 `pqxx::type_name`.  For any given type `T`, it should have a specialisation
 that provides that `T`'s human-readable name:
 
+```cxx
     namespace pqxx
     {
     template<> std::string const type_name<T>{"T"};
     }
+```
 
 (Yes, this means that you need to define something inside the pqxx namespace.
 Future versions of libpqxx may move this into a separate namespace.)
@@ -132,16 +138,19 @@ The simplest scenario is also the most common: most types don't have a null
 value built in.  In that case, derive your nullness traits from
 `pqxx::no_null`:
 
+```cxx
     namespace pqxx
     {
     template<> struct nullness<T> : pqxx::no_null<T> {};
     }
+```
 
 (Here again you're defining this in the pqxx namespace.)
 
 If your type does have a natural null value, the definition gets a little more
 complex:
 
+```cxx
     namespace pqxx
     {
     template<> struct nullness<T>
@@ -162,6 +171,7 @@ complex:
       }
     };
     }
+```
 
 You may be wondering why there's a function to produce a null value, but also a
 function to check whether a value is null.  Why not just compare the value to
@@ -181,6 +191,7 @@ Specialise `string_traits`
 This part is more work.  (You can skip it for types that are _always_ null,
 but those will be rare.)  Specialise the `pqxx::string_traits` template:
 
+```cxx
     namespace pqxx
     {
     template<> struct string_traits<T>
@@ -191,6 +202,7 @@ but those will be rare.)  Specialise the `pqxx::string_traits` template:
       static std::size_t size_buffer(T const &value) noexcept;
     };
     }
+```
 
 You'll also need to write those member functions, or as many of them as needed
 to get your code to build.
@@ -243,10 +255,12 @@ it will be there.
 
 Expressed in code, this rule must hold:
 
+```cxx
     void invariant(zview z)
     {
       assert(z[std::size(z)] == 0);
     }
+```
 
 Make sure you write your trailing zero _before_ the `end`.  If the trailing
 zero doesn't fit in the buffer, then there's just not enough room to perform
@@ -301,10 +315,12 @@ in arrays or composite types.
 
 If your type is like that, you can tell libpqxx about this by defining:
 
+```cxx
     namespace pqxx
     {
     template<> inline constexpr bool is_unquoted_safe<MY_TYPE>{true};
     }
+```
 
 The code that converts this type of field to strings in an array or a composite
 type can then use a simpler, more efficient variant of the code.  It's always

--- a/include/pqxx/doc/escaping.md
+++ b/include/pqxx/doc/escaping.md
@@ -22,10 +22,12 @@ To understand what SQL injection vulnerabilities are and why they should be
 prevented, imagine you use the following SQL statement somewhere in your
 program:
 
+```cxx
     TX.exec(
-    	"SELECT number,amount "
-    	"FROM accounts "
-    	"WHERE allowed_to_see('" + userid + "','" + password + "')");
+        "SELECT number,amount "
+        "FROM account "
+        "WHERE allowed_to_see('" + userid + "','" + password + "')");
+```
 
 This shows a logged-in user important information on all accounts he is
 authorized to view.  The userid and password strings are variables entered
@@ -35,14 +37,18 @@ Now, if the user is actually an attacker who knows (or can guess) the
 general shape of this SQL statement, imagine he enters the following
 password:
 
+```
     x') OR ('x' = 'x
+```
 
 Does that make sense to you?  Probably not.  But if this is inserted into
 the SQL string by the C++ code above, the query becomes:
 
+```sql
     SELECT number,amount
-    FROM accounts
+    FROM account
     WHERE allowed_to_see('user','x') OR ('x' = 'x')
+```
 
 Is this what you wanted to happen?  Probably not!  The neat `allowed_to_see()`
 clause is completely circumvented by the "`OR ('x' = 'x')`" clause, which is
@@ -55,18 +61,22 @@ Using the esc functions
 
 Here's how you can fix the problem in the example above:
 
+```cxx
     TX.exec(
-    	"SELECT number,amount "
-    	"FROM accounts "
-    	"WHERE allowed_to_see('" + TX.esc(userid) + "', "
-    		"'" + TX.esc(password) + "')");
+        "SELECT number,amount "
+        "FROM account "
+        "WHERE allowed_to_see('" + TX.esc(userid) + "', "
+        "'" + TX.esc(password) + "')");
+```
 
 Now, the quotes embedded in the attacker's string will be neatly escaped so
 they can't "break out" of the quoted SQL string they were meant to go into:
 
+```sql
     SELECT number,amount
-    FROM accounts
+    FROM account
     WHERE allowed_to_see('user', 'x'') OR (''x'' = ''x')
+```
 
 If you look carefully, you'll see that thanks to the added escape characters
 (a single-quote is escaped in SQL by doubling it) all we get is a very

--- a/include/pqxx/doc/escaping.md
+++ b/include/pqxx/doc/escaping.md
@@ -34,10 +34,9 @@ authorized to view.  The userid and password strings are variables entered
 by the user himself.
 
 Now, if the user is actually an attacker who knows (or can guess) the
-general shape of this SQL statement, imagine he enters the following
-password:
+general shape of this SQL statement, imagine getting following password:
 
-```
+```text
     x') OR ('x' = 'x
 ```
 

--- a/include/pqxx/doc/getting-started.md
+++ b/include/pqxx/doc/getting-started.md
@@ -5,6 +5,7 @@ The most basic three types in libpqxx are the _connection_, the _transaction_,
 and the _result_.
 
 They fit together as follows:
+
 * You connect to the database by creating a `pqxx::connection` object (see
   @ref connections).
 
@@ -37,6 +38,7 @@ Here's a very basic example.  It connects to the default database (you'll
 need to have one set up), queries it for a very simple result, converts it to
 an `int`, and prints it out.  It also contains some basic error handling.
 
+```cxx
     #include <iostream>
     #include <pqxx/pqxx>
 
@@ -78,6 +80,7 @@ an `int`, and prints it out.  It also contains some basic error handling.
         return 1;
       }
     }
+```
 
 This prints the number 1.  Notice that you can keep the result object around
 after you've closed the transaction or even the connection.  There are
@@ -90,11 +93,13 @@ connection and deal with the data.
 You can also convert an entire row to a series of C++-side types in one go,
 using the @c as member function on the row:
 
+```cxx
     pqxx::connection c;
     pqxx::work w(c);
     pqxx::row r = w.exec1("SELECT 1, 2, 'Hello'");
     auto [one, two, hello] = r.as<int, int, std::string>();
     std::cout << (one + two) << ' ' << std::strlen(hello) << std::endl;
+```
 
 Here's a slightly more complicated example.  It takes an argument from the
 command line and retrieves a string with that value.  The interesting part is
@@ -102,6 +107,7 @@ that it uses the escaping-and-quoting function `quote` to embed this
 string value in SQL safely.  It also reads the result field's value as a
 plain C-style string using its `c_str` function.
 
+```cxx
     #include <iostream>
     #include <stdexcept>
     #include <pqxx/pqxx>
@@ -132,6 +138,7 @@ plain C-style string using its `c_str` function.
         return 1;
       }
     }
+```
 
 You can find more about converting field values to native types, or
 converting values to strings for use with libpqxx, under

--- a/include/pqxx/doc/mainpage.md
+++ b/include/pqxx/doc/mainpage.md
@@ -14,10 +14,12 @@ standard C API, libpq.  The libpq headers are not needed to compile client
 programs, however.
 
 For a quick introduction to installing and using libpqxx, see the README.md
-file.  The latest information can be found at http://pqxx.org/
+file.  The latest information can be found at
+[http://pqxx.org/](http://pqxx.org/).
 
 
 Some links that should help you find your bearings:
+
 * @ref getting-started
 * @ref thread-safety
 * @ref connections

--- a/include/pqxx/doc/mainpage.md.template
+++ b/include/pqxx/doc/mainpage.md.template
@@ -14,10 +14,12 @@ standard C API, libpq.  The libpq headers are not needed to compile client
 programs, however.
 
 For a quick introduction to installing and using libpqxx, see the README.md
-file.  The latest information can be found at http://pqxx.org/
+file.  The latest information can be found at
+[http://pqxx.org/](http://pqxx.org/).
 
 
 Some links that should help you find your bearings:
+
 * @ref getting-started
 * @ref thread-safety
 * @ref connections

--- a/include/pqxx/doc/parameters.md
+++ b/include/pqxx/doc/parameters.md
@@ -69,13 +69,16 @@ counter which produces those placeholder strings, `$1`, `$2`, `$3`, et cetera.
 When you start generating a complex statement, you can create both a `params`
 and a `placeholders`:
 
+```cxx
     pqxx::params values;
     pqxx::placeholders name;
+```
 
 Let's say you've got some complex code to generate the conditions for an SQL
 "WHERE" clause.  You'll generally want to do these things close together in
 your, so that you don't accidentally update one part and forget another:
 
+```cxx
     if (extra_clause)
     {
       // Extend the query text, using the current placeholder.
@@ -85,6 +88,7 @@ your, so that you don't accidentally update one part and forget another:
       // Move on to the next placeholder value.
       name.next();
     }
+```
 
 Depending on the starting value of `name`, this might add to `query` a fragment
-like "` AND x = $3`" or "` AND x = $5`".
+like " `AND x = $3` " or " `AND x = $5` ".

--- a/include/pqxx/doc/prepared-statement.md
+++ b/include/pqxx/doc/prepared-statement.md
@@ -62,8 +62,8 @@ preparing a statement and invoking it with parameters:
       // given name (parameter 1) whose salary exceeds a given number
       // (parameter 2).
       c.prepare(
-  	    "find",
-  	    "SELECT * FROM Employee WHERE name = $1 AND salary > $2");
+        "find",
+        "SELECT * FROM Employee WHERE name = $1 AND salary > $2");
     }
 ```
 

--- a/include/pqxx/doc/streams.md
+++ b/include/pqxx/doc/streams.md
@@ -1,4 +1,4 @@
-Streams						{#streams}
+Streams                                                           {#streams}
 =======
 
 Most of the time it's fine to retrieve data from the database using `SELECT`
@@ -67,12 +67,14 @@ queries should just work.
 As you read a row, the stream converts its fields to a tuple type containing
 the value types you ask for:
 
+```cxx
     auto stream pqxx::stream_from::query(
         tx, "SELECT name, points FROM score");
     std::tuple<std::string, int> row;
     while (stream >> row)
       process(row);
     stream.complete();
+```
 
 As the stream reads each row, it converts that row's data into your tuple,
 goes through your loop body, and then promptly forgets that row's data.  This
@@ -89,6 +91,7 @@ faster if you want to insert more than just one or two rows at a time.
 As with `stream_from`, you can specify the table and the columns, and not much
 else.  You insert tuple-like objects of your choice:
 
+```cxx
     pqxx::stream_to stream{
         tx,
         "score",
@@ -96,6 +99,7 @@ else.  You insert tuple-like objects of your choice:
     for (auto const &entry: scores)
         stream << entry;
     stream.complete();
+```
 
 Each row is processed as you provide it, and not retained in memory after that.
 

--- a/tools/lint
+++ b/tools/lint
@@ -20,7 +20,7 @@ ARGS="${1:-}"
 # any surprises in contributions.
 check_ascii() {
     local exotics=$(
-        find -name \*.cxx -o -name \*.hxx |
+        find . -name \*.cxx -o -name \*.hxx |
 	xargs cat |
         tr -d '\011-\176' |
 	wc -c
@@ -157,6 +157,14 @@ pylint() {
 }
 
 
+markdownlint() {
+    if which mdl >/dev/null
+    then
+        find . -name \*.md -exec mdl -c .markdownlint.yaml '{}' ';'
+    fi
+}
+
+
 main() {
     local full="no"
     for arg in $ARGS
@@ -187,6 +195,7 @@ EOF
     pylint
     check_news_version
     check_compiler_internal_headers
+    markdownlint
     if [ $full == "yes" ]
     then
         cpplint


### PR DESCRIPTION
Use `mdl` (markdownlint) to check Markdown syntax and style.

Fixed most of the warnings, but had to disable or tweak a few rules to allow things I find necessary.