### PR TITLE
Bump minimum libpq/postgres to version 10.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 7.8.0
+ - Bumping requirements versions: need postgres 10.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - At last, streaming throughput is faster (on my system) than a regular query.
  - Ran `autoupdate` (because the autotools told me to).

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -34,10 +34,6 @@ check_function_exists("poll" PQXX_HAVE_POLL)
 
 set(CMAKE_REQUIRED_LIBRARIES pq)
 check_symbol_exists(
-	PQencryptPasswordConn
-	"${PostgreSQL_INCLUDE_DIR}/libpq-fe.h"
-	PQXX_HAVE_PQENCRYPTPASSWORDCONN)
-check_symbol_exists(
 	PQenterPipelineMode
 	"${PostgreSQL_INCLUDE_DIR}/libpq-fe.h"
 	PQXX_HAVE_PQ_PIPELINE)

--- a/configitems
+++ b/configitems
@@ -15,7 +15,6 @@ PQXX_HAVE_LIKELY	public	compiler
 PQXX_HAVE_MULTIDIMENSIONAL_SUBSCRIPT	public	compiler
 PQXX_HAVE_PATH	public	compiler
 PQXX_HAVE_POLL       internal        compiler
-PQXX_HAVE_PQENCRYPTPASSWORDCONN	internal	libpq
 PQXX_HAVE_PQ_PIPELINE	internal	libpq
 PQXX_HAVE_SLEEP_FOR	internal	compiler
 PQXX_HAVE_SPAN	public	compiler

--- a/configure
+++ b/configure
@@ -18523,39 +18523,6 @@ fi
 
 
 
-# PQencryptPasswordConn was added in postgres 10.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for PQencryptPasswordConn" >&5
-printf %s "checking for PQencryptPasswordConn... " >&6; }
-have_pqencryptpasswordconn=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include<libpq-fe.h>
-int
-main (void)
-{
-
-			extern PGconn *conn;
-			PQencryptPasswordConn(
-				conn, "pwd", "user", "scram-sha-256")
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"
-then :
-
-printf "%s\n" "#define PQXX_HAVE_PQENCRYPTPASSWORDCONN 1" >>confdefs.h
-
-else $as_nop
-  have_pqencryptpasswordconn=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_pqencryptpasswordconn" >&5
-printf "%s\n" "$have_pqencryptpasswordconn" >&6; }
-
-
 # "Pipeline mode" was introduced in libpq 14.
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libpq pipeline mode" >&5
 printf %s "checking for libpq pipeline mode... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -619,26 +619,6 @@ occurring in the file.
 	${with_postgres_libpath})
 
 
-# PQencryptPasswordConn was added in postgres 10.
-AC_MSG_CHECKING([for PQencryptPasswordConn])
-have_pqencryptpasswordconn=yes
-AC_COMPILE_IFELSE(
-	[AC_LANG_PROGRAM(
-		[#include<libpq-fe.h>],
-		[
-			extern PGconn *conn;
-			PQencryptPasswordConn(
-				conn, "pwd", "user", "scram-sha-256")
-		]
-	)],
-	AC_DEFINE(
-		[PQXX_HAVE_PQENCRYPTPASSWORDCONN],
-		1,
-		[Define if libpq has PQencryptPasswordConn (since pg 10).]),
-	[have_pqencryptpasswordconn=no])
-AC_MSG_RESULT($have_pqencryptpasswordconn)
-
-
 # "Pipeline mode" was introduced in libpq 14.
 AC_MSG_CHECKING([for libpq pipeline mode])
 have_pq_pipeline=yes

--- a/include/pqxx/config.h.in
+++ b/include/pqxx/config.h.in
@@ -90,9 +90,6 @@
 /* Define if poll() is available. */
 #undef PQXX_HAVE_POLL
 
-/* Define if libpq has PQencryptPasswordConn (since pg 10). */
-#undef PQXX_HAVE_PQENCRYPTPASSWORDCONN
-
 /* Define if libpq has pipeline mode (since pg 14). */
 #undef PQXX_HAVE_PQ_PIPELINE
 

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -3,7 +3,7 @@
 
 #  include <cassert>
 
-#include "pqxx/internal/encodings.hxx"
+#  include "pqxx/internal/encodings.hxx"
 #  include "pqxx/strconv.hxx"
 
 namespace pqxx::internal

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -295,28 +295,29 @@ template<> struct glyph_scanner<encoding_group::MONOBYTE>
 // https://en.wikipedia.org/wiki/Big5#Organization
 template<> struct glyph_scanner<encoding_group::BIG5>
 {
-  static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (not between_inc(byte1, 0x81, 0xfe) or (start + 2 > buffer_len))
-    PQXX_UNLIKELY
-  throw_for_encoding_error("BIG5", buffer, start, 1);
+    if (not between_inc(byte1, 0x81, 0xfe) or (start + 2 > buffer_len))
+      PQXX_UNLIKELY
+    throw_for_encoding_error("BIG5", buffer, start, 1);
 
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (
-    not between_inc(byte2, 0x40, 0x7e) and not between_inc(byte2, 0xa1, 0xfe))
-    PQXX_UNLIKELY
-  throw_for_encoding_error("BIG5", buffer, start, 2);
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (
+      not between_inc(byte2, 0x40, 0x7e) and
+      not between_inc(byte2, 0xa1, 0xfe))
+      PQXX_UNLIKELY
+    throw_for_encoding_error("BIG5", buffer, start, 2);
 
-  return start + 2;
-}
+    return start + 2;
+  }
 };
 
 
