### PR TITLE
No such thing as single-quoted array/composite elements!

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  - Documentation tweak. (#584)
  - Typo in README.md. (#586)
  - Support `std::optional<std::string_view>` etc. in `stream_to`. (#596)
+ - Remove support for single-quoted array/composite elements.  No such thing!
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -88,8 +88,6 @@ private:
   /// Current parsing position in the input.
   std::string::size_type m_pos = 0u;
 
-  std::string::size_type scan_single_quoted_string() const;
-  std::string parse_single_quoted_string(std::string::size_type end) const;
   std::string::size_type scan_double_quoted_string() const;
   std::string parse_double_quoted_string(std::string::size_type end) const;
   std::string::size_type scan_unquoted_string() const;

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -104,7 +104,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   auto const content{m_input.substr(1, end - m_pos - 2)};
   auto const data{std::data(content)};
   auto const stop{std::size(content)};
-  for (auto here{0}; here < stop; )
+  for (auto here{0u}; here < stop; )
   {
     // Find the end of a contiguous stretch of regular characters.
     auto next{

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -108,10 +108,11 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
     // Find a contiguous stretch of regular characters.
     auto next{
       pqxx::internal::find_char<'\\', '\''>(
-        scan_glyph, m_input.substr(0, end - 1), m_pos + 1)};
+        m_scan, m_input.substr(0, end - 1), m_pos + 1)};
     // Copy those to the output in one go.
     output.append(data + here, data + next);
-    // If we continue after this, skip the backslash or quote.
+    // If we continue after this, then the character we found must have been an
+    // escape character.  In which case, skip it and proceed to the next one.
     here = next + 1;
   }
 // XXX: }

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -99,7 +99,22 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   // closing quotes.  In the worst case, the real number could be half that.
   // Usually it'll be a pretty close estimate.
   output.reserve(end - m_pos - 2);
-  // XXX: find_char<'\\', '\''>().
+// XXX: {
+  auto const data{std::data(m_input)};
+  auto const stop{m_end - 1};
+  auto here{m_pos + 1};
+  while (here < stop)
+  {
+    // Find a contiguous stretch of regular characters.
+    auto next{internal::find_char<'\\', '\''>(scan_glyph, m_input.substr(0, end - 1), m_pos + 1)};
+    // Copy those to the output in one go.
+    output.append(data + here, data + next);
+    // If we continue after this, skip the backslash or quote.
+    here = next + 1;
+  }
+// XXX: }
+
+/*
   for (auto here = m_pos + 1, next = scan_glyph(here, end); here < end - 1;
        here = next, next = scan_glyph(here, end))
   {
@@ -114,6 +129,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
 
     output.append(std::data(m_input) + here, std::data(m_input) + next);
   }
+*/
 
   return output;
 }

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -100,19 +100,21 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   // Usually it'll be a pretty close estimate.
   output.reserve(end - m_pos - 2);
 // XXX: {
-  auto const data{std::data(m_input)};
-  auto const stop{end - 1};
-  auto here{m_pos + 1};
-  while (here < stop)
+  // We're scanning the part between the opening and closing quotes.
+  auto const content{m_input.substr(1, end - m_pos - 2)};
+  auto const data{std::data(content)};
+  auto const stop{std::size(content)};
+  for (auto here{0}; here < stop; )
   {
-    // Find a contiguous stretch of regular characters.
+    // Find the end of a contiguous stretch of regular characters.
     auto next{
-      pqxx::internal::find_char<'\\', '\''>(
-        m_scan, m_input.substr(0, stop), here)};
+      pqxx::internal::find_char<'\\', '\''>(m_scan, content, here)};
     // Copy those to the output in one go.
     output.append(data + here, data + next);
+
     // If we continue after this, then the character we found must have been an
-    // escape character.  In which case, skip it and proceed to the next one.
+    // escape character.  Could be a backslash or a quote (thanks SQL), but
+    // either way, skip it and proceed to the next one.
     here = next + 1;
   }
 // XXX: }

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -104,7 +104,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   auto const content{m_input.substr(1, end - m_pos - 2)};
   auto const data{std::data(content)};
   auto const stop{std::size(content)};
-  for (auto here{0u}; here < stop; )
+  for (std::size_t here{0u}; here < stop; )
   {
     // Find the end of a contiguous stretch of regular characters.
     auto next{

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -101,6 +101,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   output.reserve(end - m_pos - 2);
 // XXX: {
   // We're scanning the part between the opening and closing quotes.
+  //auto const content{m_input.substr(1, end - m_pos - 2)};
   auto const content{m_input.substr(0, end - m_pos - 2)}; // XXX: EXPERIMENTAL
   auto const data{std::data(content)};
   auto const stop{std::size(content)};

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -108,7 +108,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
     // Find a contiguous stretch of regular characters.
     auto next{
       pqxx::internal::find_char<'\\', '\''>(
-        m_scan, m_input.substr(0, end - 1), m_pos + 1)};
+        m_scan, m_input.substr(0, stop), here)};
     // Copy those to the output in one go.
     output.append(data + here, data + next);
     // If we continue after this, then the character we found must have been an

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -102,7 +102,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
 // XXX: {
   // We're scanning the part between the opening and closing quotes.
   //auto const content{m_input.substr(1, end - m_pos - 2)};
