### PR TITLE
Make `stream_to` accept `optional<string_view>`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:stable
+      - image: debian:testing
     environment:
       - PGHOST: "/tmp"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ jobs:
           command: apt update
       - run:
           name: Install
-          command: apt upgrade -y && apt install -y lsb-release python3 cmake postgresql libpq-dev postgresql-server-dev-all build-essential autoconf dh-autoreconf autoconf-archive automake cppcheck
+          command: apt install -y lsb-release python3 cmake postgresql libpq-dev postgresql-server-dev-all build-essential autoconf dh-autoreconf autoconf-archive automake cppcheck clang
       - run:
           name: Identify
-          command: lsb_release -a && c++ --version
+          command: lsb_release -a && c++ --version && clang++ --version
       - run:
           name: Prepare postgres
           command: |
@@ -43,7 +43,8 @@ jobs:
                   --enable-maintainer-mode \
                   --enable-audit \
                   --enable-shared --disable-static \
-                  CXXFLAGS=-O3
+                  CXXFLAGS=-O3 \
+                  CXX=clang++
       - store_artifacts:
           path: config.log
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:testing
-#      - image: postgres:latest
+      - image: debian:stable
     environment:
       - PGHOST: "/tmp"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:testing
+      - image: debian:unstable
     environment:
       - PGHOST: "/tmp"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
                   --enable-maintainer-mode \
                   --enable-audit \
                   --enable-shared --disable-static \
-                  CXXFLAGS=-O3 \
+                  CXXFLAGS='-O3 -std=c++17' \
                   CXX=clang++
       - store_artifacts:
           path: config.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: apt update
       - run:
           name: Install
-          command: apt install -y lsb-release python3 cmake postgresql libpq-dev postgresql-server-dev-all build-essential autoconf dh-autoreconf autoconf-archive automake cppcheck
+          command: apt upgrade -y && apt install -y lsb-release python3 cmake postgresql libpq-dev postgresql-server-dev-all build-essential autoconf dh-autoreconf autoconf-archive automake cppcheck
       - run:
           name: Identify
           command: lsb_release -a && c++ --version
@@ -34,7 +34,7 @@ jobs:
           command: createdb root
       - run:
           name: Autogen
-          command: NOCONFIGURE=1 ./autogen.sh
+          command: ./autogen.sh
       - run:
           name: Configure
           command: |

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -123,7 +123,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub install-sh ltmain.sh missing mkinstalldirs
+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -349,7 +349,6 @@ private:
         // Shrink to fit.  Keep the tab though.
         m_buffer.resize(static_cast<std::size_t>(end - data));
       }
-      // TODO: Also support std::optional<std::string_view> etc. (#596)
       else if constexpr (
         std::is_same_v<Field, std::string> or
         std::is_same_v<Field, std::string_view> or
@@ -359,6 +358,17 @@ private:
         m_field_buf.resize(budget);
         escape_field_to_buffer(f);
       }
+      else if constexpr (
+        std::is_same_v<Field, std::optional<std::string>> or
+        std::is_same_v<Field, std::optional<std::string_view>> or
+        std::is_same_v<Field, std::optional<zview>>)
+      {
+        // This is effectively an optional string.  It's not null (we checked
+        // for that above), so... Treat like a string.
+        m_field_buf.resize(budget);
+        escape_field_to_buffer(f.value());
+      }
+      // TODO: Support smart-pointer-to-string as well.  Many types!
       else
       {
         // This field needs to be converted to a string, and after that,

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -368,6 +368,7 @@ private:
         m_field_buf.resize(budget);
         escape_field_to_buffer(f.value());
       }
+      // TODO: Support deleter template argument on unique_ptr.
       else if constexpr (
         std::is_same_v<Field, std::unique_ptr<std::string>> or
         std::is_same_v<Field, std::unique_ptr<std::string_view>> or

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -363,12 +363,25 @@ private:
         std::is_same_v<Field, std::optional<std::string_view>> or
         std::is_same_v<Field, std::optional<zview>>)
       {
-        // This is effectively an optional string.  It's not null (we checked
-        // for that above), so... Treat like a string.
+        // Optional string.  It's not null (we checked for that above), so...
+        // Treat like a string.
         m_field_buf.resize(budget);
         escape_field_to_buffer(f.value());
       }
-      // TODO: Support smart-pointer-to-string as well.  Many types!
+      else if constexpr (
+        std::is_same_v<Field, std::unique_ptr<std::string>> or
+        std::is_same_v<Field, std::unique_ptr<std::string_view>> or
+        std::is_same_v<Field, std::unique_ptr<zview>> or
+        std::is_same_v<Field, std::shared_ptr<std::string>> or
+        std::is_same_v<Field, std::shared_ptr<std::string_view>> or
+        std::is_same_v<Field, std::shared_ptr<zview>>)
+      {
+        // TODO: Can we generalise this elegantly without Concepts?
+        // Effectively also an optional string.  It's not null (we checked
+        // for that above).
+        m_field_buf.resize(budget);
+        escape_field_to_buffer(*f);
+      }
       else
       {
         // This field needs to be converted to a string, and after that,


### PR DESCRIPTION
Fixes #596.

Supports `std::optional`, `std::shared_ptr`, and `std::unique_ptr` of `std::string`, `std::string_view`, and `pqxx::zview`.  It's not the prettiest code, and some day I hope to generalise this stuff using C++20's Concepts.