@@ -334,202 +335,202 @@ depending on the specific extension:
 // https://en.wikipedia.org/wiki/GB_2312#EUC-CN
 template<> struct glyph_scanner<encoding_group::EUC_CN>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (not between_inc(byte1, 0xa1, 0xf7) or start + 2 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_CN", buffer, start, 1);
+    if (not between_inc(byte1, 0xa1, 0xf7) or start + 2 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("EUC_CN", buffer, start, 1);
 
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (not between_inc(byte2, 0xa1, 0xfe))
-    PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_CN", buffer, start, 2);
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (not between_inc(byte2, 0xa1, 0xfe))
+      PQXX_UNLIKELY
+    throw_for_encoding_error("EUC_CN", buffer, start, 2);
 
-  return start + 2;
-}
+    return start + 2;
+  }
 };
 
 
 template<> struct glyph_scanner<encoding_group::EUC_JP>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  return next_seq_for_euc_jplike(buffer, buffer_len, start, "EUC_JP");
-}
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    return next_seq_for_euc_jplike(buffer, buffer_len, start, "EUC_JP");
+  }
 };
 
 
 template<> struct glyph_scanner<encoding_group::EUC_JIS_2004>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  return next_seq_for_euc_jplike(buffer, buffer_len, start, "EUC_JIS_2004");
-}
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    return next_seq_for_euc_jplike(buffer, buffer_len, start, "EUC_JIS_2004");
+  }
 };
 
 
 // https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR
 template<> struct glyph_scanner<encoding_group::EUC_KR>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (not between_inc(byte1, 0xa1, 0xfe) or start + 2 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_KR", buffer, start, 1);
+    if (not between_inc(byte1, 0xa1, 0xfe) or start + 2 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("EUC_KR", buffer, start, 1);
 
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (not between_inc(byte2, 0xa1, 0xfe))
-    PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_KR", buffer, start, 1);
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (not between_inc(byte2, 0xa1, 0xfe))
+      PQXX_UNLIKELY
+    throw_for_encoding_error("EUC_KR", buffer, start, 1);
 
-  return start + 2;
-}
+    return start + 2;
+  }
 };
 
 
 // https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-TW
 template<> struct glyph_scanner<encoding_group::EUC_TW>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    PQXX_UNLIKELY