-  auto const content{m_input.substr(0, end - m_pos - 2)}; // XXX: EXPERIMENTAL
+  auto const content{m_input.substr(0, end - m_pos)}; // XXX: EXPERIMENTAL
   auto const data{std::data(content)};
   auto const stop{std::size(content)};
   for (std::size_t here{0u}; here < stop; )

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -106,7 +106,9 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   while (here < stop)
   {
     // Find a contiguous stretch of regular characters.
-    auto next{internal::find_char<'\\', '\''>(scan_glyph, m_input.substr(0, end - 1), m_pos + 1)};
+    auto next{
+      pqxx::internal::find_char<'\\', '\''>(
+        scan_glyph, m_input.substr(0, end - 1), m_pos + 1)};
     // Copy those to the output in one go.
     output.append(data + here, data + next);
     // If we continue after this, skip the backslash or quote.

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -101,7 +101,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   output.reserve(end - m_pos - 2);
 // XXX: {
   auto const data{std::data(m_input)};
-  auto const stop{m_end - 1};
+  auto const stop{end - 1};
   auto here{m_pos + 1};
   while (here < stop)
   {

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -101,7 +101,7 @@ array_parser::parse_single_quoted_string(std::string::size_type end) const
   output.reserve(end - m_pos - 2);
 // XXX: {
   // We're scanning the part between the opening and closing quotes.
-  auto const content{m_input.substr(1, end - m_pos - 2)};
+  auto const content{m_input.substr(0, end - m_pos - 2)}; // XXX: EXPERIMENTAL
   auto const data{std::data(content)};
   auto const stop{std::size(content)};
   for (std::size_t here{0u}; here < stop; )

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -537,7 +537,6 @@ PQXX_REGISTER_TEST(test_unquoted_string);
 PQXX_REGISTER_TEST(test_multiple_values);
 PQXX_REGISTER_TEST(test_nested_array);
 PQXX_REGISTER_TEST(test_nested_array_with_multiple_entries);
-PQXX_REGISTER_TEST(test_array_parse);
 PQXX_REGISTER_TEST(test_array_generate);
 PQXX_REGISTER_TEST(test_array_roundtrip);
 } // namespace

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -306,7 +306,7 @@ void test_array_multiple_values()
 }
 
 
-void test_array_nested_array()
+void test_nested_array()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{{item}}");

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -100,66 +100,6 @@ void test_array_null_value()
 }
 
 
-void test_array_single_quoted_string()
-{
-  std::pair<pqxx::array_parser::juncture, std::string> output;
-  pqxx::array_parser parser("{'item'}");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::row_start,
-    "Array did not start with row_start.");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::string_value,
-    "Array did not return string_value.");
-  PQXX_CHECK_EQUAL(output.second, "item", "Unexpected string value.");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::row_end,
-    "Array did not end with row_end.");
-  PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::done,
-    "Array did not conclude with done.");
-  PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
-}
-
-
-void test_array_single_quoted_escaping()
-{
-  std::pair<pqxx::array_parser::juncture, std::string> output;
-  pqxx::array_parser parser("{'don''t\\\\ care'}");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::row_start,
-    "Array did not start with row_start.");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::string_value,
-    "Array did not return string_value.");
-  PQXX_CHECK_EQUAL(output.second, "don't\\ care", "Unexpected string value.");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::row_end,
-    "Array did not end with row_end.");
-  PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
-
-  output = parser.get_next();
-  PQXX_CHECK_EQUAL(
-    output.first, pqxx::array_parser::juncture::done,
-    "Array did not conclude with done.");
-  PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
-}
-
-
 void test_array_double_quoted_string()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
@@ -528,8 +468,6 @@ void test_array_roundtrip()
 
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);
-PQXX_REGISTER_TEST(test_array_single_quoted_string);
-PQXX_REGISTER_TEST(test_array_single_quoted_escaping);
 PQXX_REGISTER_TEST(test_array_double_quoted_string);
 PQXX_REGISTER_TEST(test_array_double_quoted_escaping);
 PQXX_REGISTER_TEST(test_array_double_double_quoted_string);

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -69,7 +69,7 @@ void test_empty_arrays()
 }
 
 
-void test_null_value()
+void test_array_null_value()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser containing_null("{NULL}");
@@ -100,7 +100,7 @@ void test_null_value()
 }
 
 
