### PR TITLE
Overhaul array parser.  Comma-separated types only.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 7.8.0
+ - Use `array_parser` only on comma-separated types (which is most of them).
  - Bumping requirements versions: need postgres 10.
+ - Fix array parsing bug when parsing semicolon in an unquoted string.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - At last, streaming throughput is faster (on my system) than a regular query.
  - Ran `autoupdate` (because the autotools told me to).

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 7.8.0
- - Use `array_parser` only on comma-separated types (which is most of them).
+ - Use `array_parser` only on comma-separated types, i.e. most of them. (#590)
  - Bumping requirements versions: need postgres 10.
  - Fix array parsing bug when parsing semicolon in an unquoted string.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -41,7 +41,7 @@ namespace pqxx
  * on the fly.  The string must remain in memory until parsing is done.
  *
  * Parse the array by making calls to @ref get_next until it returns a
- * @ref juncture of "done".  The @ref juncture tells you what the parser found
+ * @ref juncture of `done`.  The @ref juncture tells you what the parser found
  * in that step: did the array "nest" to a deeper level, or "un-nest" back up?
  */
 class PQXX_LIBEXPORT array_parser

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -26,7 +26,7 @@
 namespace pqxx
 {
 /// Low-level array parser.
-/** @warning This is not a great API.  Something newer is on the way.
+/** @warning This is not a great API.  Something nicer is on the way.
  *
  * Use this to read an array field retrieved from the database.
  *

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -26,14 +26,19 @@
 namespace pqxx
 {
 /// Low-level array parser.
-/** Use this to read an array field retrieved from the database.
+/** @warning This is not a great API.  Something newer is on the way.
  *
- * This parser will only work reliably if your client encoding is UTF-8, ASCII,
- * or a single-byte encoding which is a superset of ASCII (such as Latin-1).
+ * Use this to read an array field retrieved from the database.
  *
- * Also, the parser only supports array element types which use a comma (',')
- * as the separator between array elements.  All built-in types use comma,
- * except for one which uses semicolon, but some custom types may not work.
+ * @warning This parser will only work reliably if your client encoding is
+ * UTF-8, ASCII, or a "safe ASCII superset" (such as the EUC encodings) where
+ * a byte value in the ASCII range can only occur as an actual ASCII character,
+ * never as one byte in a multi-byte character.
+ *
+ * @warning The parser only supports array element types which use a comma
+ * (`','`) as the separator between array elements.  All built-in SQL types use
+ * comma, except for `box` which uses semicolon.  However some custom types may
+ * not work.
  *
  * The input is a C-style string containing the textual representation of an
  * array, as returned by the database.  The parser reads this representation

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -82,8 +82,7 @@ public:
    * Call this until the @ref array_parser::juncture it returns is
    * @ref juncture::done.
    */
-  std::pair<juncture, std::string> get_next()
-  { return (this->*m_impl)(); }
+  std::pair<juncture, std::string> get_next() { return (this->*m_impl)(); }
 
 private:
   std::string_view m_input;
@@ -100,13 +99,15 @@ private:
   using implementation = std::pair<juncture, std::string> (array_parser::*)();
 
   /// Pick the `implementation` for `enc`.
-  static implementation specialize_for_encoding(pqxx::internal::encoding_group enc);
+  static implementation
+  specialize_for_encoding(pqxx::internal::encoding_group enc);
 
   /// Our implementation of `parse_array_step`, specialised for our encoding.
   implementation m_impl;
 
   /// Perform one step of array parsing.
-  template<pqxx::internal::encoding_group> std::pair<juncture, std::string> parse_array_step();
+  template<pqxx::internal::encoding_group>
+  std::pair<juncture, std::string> parse_array_step();
 
   template<pqxx::internal::encoding_group>
   std::string::size_type scan_double_quoted_string() const;

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -31,10 +31,9 @@ namespace pqxx
  * This parser will only work reliably if your client encoding is UTF-8, ASCII,
  * or a single-byte encoding which is a superset of ASCII (such as Latin-1).
  *
- * Also, the parser only supports array element types which use either a comma
- * or a semicolon ("," or ";") as the separator between array elements.  All
- * built-in types use comma, except for one which uses semicolon, but some
- * custom types may not work.
+ * Also, the parser only supports array element types which use a comma (',')
+ * as the separator between array elements.  All built-in types use comma,
+ * except for one which uses semicolon, but some custom types may not work.
  *
  * The input is a C-style string containing the textual representation of an
  * array, as returned by the database.  The parser reads this representation

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -50,10 +50,11 @@ inline void parse_composite(
 
   here = next;
 
+  // XXX: Reuse parse_composite_field specialisation across calls.
   constexpr auto num_fields{sizeof...(fields)};
   std::size_t index{0};
-  (pqxx::internal::parse_composite_field(
-     index, text, here, fields, scan, num_fields - 1),
+  (pqxx::internal::specialize_parse_composite_field<T>(enc)(
+     index, text, here, fields, num_fields - 1),
    ...);
   if (here != std::size(text))
     throw conversion_error{internal::concat(

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -250,7 +250,7 @@ public:
    * you keep the @ref row of `field` object alive, it will keep the @ref
    * result object alive as well.
    */
-  array_parser as_array() const & noexcept
+  array_parser as_array() const &noexcept
   {
     return array_parser{c_str(), m_home.m_encoding};
   }

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -84,7 +84,8 @@ inline std::string parse_double_quoted_string(
 
   // TODO: Use find_char<...>().
   using scanner = glyph_scanner<ENC>;
-  for (auto here{scanner::call(input, end, pos)}, next{scanner::call(input, end, here)};
+  for (auto here{scanner::call(input, end, pos)},
+       next{scanner::call(input, end, here)};
        here < end - 1; here = next, next = scanner::call(input, end, here))
   {
     // A backslash here is always an escape.  So is a double-quote, since we're
@@ -111,8 +112,8 @@ inline std::string parse_double_quoted_string(
  * a value of a composite type, STOP is a comma or a closing parenthesis.
  */
 template<pqxx::internal::encoding_group ENC, char... STOP>
-inline std::size_t scan_unquoted_string(
-  char const input[], std::size_t size, std::size_t pos)
+inline std::size_t
+scan_unquoted_string(char const input[], std::size_t size, std::size_t pos)
 {
   // TODO: Backslashes don't show up in unquoted strings at all.
   bool at_backslash{false};
@@ -132,8 +133,8 @@ inline std::size_t scan_unquoted_string(
 
 /// Parse an unquoted array entry or cfield of a composite-type field.
 template<pqxx::internal::encoding_group ENC>
-inline std::string parse_unquoted_string(
-  char const input[], std::size_t end, std::size_t pos)
+inline std::string
+parse_unquoted_string(char const input[], std::size_t end, std::size_t pos)
 {
   using scanner = glyph_scanner<ENC>;
   std::string output;
@@ -201,8 +202,8 @@ inline void parse_composite_field(
     break;
 
   case '"': {
-    auto const stop{scan_double_quoted_string<ENC>(
-      std::data(input), std::size(input), pos)};
+    auto const stop{
+      scan_double_quoted_string<ENC>(std::data(input), std::size(input), pos)};
     auto const text{
       parse_double_quoted_string<ENC>(std::data(input), stop, pos)};
     field = from_string<T>(text);
@@ -259,7 +260,9 @@ inline void parse_composite_field(
 
 /// Pointer to an encoding-specific specialisation of parse_composite_field.
 template<typename T>
-using composite_field_parser = void (*)(std::size_t &index, std::string_view input, std::size_t &pos, T &field, std::size_t last_field);
+using composite_field_parser = void (*)(
+  std::size_t &index, std::string_view input, std::size_t &pos, T &field,
+  std::size_t last_field);
 
 
 /// Look up implementation of parse_composite_field for ENC.
@@ -268,21 +271,34 @@ composite_field_parser<T> specialize_parse_composite_field(encoding_group enc)
 {
   switch (enc)
   {
-  case encoding_group::MONOBYTE: return parse_composite_field<encoding_group::MONOBYTE>;
-  case encoding_group::BIG5: return parse_composite_field<encoding_group::BIG5>;
-  case encoding_group::EUC_CN: return parse_composite_field<encoding_group::EUC_CN>;
-  case encoding_group::EUC_JP: return parse_composite_field<encoding_group::EUC_JP>;
-  case encoding_group::EUC_JIS_2004: return parse_composite_field<encoding_group::EUC_JIS_2004>;
-  case encoding_group::EUC_KR: return parse_composite_field<encoding_group::EUC_KR>;
-  case encoding_group::EUC_TW: return parse_composite_field<encoding_group::EUC_TW>;
-  case encoding_group::GB18030: return parse_composite_field<encoding_group::GB18030>;
+  case encoding_group::MONOBYTE:
+    return parse_composite_field<encoding_group::MONOBYTE>;
+  case encoding_group::BIG5:
+    return parse_composite_field<encoding_group::BIG5>;
+  case encoding_group::EUC_CN:
+    return parse_composite_field<encoding_group::EUC_CN>;
+  case encoding_group::EUC_JP:
+    return parse_composite_field<encoding_group::EUC_JP>;
+  case encoding_group::EUC_JIS_2004:
+    return parse_composite_field<encoding_group::EUC_JIS_2004>;
+  case encoding_group::EUC_KR:
+    return parse_composite_field<encoding_group::EUC_KR>;
+  case encoding_group::EUC_TW:
+    return parse_composite_field<encoding_group::EUC_TW>;
+  case encoding_group::GB18030:
+    return parse_composite_field<encoding_group::GB18030>;
   case encoding_group::GBK: return parse_composite_field<encoding_group::GBK>;
-  case encoding_group::JOHAB: return parse_composite_field<encoding_group::JOHAB>;
-  case encoding_group::MULE_INTERNAL: return parse_composite_field<encoding_group::MULE_INTERNAL>;
-  case encoding_group::SJIS: return parse_composite_field<encoding_group::SJIS>;
-  case encoding_group::SHIFT_JIS_2004: return parse_composite_field<encoding_group::SHIFT_JIS_2004>;
+  case encoding_group::JOHAB:
+    return parse_composite_field<encoding_group::JOHAB>;
+  case encoding_group::MULE_INTERNAL:
+    return parse_composite_field<encoding_group::MULE_INTERNAL>;
+  case encoding_group::SJIS:
+    return parse_composite_field<encoding_group::SJIS>;
+  case encoding_group::SHIFT_JIS_2004:
+    return parse_composite_field<encoding_group::SHIFT_JIS_2004>;
   case encoding_group::UHC: return parse_composite_field<encoding_group::UHC>;
-  case encoding_group::UTF8: return parse_composite_field<encoding_group::UTF8>;
+  case encoding_group::UTF8:
+    return parse_composite_field<encoding_group::UTF8>;
   }
   throw internal_error{concat("Unexpected encoding group code: ", enc, ".")};
 }

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -9,6 +9,7 @@
 namespace pqxx::internal
 {
 // XXX: Get rid of this one; use the compile-time-specialised version instead.
+// XXX: Used only in parse_composite_field.
 // Find the end of a double-quoted string.
 /** `input[pos]` must be the opening double quote.
  *
@@ -135,6 +136,7 @@ inline std::size_t s_scan_double_quoted_string(
 
 
 // XXX: Get rid of this one; use the compile-time-specialised version instead.
+// XXX: Used only in parse_composite_field().
 /// Un-quote and un-escape a double-quoted SQL string.
 inline std::string parse_double_quoted_string(
   char const input[], std::size_t end, std::size_t pos,
@@ -199,6 +201,7 @@ inline std::string s_parse_double_quoted_string(
 
 
 // XXX: Get rid of this one; use the compile-time-specialised version instead.
+// XXX: Used only in parse_composite_field().
 /// Find the end of an unquoted string in an array or composite-type value.
 /** Stops when it gets to the end of the input; or when it sees any of the
  * characters in STOP which has not been escaped.
@@ -211,7 +214,6 @@ inline std::size_t scan_unquoted_string(
   char const input[], std::size_t size, std::size_t pos,
   pqxx::internal::glyph_scanner_func *scan)
 {
-  // TODO: Backslashes don't show up in unquoted strings at all.
   bool at_backslash{false};
   auto next{scan(input, size, pos)};
   while ((pos < size) and
@@ -255,6 +257,7 @@ inline std::size_t s_scan_unquoted_string(
 
 
 // XXX: Get rid of this one; use the compile-time-specialised version instead.
+// XXX: Used only in parse_composite_field().
 /// Parse an unquoted array entry or cfield of a composite-type field.
 inline std::string parse_unquoted_string(
   char const input[], std::size_t end, std::size_t pos,
@@ -297,6 +300,7 @@ inline std::string s_parse_unquoted_string(
 }
 
 
+// XXX: Specialise by encoding group.
 /// Parse a field of a composite-type value.
 /** `T` is the C++ type of the field we're parsing, and `index` is its
  * zero-based number.

--- a/include/pqxx/internal/encoding_group.hxx
+++ b/include/pqxx/internal/encoding_group.hxx
@@ -42,7 +42,7 @@ enum class encoding_group
 };
 
 
-// TODO:: Can we just use string_view now?
+// XXX: Get rid of these.  Specialise at higher level.
 /// Function type: "find the end of the current glyph."
 /** This type of function takes a text buffer, and a location in that buffer,
  * and returns the location one byte past the end of the current glyph.

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -760,16 +760,18 @@ template<> struct glyph_scanner<encoding_group::UTF8>
  * specific purpose of looking for a given ASCII character.
  *
  * The "difficult" encoding groups will map to themselves.  But the ones that
- * work like "ASCII supersets" have the wonderful property that even a multibyte
- * character cannot contain a byte that happens to be in the ASCII range.  This
- * holds for the single-byte encodings, for example, but also for UTF-8.
+ * work like "ASCII supersets" have the wonderful property that even a
+ * multibyte character cannot contain a byte that happens to be in the ASCII
+ * range.  This holds for the single-byte encodings, for example, but also for
+ * UTF-8.
  *
  * For those encodings, we can just pretend that we're dealing with a
  * single-byte encoding and scan byte-by-byte until we find a byte with the
  * value we're looking for.  We don't actually need to know where the
  * boundaries between the characters are.
  */
-constexpr inline encoding_group map_ascii_search_group(encoding_group enc) noexcept
+constexpr inline encoding_group
+map_ascii_search_group(encoding_group enc) noexcept
 {
   switch (enc)
   {
@@ -786,8 +788,7 @@ constexpr inline encoding_group map_ascii_search_group(encoding_group enc) noexc
     // string byte for byte.  Multibyte characters have the high bit set.
     return encoding_group::MONOBYTE;
 
-  default:
-    PQXX_UNLIKELY return enc;
+  default: PQXX_UNLIKELY return enc;
   }
 }
 
@@ -800,13 +801,15 @@ constexpr inline encoding_group map_ascii_search_group(encoding_group enc) noexc
  * `haystack` if it found none.
  */
 template<char... NEEDLE>
-PQXX_PURE constexpr inline char_finder_func *get_char_finder(encoding_group enc)
+PQXX_PURE constexpr inline char_finder_func *
+get_char_finder(encoding_group enc)
 {
   auto const as_if{map_ascii_search_group(enc)};
   switch (as_if)
   {
   case encoding_group::MONOBYTE:
-    return pqxx::internal::find_ascii_char<encoding_group::MONOBYTE, NEEDLE...>;
+    return pqxx::internal::find_ascii_char<
+      encoding_group::MONOBYTE, NEEDLE...>;
   case encoding_group::BIG5:
     return pqxx::internal::find_ascii_char<encoding_group::BIG5, NEEDLE...>;
   case encoding_group::GB18030:
@@ -818,12 +821,14 @@ PQXX_PURE constexpr inline char_finder_func *get_char_finder(encoding_group enc)
   case encoding_group::SJIS:
     return pqxx::internal::find_ascii_char<encoding_group::SJIS, NEEDLE...>;
   case encoding_group::SHIFT_JIS_2004:
-    return pqxx::internal::find_ascii_char<encoding_group::SHIFT_JIS_2004, NEEDLE...>;
+    return pqxx::internal::find_ascii_char<
+      encoding_group::SHIFT_JIS_2004, NEEDLE...>;
   case encoding_group::UHC:
     return pqxx::internal::find_ascii_char<encoding_group::UHC, NEEDLE...>;
 
   default:
-    throw pqxx::internal_error{concat("Unexpected encoding group: ", as_if, " (mapped from ", enc, ").")};
+    throw pqxx::internal_error{concat(
+      "Unexpected encoding group: ", as_if, " (mapped from ", enc, ").")};
   }
 }
 } // namespace pqxx::internal

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -40,6 +40,7 @@ PQXX_LIBEXPORT encoding_group enc_group(int /* libpq encoding ID */);
 PQXX_LIBEXPORT glyph_scanner_func *get_glyph_scanner(encoding_group);
 
 
+// XXX: Get rid of thise one.  Use compile-time-specialised version instead.
 /// Find any of the ASCII characters `NEEDLE` in `haystack`.
 /** Scans through `haystack` until it finds a single-byte character that
  * matches any value in `NEEDLE`.
@@ -76,6 +77,7 @@ inline std::size_t find_char(
 }
 
 
+// XXX: Get rid of this one.  Use compile-time-specialised loop instead.
 /// Iterate over the glyphs in a buffer.
 /** Scans the glyphs in the buffer, and for each, passes its begin and its
  * one-past-end pointers to `callback`.
@@ -234,7 +236,7 @@ PQXX_PURE std::size_t next_seq_for_sjislike(
  */
 template<encoding_group> struct glyph_scanner
 {
-  // TODO: Convert to use string_view.
+  // TODO: Convert to use string_view?
   /// Find the next glyph in `buffer` after position `start`.
   PQXX_PURE static std::size_t
   call(char const buffer[], std::size_t buffer_len, std::size_t start);
@@ -753,6 +755,7 @@ template<> struct glyph_scanner<encoding_group::UTF8>
 };
 
 
+// XXX: Extract encoding_group remapper for "search only."
 /// Look up a character search function for an encoding group.
 /** We only define a few individual instantiations of this function, as needed.
  *
@@ -761,7 +764,7 @@ template<> struct glyph_scanner<encoding_group::UTF8>
  * `haystack` if it found none.
  */
 template<char... NEEDLE>
-PQXX_PURE char_finder_func *get_char_finder(encoding_group enc)
+PQXX_PURE inline char_finder_func *get_char_finder(encoding_group enc)
 {
   // Many encodings are "ASCII-safe" in the sense that for a search loop such
   // as this one, we can treat them like any single-byte encoding.  That will

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -450,8 +450,10 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     // The string may leave out either bound to indicate that it's unlimited.
     std::optional<TYPE> lower, upper;
     // We reuse the same field parser we use for composite values and arrays.
-// XXX: Use applicable encoding!
-    auto const field_parser{pqxx::internal::specialize_parse_composite_field<std::optional<TYPE>>(pqxx::internal::encoding_group::UTF8)};
+    // XXX: Use applicable encoding!
+    auto const field_parser{
+      pqxx::internal::specialize_parse_composite_field<std::optional<TYPE>>(
+        pqxx::internal::encoding_group::UTF8)};
     field_parser(index, text, pos, lower, last);
     field_parser(index, text, pos, upper, last);
 

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -440,7 +440,6 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     default: throw pqxx::conversion_error{err_bad_input(text)};
     }
 
-    auto scan{internal::get_glyph_scanner(internal::encoding_group::UTF8)};
     // The field parser uses this to track which field it's parsing, and
     // when not to expect a field separator.
     std::size_t index{0};
@@ -451,8 +450,10 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     // The string may leave out either bound to indicate that it's unlimited.
     std::optional<TYPE> lower, upper;
     // We reuse the same field parser we use for composite values and arrays.
-    internal::parse_composite_field(index, text, pos, lower, scan, last);
-    internal::parse_composite_field(index, text, pos, upper, scan, last);
+// XXX: Use applicable encoding!
+    auto const field_parser{pqxx::internal::specialize_parse_composite_field<std::optional<TYPE>>(pqxx::internal::encoding_group::UTF8)};
+    field_parser(index, text, pos, lower, last);
+    field_parser(index, text, pos, upper, last);
 
     // We need one more character: the closing parenthesis or bracket.
     if (pos != std::size(text))

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -450,7 +450,6 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     // The string may leave out either bound to indicate that it's unlimited.
     std::optional<TYPE> lower, upper;
     // We reuse the same field parser we use for composite values and arrays.
-    // XXX: Use applicable encoding!
     auto const field_parser{
       pqxx::internal::specialize_parse_composite_field<std::optional<TYPE>>(
         pqxx::internal::encoding_group::UTF8)};

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -303,7 +303,8 @@ private:
   static std::string const s_empty_string;
 
   friend class pqxx::field;
-  PQXX_PURE char const *get_value(size_type row, row_size_type col) const noexcept;
+  PQXX_PURE char const *
+  get_value(size_type row, row_size_type col) const noexcept;
   PQXX_PURE bool get_is_null(size_type row, row_size_type col) const noexcept;
   PQXX_PURE
   field_size_type get_length(size_type, row_size_type) const noexcept;

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -48,7 +48,7 @@ std::string::size_type array_parser::scan_glyph(
 template<pqxx::internal::encoding_group ENC>
 std::string::size_type array_parser::scan_double_quoted_string() const
 {
-  return pqxx::internal::s_scan_double_quoted_string<ENC>(
+  return pqxx::internal::scan_double_quoted_string<ENC>(
     std::data(m_input), std::size(m_input), m_pos);
 }
 
@@ -58,7 +58,7 @@ template<pqxx::internal::encoding_group ENC>
 std::string
 array_parser::parse_double_quoted_string(std::string::size_type end) const
 {
-  return pqxx::internal::s_parse_double_quoted_string<ENC>(
+  return pqxx::internal::parse_double_quoted_string<ENC>(
     std::data(m_input), end, m_pos);
 }
 
@@ -69,7 +69,7 @@ array_parser::parse_double_quoted_string(std::string::size_type end) const
 template<pqxx::internal::encoding_group ENC>
 std::string::size_type array_parser::scan_unquoted_string() const
 {
-  return pqxx::internal::s_scan_unquoted_string<ENC, ',', '}'>(
+  return pqxx::internal::scan_unquoted_string<ENC, ',', '}'>(
     std::data(m_input), std::size(m_input), m_pos);
 }
 
@@ -82,7 +82,7 @@ template<pqxx::internal::encoding_group ENC>
 std::string
 array_parser::parse_unquoted_string(std::string::size_type end) const
 {
-  return pqxx::internal::s_parse_unquoted_string<ENC>(
+  return pqxx::internal::parse_unquoted_string<ENC>(
     std::data(m_input), end, m_pos);
 }
 

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -69,7 +69,7 @@ array_parser::parse_double_quoted_string(std::string::size_type end) const
 template<pqxx::internal::encoding_group ENC>
 std::string::size_type array_parser::scan_unquoted_string() const
 {
-  return pqxx::internal::s_scan_unquoted_string<ENC, ',', ';', '}'>(
+  return pqxx::internal::s_scan_unquoted_string<ENC, ',', '}'>(
     std::data(m_input), std::size(m_input), m_pos);
 }
 
@@ -152,7 +152,7 @@ std::pair<array_parser::juncture, std::string> array_parser::parse_array_step()
   if (end < std::size(m_input))
   {
     auto next{scan_glyph<ENC>(end)};
-    if (next - end == 1 and (m_input[end] == ',' or m_input[end] == ';'))
+    if (((next - end) == 1) and (m_input[end] == ','))
       PQXX_UNLIKELY
     end = next;
   }

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -40,7 +40,8 @@ template<pqxx::internal::encoding_group ENC>
 std::string::size_type array_parser::scan_glyph(
   std::string::size_type pos, std::string::size_type end) const
 {
-  return pqxx::internal::glyph_scanner<ENC>::call(std::data(m_input), end, pos);
+  return pqxx::internal::glyph_scanner<ENC>::call(
+    std::data(m_input), end, pos);
 }
 
 
@@ -162,33 +163,35 @@ std::pair<array_parser::juncture, std::string> array_parser::parse_array_step()
 }
 
 
-array_parser::implementation array_parser::specialize_for_encoding(pqxx::internal::encoding_group enc)
+array_parser::implementation
+array_parser::specialize_for_encoding(pqxx::internal::encoding_group enc)
 {
   using encoding_group = pqxx::internal::encoding_group;
 
-#define PQXX_ENCODING_CASE(GROUP) \
-  case encoding_group::GROUP: \
+#define PQXX_ENCODING_CASE(GROUP)                                             \
+  case encoding_group::GROUP:                                                 \
     return &array_parser::parse_array_step<encoding_group::GROUP>
 
   switch (enc)
   {
-  PQXX_ENCODING_CASE(MONOBYTE);
-  PQXX_ENCODING_CASE(BIG5);
-  PQXX_ENCODING_CASE(EUC_CN);
-  PQXX_ENCODING_CASE(EUC_JP);
-  PQXX_ENCODING_CASE(EUC_JIS_2004);
-  PQXX_ENCODING_CASE(EUC_KR);
-  PQXX_ENCODING_CASE(EUC_TW);
-  PQXX_ENCODING_CASE(GB18030);
-  PQXX_ENCODING_CASE(GBK);
-  PQXX_ENCODING_CASE(JOHAB);
-  PQXX_ENCODING_CASE(MULE_INTERNAL);
-  PQXX_ENCODING_CASE(SJIS);
-  PQXX_ENCODING_CASE(SHIFT_JIS_2004);
-  PQXX_ENCODING_CASE(UHC);
-  PQXX_ENCODING_CASE(UTF8);
+    PQXX_ENCODING_CASE(MONOBYTE);
+    PQXX_ENCODING_CASE(BIG5);
+    PQXX_ENCODING_CASE(EUC_CN);
+    PQXX_ENCODING_CASE(EUC_JP);
+    PQXX_ENCODING_CASE(EUC_JIS_2004);
+    PQXX_ENCODING_CASE(EUC_KR);
+    PQXX_ENCODING_CASE(EUC_TW);
+    PQXX_ENCODING_CASE(GB18030);
+    PQXX_ENCODING_CASE(GBK);
+    PQXX_ENCODING_CASE(JOHAB);
+    PQXX_ENCODING_CASE(MULE_INTERNAL);
+    PQXX_ENCODING_CASE(SJIS);
+    PQXX_ENCODING_CASE(SHIFT_JIS_2004);
+    PQXX_ENCODING_CASE(UHC);
+    PQXX_ENCODING_CASE(UTF8);
   }
-  PQXX_UNLIKELY throw pqxx::internal_error{pqxx::internal::concat("Unsupported encoding code: ", enc, ".")};
+  PQXX_UNLIKELY throw pqxx::internal_error{
+    pqxx::internal::concat("Unsupported encoding code: ", enc, ".")};
 
 #undef PQXX_ENCODING_CASE
 }

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -466,6 +466,34 @@ void test_array_roundtrip()
 }
 
 
+void test_array_strings()
+{
+  std::vector<std::string_view> inputs{
+    "",
+    "'",
+    "''",
+    "\\",
+    "\n",
+    "\"",
+    "\"\"",
+  };
+  pqxx::connection conn;
+  pqxx::work tx{conn};
+
+  for (auto const &input: inputs)
+  {
+    auto const r{tx.exec_params("SELECT ARRAY[$1]", input)};
+    pqxx::array_parser parser{r[0][0].as<std::string_view>()};
+    auto [start_juncture, start_value]{parser.get_next()};
+    pqxx::ignore_unused(start_value);
+    PQXX_CHECK_EQUAL(start_juncture, pqxx::array_parser::juncture::row_start, "Bad start.");
+    auto [value_juncture, value]{parser.get_next()};
+    PQXX_CHECK_EQUAL(value_juncture, pqxx::array_parser::juncture::string_value, "Bad value juncture.");
+    PQXX_CHECK_EQUAL(value, input, "Bad array value roundtrip from parameterised statement.");
+  }
+}
+
+
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);
 PQXX_REGISTER_TEST(test_array_double_quoted_string);
@@ -477,4 +505,5 @@ PQXX_REGISTER_TEST(test_nested_array);
 PQXX_REGISTER_TEST(test_nested_array_with_multiple_entries);
 PQXX_REGISTER_TEST(test_array_generate);
 PQXX_REGISTER_TEST(test_array_roundtrip);
+PQXX_REGISTER_TEST(test_array_strings);
 } // namespace

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -470,12 +470,21 @@ void test_array_strings()
 {
   std::vector<std::string_view> inputs{
     "",
+    "null",
+    "NULL",
+    "\\N",
     "'",
     "''",
     "\\",
-    "\n",
+    "\n\t",
+    "\\n",
     "\"",
     "\"\"",
+    "a b",
+    "a<>b",
+    "{",
+    "}",
+    "{}",
   };
   pqxx::connection conn;
   pqxx::work tx{conn};
@@ -489,7 +498,7 @@ void test_array_strings()
     PQXX_CHECK_EQUAL(start_juncture, pqxx::array_parser::juncture::row_start, "Bad start.");
     auto [value_juncture, value]{parser.get_next()};
     PQXX_CHECK_EQUAL(value_juncture, pqxx::array_parser::juncture::string_value, "Bad value juncture.");
-    PQXX_CHECK_EQUAL(value, input, "Bad array value roundtrip from parameterised statement.");
+    PQXX_CHECK_EQUAL(value, input, "Bad array value roundtrip.");
   }
 }
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -469,35 +469,24 @@ void test_array_roundtrip()
 void test_array_strings()
 {
   std::vector<std::string_view> inputs{
-    "",
-    "null",
-    "NULL",
-    "\\N",
-    "'",
-    "''",
-    "\\",
-    "\n\t",
-    "\\n",
-    "\"",
-    "\"\"",
-    "a b",
-    "a<>b",
-    "{",
-    "}",
-    "{}",
+    "",    "null", "NULL", "\\N", "'",    "''", "\\", "\n\t",
+    "\\n", "\"",   "\"\"", "a b", "a<>b", "{",  "}",  "{}",
   };
   pqxx::connection conn;
   pqxx::work tx{conn};
 
-  for (auto const &input: inputs)
+  for (auto const &input : inputs)
   {
     auto const r{tx.exec_params("SELECT ARRAY[$1]", input)};
     pqxx::array_parser parser{r[0][0].as<std::string_view>()};
     auto [start_juncture, start_value]{parser.get_next()};
     pqxx::ignore_unused(start_value);
-    PQXX_CHECK_EQUAL(start_juncture, pqxx::array_parser::juncture::row_start, "Bad start.");
+    PQXX_CHECK_EQUAL(
+      start_juncture, pqxx::array_parser::juncture::row_start, "Bad start.");
     auto [value_juncture, value]{parser.get_next()};
-    PQXX_CHECK_EQUAL(value_juncture, pqxx::array_parser::juncture::string_value, "Bad value juncture.");
+    PQXX_CHECK_EQUAL(
+      value_juncture, pqxx::array_parser::juncture::string_value,
+      "Bad value juncture.");
     PQXX_CHECK_EQUAL(value, input, "Bad array value roundtrip.");
   }
 }


### PR DESCRIPTION
The `array_parser` was seriously broken (#590): SQL arrays may contain elements that have a semicolon in them... _and the back-end won't put them in quotes._  The parser would always see that as a field separator.  Same thing for commas in e.g. the SQL "box" type, which uses the semicolon as its separator but uses commas inside an object.

So I'm limiting `array_parser` for use with comma-separated types only, and planning a better, friendlier, faster, more flexible API for parsing arrays.

At the same time, I did manage to specialise `array_parser` internally to different encodings, which should make it considerably faster.  These changes will also benefit the future array parsing API.