-  return std::string::npos;
-
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
-
-  if (start + 2 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_KR", buffer, start, 1);
-
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (between_inc(byte1, 0xa1, 0xfe))
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
   {
-    if (not between_inc(byte2, 0xa1, 0xfe))
+    if (start >= buffer_len)
       PQXX_UNLIKELY
-    throw_for_encoding_error("EUC_KR", buffer, start, 2);
+    return std::string::npos;
 
-    return start + 2;
-  }
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (byte1 != 0x8e or start + 4 > buffer_len)
+    if (start + 2 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("EUC_KR", buffer, start, 1);
+
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (between_inc(byte1, 0xa1, 0xfe))
+    {
+      if (not between_inc(byte2, 0xa1, 0xfe))
+        PQXX_UNLIKELY
+      throw_for_encoding_error("EUC_KR", buffer, start, 2);
+
+      return start + 2;
+    }
+
+    if (byte1 != 0x8e or start + 4 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("EUC_KR", buffer, start, 1);
+
+    if (
+      between_inc(byte2, 0xa1, 0xb0) and
+      between_inc(get_byte(buffer, start + 2), 0xa1, 0xfe) and
+      between_inc(get_byte(buffer, start + 3), 0xa1, 0xfe))
+      return start + 4;
+
     PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_KR", buffer, start, 1);
-
-  if (
-    between_inc(byte2, 0xa1, 0xb0) and
-    between_inc(get_byte(buffer, start + 2), 0xa1, 0xfe) and
-    between_inc(get_byte(buffer, start + 3), 0xa1, 0xfe))
-    return start + 4;
-
-  PQXX_UNLIKELY
-  throw_for_encoding_error("EUC_KR", buffer, start, 4);
-}
+    throw_for_encoding_error("EUC_KR", buffer, start, 4);
+  }
 };
 
 
 // https://en.wikipedia.org/wiki/GB_18030#Mapping
 template<> struct glyph_scanner<encoding_group::GB18030>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
-  if (byte1 == 0x80)
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
+    if (byte1 == 0x80)
+      throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
+
+    if (start + 2 > buffer_len)
+      PQXX_UNLIKELY
     throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
 
-  if (start + 2 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (between_inc(byte2, 0x40, 0xfe))
+    {
+      if (byte2 == 0x7f)
+        PQXX_UNLIKELY
+      throw_for_encoding_error("GB18030", buffer, start, 2);
 
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (between_inc(byte2, 0x40, 0xfe))
-  {
-    if (byte2 == 0x7f)
+      return start + 2;
+    }
+
+    if (start + 4 > buffer_len)
       PQXX_UNLIKELY
-    throw_for_encoding_error("GB18030", buffer, start, 2);
+    throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
 
-    return start + 2;
-  }
+    if (
+      between_inc(byte2, 0x30, 0x39) and
+      between_inc(get_byte(buffer, start + 2), 0x81, 0xfe) and
+      between_inc(get_byte(buffer, start + 3), 0x30, 0x39))
+      return start + 4;
 
-  if (start + 4 > buffer_len)
     PQXX_UNLIKELY
-  throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
-
-  if (
-    between_inc(byte2, 0x30, 0x39) and
-    between_inc(get_byte(buffer, start + 2), 0x81, 0xfe) and
-    between_inc(get_byte(buffer, start + 3), 0x30, 0x39))
-    return start + 4;
-
-  PQXX_UNLIKELY
-  throw_for_encoding_error("GB18030", buffer, start, 4);
-}
+    throw_for_encoding_error("GB18030", buffer, start, 4);
+  }
 };
 
 
 // https://en.wikipedia.org/wiki/GBK_(character_encoding)#Encoding
 template<> struct glyph_scanner<encoding_group::GBK>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (start + 2 > buffer_len)