-void test_single_quoted_string()
+void test_array_single_quoted_string()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{'item'}");
@@ -130,7 +130,7 @@ void test_single_quoted_string()
 }
 
 
-void test_single_quoted_escaping()
+void test_array_single_quoted_escaping()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{'don''t\\\\ care'}");
@@ -160,7 +160,7 @@ void test_single_quoted_escaping()
 }
 
 
-void test_double_quoted_string()
+void test_array_double_quoted_string()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{\"item\"}");
@@ -190,7 +190,7 @@ void test_double_quoted_string()
 }
 
 
-void test_double_quoted_escaping()
+void test_array_double_quoted_escaping()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser(R"--({"don''t\\ care"})--");
@@ -221,7 +221,7 @@ void test_double_quoted_escaping()
 
 
 // A pair of double quotes in a double-quoted string is an escaped quote.
-void test_double_double_quoted_string()
+void test_array_double_double_quoted_string()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser{R"--({"3"" steel"})--"};
@@ -240,7 +240,7 @@ void test_double_double_quoted_string()
 }
 
 
-void test_unquoted_string()
+void test_array_unquoted_string()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{item}");
@@ -270,7 +270,7 @@ void test_unquoted_string()
 }
 
 
-void test_multiple_values()
+void test_array_multiple_values()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{1,2}");
@@ -306,7 +306,7 @@ void test_multiple_values()
 }
 
 
-void test_nested_array()
+void test_array_nested_array()
 {
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{{item}}");
@@ -527,14 +527,14 @@ void test_array_roundtrip()
 
 
 PQXX_REGISTER_TEST(test_empty_arrays);
-PQXX_REGISTER_TEST(test_null_value);
-PQXX_REGISTER_TEST(test_single_quoted_string);
-PQXX_REGISTER_TEST(test_single_quoted_escaping);
-PQXX_REGISTER_TEST(test_double_quoted_string);
-PQXX_REGISTER_TEST(test_double_quoted_escaping);
-PQXX_REGISTER_TEST(test_double_double_quoted_string);
-PQXX_REGISTER_TEST(test_unquoted_string);
-PQXX_REGISTER_TEST(test_multiple_values);
+PQXX_REGISTER_TEST(test_array_null_value);
+PQXX_REGISTER_TEST(test_array_single_quoted_string);
+PQXX_REGISTER_TEST(test_array_single_quoted_escaping);
+PQXX_REGISTER_TEST(test_array_double_quoted_string);
+PQXX_REGISTER_TEST(test_array_double_quoted_escaping);
+PQXX_REGISTER_TEST(test_array_double_double_quoted_string);
+PQXX_REGISTER_TEST(test_array_unquoted_string);
+PQXX_REGISTER_TEST(test_array_multiple_values);
 PQXX_REGISTER_TEST(test_nested_array);
 PQXX_REGISTER_TEST(test_nested_array_with_multiple_entries);
 PQXX_REGISTER_TEST(test_array_generate);

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -417,22 +417,6 @@ void test_nested_array_with_multiple_entries()
 }
 
 
-void test_array_parse()
-{
-  test_empty_arrays();
-  test_null_value();
-  test_single_quoted_string();
-  test_single_quoted_escaping();
-  test_double_quoted_string();
-  test_double_quoted_escaping();
-  test_double_double_quoted_string();
-  test_unquoted_string();
-  test_multiple_values();
-  test_nested_array();
-  test_nested_array_with_multiple_entries();
-}
-
-
 void test_generate_empty_array()
 {
   PQXX_CHECK_EQUAL(
@@ -542,6 +526,17 @@ void test_array_roundtrip()
 }
 
 
+PQXX_REGISTER_TEST(test_empty_arrays);
+PQXX_REGISTER_TEST(test_null_value);
+PQXX_REGISTER_TEST(test_single_quoted_string);
+PQXX_REGISTER_TEST(test_single_quoted_escaping);
+PQXX_REGISTER_TEST(test_double_quoted_string);
+PQXX_REGISTER_TEST(test_double_quoted_escaping);
+PQXX_REGISTER_TEST(test_double_double_quoted_string);
+PQXX_REGISTER_TEST(test_unquoted_string);
+PQXX_REGISTER_TEST(test_multiple_values);
+PQXX_REGISTER_TEST(test_nested_array);
+PQXX_REGISTER_TEST(test_nested_array_with_multiple_entries);
 PQXX_REGISTER_TEST(test_array_parse);
 PQXX_REGISTER_TEST(test_array_generate);
 PQXX_REGISTER_TEST(test_array_roundtrip);


### PR DESCRIPTION
This started out as a completely different project.  But along the way, I discovered that elements of arrays or of composite values are _never single-quoted._  If we see an element that's surrounded by single quotes, those quotes are part of the string itself.