### PR TITLE
Added missing field in README.md tx.query1 example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Here's an example with all the basics to get you going:
             // unless the result contains exactly 1 row.
             auto [top_name, top_salary] = tx.query1<std::string, int>(
                 R"(
-                    SELECT salary
+                    SELECT name, salary
                     FROM employee
                     WHERE salary = max(salary)
                     LIMIT 1


### PR DESCRIPTION
I was interested in trying out some of the code from the README.md file, but noticed a missing field in the `tx.query1` example.  When I attempted to run it I received an error.  I needed to `SELECT` both field names so that they were both available in the result set to be loaded into my c++ variables.  I assume this is just an accidental omission, so here's a pull request adding the other field name.

```
terminate called after throwing an instance of 'pqxx::usage_error'
  what():  Tried to extract 2 field(s) from a row of 1.
```