+    if (start + 2 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("GBK", buffer, start, 1);
+
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (
+      (between_inc(byte1, 0xa1, 0xa9) and between_inc(byte2, 0xa1, 0xfe)) or
+      (between_inc(byte1, 0xb0, 0xf7) and between_inc(byte2, 0xa1, 0xfe)) or
+      (between_inc(byte1, 0x81, 0xa0) and between_inc(byte2, 0x40, 0xfe) and
+       byte2 != 0x7f) or
+      (between_inc(byte1, 0xaa, 0xfe) and between_inc(byte2, 0x40, 0xa0) and
+       byte2 != 0x7f) or
+      (between_inc(byte1, 0xa8, 0xa9) and between_inc(byte2, 0x40, 0xa0) and
+       byte2 != 0x7f) or
+      (between_inc(byte1, 0xaa, 0xaf) and between_inc(byte2, 0xa1, 0xfe)) or
+      (between_inc(byte1, 0xf8, 0xfe) and between_inc(byte2, 0xa1, 0xfe)) or
+      (between_inc(byte1, 0xa1, 0xa7) and between_inc(byte2, 0x40, 0xa0) and
+       byte2 != 0x7f))
+      return start + 2;
+
     PQXX_UNLIKELY
-  throw_for_encoding_error("GBK", buffer, start, 1);
-
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (
-    (between_inc(byte1, 0xa1, 0xa9) and between_inc(byte2, 0xa1, 0xfe)) or
-    (between_inc(byte1, 0xb0, 0xf7) and between_inc(byte2, 0xa1, 0xfe)) or
-    (between_inc(byte1, 0x81, 0xa0) and between_inc(byte2, 0x40, 0xfe) and
-     byte2 != 0x7f) or
-    (between_inc(byte1, 0xaa, 0xfe) and between_inc(byte2, 0x40, 0xa0) and
-     byte2 != 0x7f) or
-    (between_inc(byte1, 0xa8, 0xa9) and between_inc(byte2, 0x40, 0xa0) and
-     byte2 != 0x7f) or
-    (between_inc(byte1, 0xaa, 0xaf) and between_inc(byte2, 0xa1, 0xfe)) or
-    (between_inc(byte1, 0xf8, 0xfe) and between_inc(byte2, 0xa1, 0xfe)) or
-    (between_inc(byte1, 0xa1, 0xa7) and between_inc(byte2, 0x40, 0xa0) and
-     byte2 != 0x7f))
-    return start + 2;
-
-  PQXX_UNLIKELY
-  throw_for_encoding_error("GBK", buffer, start, 2);
-}
+    throw_for_encoding_error("GBK", buffer, start, 2);
+  }
 };
 
 
@@ -544,31 +545,31 @@ CJKV Information Processing by Ken Lunde, pg. 269:
 */
 template<> struct glyph_scanner<encoding_group::JOHAB>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (start + 2 > buffer_len)
+    if (start + 2 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("JOHAB", buffer, start, 1);
+
+    auto const byte2{get_byte(buffer, start)};
+    if (
+      (between_inc(byte1, 0x84, 0xd3) and
+       (between_inc(byte2, 0x41, 0x7e) or between_inc(byte2, 0x81, 0xfe))) or
+      ((between_inc(byte1, 0xd8, 0xde) or between_inc(byte1, 0xe0, 0xf9)) and
+       (between_inc(byte2, 0x31, 0x7e) or between_inc(byte2, 0x91, 0xfe))))
+      return start + 2;
+
     PQXX_UNLIKELY
-  throw_for_encoding_error("JOHAB", buffer, start, 1);
-
-  auto const byte2{get_byte(buffer, start)};
-  if (
-    (between_inc(byte1, 0x84, 0xd3) and
-     (between_inc(byte2, 0x41, 0x7e) or between_inc(byte2, 0x81, 0xfe))) or
-    ((between_inc(byte1, 0xd8, 0xde) or between_inc(byte1, 0xe0, 0xf9)) and
-     (between_inc(byte2, 0x31, 0x7e) or between_inc(byte2, 0x91, 0xfe))))
-    return start + 2;
-
-  PQXX_UNLIKELY
-  throw_for_encoding_error("JOHAB", buffer, start, 2);
-}
+    throw_for_encoding_error("JOHAB", buffer, start, 2);
+  }
 };
 
 
@@ -581,174 +582,174 @@ using PostgreSQL 9.2.23.  Use this at your own risk.
 */
 template<> struct glyph_scanner<encoding_group::MULE_INTERNAL>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    if (start >= buffer_len)
