### PR TITLE
Test `stream_from` scanning better.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: su postgres -c "createuser -w -d root"
       - run:
           name: Set up database
-          command: createdb --encoding=UNICODE root
+          command: createdb --template=template0 --encoding=UNICODE root
       - run:
           name: Autogen
           command: ./autogen.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: su postgres -c "createuser -w -d root"
       - run:
           name: Set up database
-          command: createdb root
+          command: createdb --encoding=UNICODE root
       - run:
           name: Autogen
           command: ./autogen.sh


### PR DESCRIPTION
I was too ambitious in a previous attempt.  I want to replace some text
scanning with a "find single-byte character" function specialised to the
applicable encoding.  To begin with, I want to do this in `stream_from`.
I then hope to be able to inline the scanning of character boundaries in
that function; and I hope to use "monobyte" scanning for UTF-8, since it
will never have a byte inside a multibyte character that looks as if it
were an ASCII character.  Those changes should make `stream_from` tons
faster, especially for monobyte encodings and "ASCII-safe" encodings
like UTF-8.

But that's a lot of work, with lots of opportunities to mess up.  So, as
a first step, I'm testing the glyph scanning in `stream_from` more
thoroughly.  This'll give me more confidence as I refactor the code.