+      return std::string::npos;
 
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (start + 2 > buffer_len)
+    if (start + 2 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("MULE_INTERNAL", buffer, start, 1);
+
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (between_inc(byte1, 0x81, 0x8d) and byte2 >= 0xa0)
+      return start + 2;
+
+    if (start + 3 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("MULE_INTERNAL", buffer, start, 2);
+
+    if (
+      ((byte1 == 0x9a and between_inc(byte2, 0xa0, 0xdf)) or
+       (byte1 == 0x9b and between_inc(byte2, 0xe0, 0xef)) or
+       (between_inc(byte1, 0x90, 0x99) and byte2 >= 0xa0)) and
+      (byte2 >= 0xa0))
+      return start + 3;
+
+    if (start + 4 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("MULE_INTERNAL", buffer, start, 3);
+
+    if (
+      ((byte1 == 0x9c and between_inc(byte2, 0xf0, 0xf4)) or
+       (byte1 == 0x9d and between_inc(byte2, 0xf5, 0xfe))) and
+      get_byte(buffer, start + 2) >= 0xa0 and
+      get_byte(buffer, start + 4) >= 0xa0)
+      return start + 4;
+
     PQXX_UNLIKELY
-  throw_for_encoding_error("MULE_INTERNAL", buffer, start, 1);
-
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (between_inc(byte1, 0x81, 0x8d) and byte2 >= 0xa0)
-    return start + 2;
-
-  if (start + 3 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("MULE_INTERNAL", buffer, start, 2);
-
-  if (
-    ((byte1 == 0x9a and between_inc(byte2, 0xa0, 0xdf)) or
-     (byte1 == 0x9b and between_inc(byte2, 0xe0, 0xef)) or
-     (between_inc(byte1, 0x90, 0x99) and byte2 >= 0xa0)) and
-    (byte2 >= 0xa0))
-    return start + 3;
-
-  if (start + 4 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("MULE_INTERNAL", buffer, start, 3);
-
-  if (
-    ((byte1 == 0x9c and between_inc(byte2, 0xf0, 0xf4)) or
-     (byte1 == 0x9d and between_inc(byte2, 0xf5, 0xfe))) and
-    get_byte(buffer, start + 2) >= 0xa0 and
-    get_byte(buffer, start + 4) >= 0xa0)
-    return start + 4;
-
-  PQXX_UNLIKELY
-  throw_for_encoding_error("MULE_INTERNAL", buffer, start, 4);
-}
+    throw_for_encoding_error("MULE_INTERNAL", buffer, start, 4);
+  }
 };
 
 
 template<> struct glyph_scanner<encoding_group::SJIS>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  return next_seq_for_sjislike(buffer, buffer_len, start, "SJIS");
-}
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    return next_seq_for_sjislike(buffer, buffer_len, start, "SJIS");
+  }
 };
 
 
 template<> struct glyph_scanner<encoding_group::SHIFT_JIS_2004>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  return next_seq_for_sjislike(buffer, buffer_len, start, "SHIFT_JIS_2004");
-}
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  {
+    return next_seq_for_sjislike(buffer, buffer_len, start, "SHIFT_JIS_2004");
+  }
 };
 
 
 // https://en.wikipedia.org/wiki/Unified_Hangul_Code
 template<> struct glyph_scanner<encoding_group::UHC>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
-
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
-
-  if (start + 2 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("UHC", buffer, start, buffer_len - start);
-
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (between_inc(byte1, 0x80, 0xc6))
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
   {
-    if (
-      between_inc(byte2, 0x41, 0x5a) or between_inc(byte2, 0x61, 0x7a) or
-      between_inc(byte2, 0x80, 0xfe))
-      return start + 2;
+    if (start >= buffer_len)
+      return std::string::npos;
 
-    PQXX_UNLIKELY
-    throw_for_encoding_error("UHC", buffer, start, 2);
-  }
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
 
-  if (between_inc(byte1, 0xa1, 0xfe))
-  {
-    if (not between_inc(byte2, 0xa1, 0xfe))
+    if (start + 2 > buffer_len)
       PQXX_UNLIKELY
-    throw_for_encoding_error("UHC", buffer, start, 2);
+    throw_for_encoding_error("UHC", buffer, start, buffer_len - start);
 
-    return start + 2;
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (between_inc(byte1, 0x80, 0xc6))
+    {
+      if (
+        between_inc(byte2, 0x41, 0x5a) or between_inc(byte2, 0x61, 0x7a) or
+        between_inc(byte2, 0x80, 0xfe))
+        return start + 2;
+
+      PQXX_UNLIKELY
+      throw_for_encoding_error("UHC", buffer, start, 2);
+    }
+
+    if (between_inc(byte1, 0xa1, 0xfe))
+    {
+      if (not between_inc(byte2, 0xa1, 0xfe))
+        PQXX_UNLIKELY
+      throw_for_encoding_error("UHC", buffer, start, 2);
+
+      return start + 2;
+    }
+
+    throw_for_encoding_error("UHC", buffer, start, 1);
   }
-
-  throw_for_encoding_error("UHC", buffer, start, 1);
-}
 };
 
 
 // https://en.wikipedia.org/wiki/UTF-8#Description
 template<> struct glyph_scanner<encoding_group::UTF8>
 {
-static PQXX_PURE std::size_t call(
-  char const buffer[], std::size_t buffer_len, std::size_t start)
-{
-  if (start >= buffer_len)
-    return std::string::npos;
-
-  auto const byte1{get_byte(buffer, start)};
-  if (byte1 < 0x80)
-    return start + 1;
-
-  if (start + 2 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
-
-  auto const byte2{get_byte(buffer, start + 1)};
-  if (between_inc(byte1, 0xc0, 0xdf))
+  static PQXX_PURE std::size_t
+  call(char const buffer[], std::size_t buffer_len, std::size_t start)
   {
-    if (not between_inc(byte2, 0x80, 0xbf))
+    if (start >= buffer_len)
+      return std::string::npos;
+
+    auto const byte1{get_byte(buffer, start)};
+    if (byte1 < 0x80)
+      return start + 1;
+
+    if (start + 2 > buffer_len)
       PQXX_UNLIKELY
-    throw_for_encoding_error("UTF8", buffer, start, 2);
+    throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
 
-    return start + 2;
+    auto const byte2{get_byte(buffer, start + 1)};
+    if (between_inc(byte1, 0xc0, 0xdf))
+    {
+      if (not between_inc(byte2, 0x80, 0xbf))
+        PQXX_UNLIKELY
+      throw_for_encoding_error("UTF8", buffer, start, 2);
+
+      return start + 2;
+    }
+
+    if (start + 3 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
+
+    auto const byte3{get_byte(buffer, start + 2)};
+    if (between_inc(byte1, 0xe0, 0xef))
+    {
+      if (between_inc(byte2, 0x80, 0xbf) and between_inc(byte3, 0x80, 0xbf))
+        return start + 3;
+
+      PQXX_UNLIKELY
+      throw_for_encoding_error("UTF8", buffer, start, 3);
+    }
+
+    if (start + 4 > buffer_len)
+      PQXX_UNLIKELY
+    throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
+
+    if (between_inc(byte1, 0xf0, 0xf7))
+    {
+      if (
+        between_inc(byte2, 0x80, 0xbf) and between_inc(byte3, 0x80, 0xbf) and
+        between_inc(get_byte(buffer, start + 3), 0x80, 0xbf))
+        return start + 4;
+
+      PQXX_UNLIKELY
+      throw_for_encoding_error("UTF8", buffer, start, 4);
+    }
+
+    PQXX_UNLIKELY
+    throw_for_encoding_error("UTF8", buffer, start, 1);
   }
-
-  if (start + 3 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
-
-  auto const byte3{get_byte(buffer, start + 2)};
-  if (between_inc(byte1, 0xe0, 0xef))
-  {
-    if (between_inc(byte2, 0x80, 0xbf) and between_inc(byte3, 0x80, 0xbf))
-      return start + 3;
-
-    PQXX_UNLIKELY
-    throw_for_encoding_error("UTF8", buffer, start, 3);
-  }
-
-  if (start + 4 > buffer_len)
-    PQXX_UNLIKELY
-  throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
-
-  if (between_inc(byte1, 0xf0, 0xf7))
-  {
-    if (
-      between_inc(byte2, 0x80, 0xbf) and between_inc(byte3, 0x80, 0xbf) and
-      between_inc(get_byte(buffer, start + 3), 0x80, 0xbf))
-      return start + 4;
-
-    PQXX_UNLIKELY
-    throw_for_encoding_error("UTF8", buffer, start, 4);
-  }
-
-  PQXX_UNLIKELY
-  throw_for_encoding_error("UTF8", buffer, start, 1);
-}
 };
 
 
@@ -778,7 +779,8 @@ PQXX_PURE char_finder_func *get_char_finder(encoding_group enc)
     // All these encodings are "ASCII-safe," meaning that if we're looking
     // for a particular ASCII character, we can safely just go through the
     // string byte for byte.  Multibyte characters have the high bit set.
-    PQXX_LIKELY return pqxx::internal::find_ascii_char<encoding_group::MONOBYTE, NEEDLE...>;
+    PQXX_LIKELY return pqxx::internal::find_ascii_char<
+      encoding_group::MONOBYTE, NEEDLE...>;
 
   case encoding_group::BIG5:
     return pqxx::internal::find_ascii_char<encoding_group::BIG5, NEEDLE...>;
@@ -786,20 +788,23 @@ PQXX_PURE char_finder_func *get_char_finder(encoding_group enc)
   case encoding_group::GB18030:
     return pqxx::internal::find_ascii_char<encoding_group::GB18030>;
 
-  case encoding_group::GBK: return pqxx::internal::find_ascii_char<encoding_group::GBK>;
+  case encoding_group::GBK:
+    return pqxx::internal::find_ascii_char<encoding_group::GBK>;
 
-  case encoding_group::JOHAB: return pqxx::internal::find_ascii_char<encoding_group::JOHAB>;
+  case encoding_group::JOHAB:
+    return pqxx::internal::find_ascii_char<encoding_group::JOHAB>;
 
-  case encoding_group::SJIS: return pqxx::internal::find_ascii_char<encoding_group::SJIS>;
+  case encoding_group::SJIS:
+    return pqxx::internal::find_ascii_char<encoding_group::SJIS>;
 
   case encoding_group::SHIFT_JIS_2004:
     return pqxx::internal::find_ascii_char<encoding_group::SHIFT_JIS_2004>;
 
-  case encoding_group::UHC: return pqxx::internal::find_ascii_char<encoding_group::UHC>;
+  case encoding_group::UHC:
+    return pqxx::internal::find_ascii_char<encoding_group::UHC>;
   }
   PQXX_UNLIKELY
-  throw usage_error{
-    concat("Unsupported encoding group code ", enc, ".")};
+  throw usage_error{concat("Unsupported encoding group code ", enc, ".")};
 }
 } // namespace pqxx::internal
 #endif

--- a/requirements.json
+++ b/requirements.json
@@ -1,8 +1,8 @@
 {
     "description": "Minimum versions needed of various things.",
     "c++": "17",
-    "libpq": "9.6",
-    "postgresql": "9.6",
+    "libpq": "10.0",
+    "postgresql": "10.0",
     "gcc": "8",
     "clang": "11",
     "msvc": "2019"

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -719,26 +719,10 @@ pqxx::result pqxx::connection::exec(
 std::string pqxx::connection::encrypt_password(
   char const user[], char const password[], char const *algorithm)
 {
-#if defined(PQXX_HAVE_PQENCRYPTPASSWORDCONN)
-  {
-    auto const buf{PQencryptPasswordConn(m_conn, password, user, algorithm)};
-    std::unique_ptr<char const, std::function<void(char const *)>> ptr{
-      buf, [](char const *x) { PQfreemem(const_cast<char *>(x)); }};
-    return std::string(ptr.get());
-  }
-#else
-  {
-    // No PQencryptPasswordConn.  Fall back on the old PQencryptPassword...
-    // unless the caller selects a different algorithm.
-    if (algorithm != nullptr and std::strcmp(algorithm, "md5") != 0)
-      throw feature_not_supported{
-        "Could not encrypt password: available libpq version does not support "
-        "algorithms other than md5."};
-#  include "pqxx/internal/ignore-deprecated-pre.hxx"
-    return pqxx::encrypt_password(user, password);
-#  include "pqxx/internal/ignore-deprecated-post.hxx"
-  }
-#endif // PQXX_HAVE_PQENCRYPTPASSWORDCONN
+  auto const buf{PQencryptPasswordConn(m_conn, password, user, algorithm)};
+  std::unique_ptr<char const, std::function<void(char const *)>> ptr{
+    buf, [](char const *x) { PQfreemem(const_cast<char *>(x)); }};
+  return std::string(ptr.get());
 }
 
 

--- a/src/encodings.cxx
+++ b/src/encodings.cxx
@@ -38,7 +38,8 @@ pqxx::internal::encoding_group enc_group(std::string_view encoding_name)
   {
     std::string_view const name;
     pqxx::internal::encoding_group const group;
-    constexpr mapping(std::string_view n, pqxx::internal::encoding_group g) : name{n}, group{g}
+    constexpr mapping(std::string_view n, pqxx::internal::encoding_group g) :
+            name{n}, group{g}
     {}
     constexpr bool operator<(mapping const &rhs) const
     {

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -40,15 +40,17 @@ constexpr char escape_char(char special)
 {
   switch (special)
   {
-        case '\b': return 'b';
-        case '\f': return 'f';
-        case '\n': return 'n';
-        case '\r': return 'r';
-        case '\t': return 't';
-        case '\v': return 'v';
-        case '\\': return '\\';
-   }
-   PQXX_UNLIKELY throw pqxx::internal_error{pqxx::internal::concat("Stream escaping unexpectedly stopped at '", static_cast<unsigned>(static_cast<unsigned char>(special)))};
+  case '\b': return 'b';
+  case '\f': return 'f';
+  case '\n': return 'n';
+  case '\r': return 'r';
+  case '\t': return 't';
+  case '\v': return 'v';
+  case '\\': return '\\';
+  }
+  PQXX_UNLIKELY throw pqxx::internal_error{pqxx::internal::concat(
+    "Stream escaping unexpectedly stopped at '",
+    static_cast<unsigned>(static_cast<unsigned char>(special)))};
 }
 } // namespace
 
@@ -102,7 +104,8 @@ pqxx::stream_to &pqxx::stream_to::operator<<(stream_from &tr)
 pqxx::stream_to::stream_to(
   transaction_base &tx, std::string_view path, std::string_view columns) :
         transaction_focus{tx, s_classname, path},
-        m_finder{pqxx::internal::get_char_finder<'\b', '\f', '\n', '\r', '\t', '\v', '\\'>(
+        m_finder{pqxx::internal::get_char_finder<
+          '\b', '\f', '\n', '\r', '\t', '\v', '\\'>(
           pqxx::internal::enc_group(tx.conn().encoding_id()))}
 {
   begin_copy(tx, path, columns);

--- a/test/unit/test_stream_to.cxx
+++ b/test/unit/test_stream_to.cxx
@@ -498,16 +498,9 @@ void test_stream_to_escaping()
 
   // We'll check that streaming these strings to the database and querying them
   // back reproduces them faithfully.
-  std::string_view const inputs[] =
-  {
-    ""sv,
-    "hello"sv,
-    "a\tb"sv,
-    "a\nb"sv,
-    "don't"sv,
-    "\\\\\\''"sv,
-    "\\N"sv,
-    "\\Nfoo"sv,
+  std::string_view const inputs[] = {
+    ""sv,      "hello"sv,    "a\tb"sv, "a\nb"sv,
+    "don't"sv, "\\\\\\''"sv, "\\N"sv,  "\\Nfoo"sv,
   };
 
   // Stream the input strings into the databsae.
@@ -518,12 +511,17 @@ void test_stream_to_escaping()
 
   // Verify.
   auto outputs{tx.exec("SELECT i, t FROM foo ORDER BY i")};
-  PQXX_CHECK_EQUAL(static_cast<std::size_t>(std::size(outputs)), std::size(inputs), "Wrong number of rows came back.");
+  PQXX_CHECK_EQUAL(
+    static_cast<std::size_t>(std::size(outputs)), std::size(inputs),
+    "Wrong number of rows came back.");
   for (std::size_t i{0}; i < std::size(inputs); ++i)
   {
     int idx{static_cast<int>(i)};
-    PQXX_CHECK_EQUAL(outputs[idx][0].as<std::size_t>(), i, "Unexpected index.");
-    PQXX_CHECK_EQUAL(outputs[idx][1].as<std::string_view>(), inputs[i], "String changed in transit.");
+    PQXX_CHECK_EQUAL(
+      outputs[idx][0].as<std::size_t>(), i, "Unexpected index.");
+    PQXX_CHECK_EQUAL(
+      outputs[idx][1].as<std::string_view>(), inputs[i],
+      "String changed in transit.");
   }
 }
 


### PR DESCRIPTION
The PostgreSQL project no longer supports postgres 9, so I'm dropping it off the libpqxx support list as well.

The only consequence code-wise is that libpqxx will now assume that libpq has a `PQencryptPasswordConn()`.

Actually might be nice to have a compile-time check for an acceptable libpq version.  But that's a separate project.