### PR TITLE
WIP: New array API

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,8 @@
 7.8.0
+ - New `array` class for easier parsing of SQL arrays.
  - Use `array_parser` only on comma-separated types, i.e. most of them. (#590)
  - Bumping requirements versions: need postgres 10.
- - Fix array parsing bug when parsing semicolon in an unquoted string.
+ - Fix `array_parser` bug when parsing semicolon in an unquoted string.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - At last, streaming throughput is faster (on my system) than a regular query.
  - Deprecate `basic_fieldstream` and `fieldstream`.

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -360,8 +360,7 @@ private:
   }
 
   template<typename OUTER, typename... INDEX>
-  constexpr std::size_t
-  add_index(OUTER outer, INDEX... indexes) const noexcept
+  constexpr std::size_t add_index(OUTER outer, INDEX... indexes) const noexcept
   {
     std::size_t const first{check_cast<std::size_t>(outer, "array index"sv)};
     if constexpr (sizeof...(indexes) == 0)
@@ -387,7 +386,10 @@ private:
     assert(sizeof...(indexes) < DIMENSIONS);
     constexpr auto dimension{DIMENSIONS - sizeof...(indexes) - 1};
     assert(dimension < DIMENSIONS);
-    if (first >= m_extents[dimension]) throw range_error{pqxx::internal::concat("Array index for dimension ", dimension, " is out of bounds: ", first, " >= ", m_extents[dimension])};
+    if (first >= m_extents[dimension])
+      throw range_error{pqxx::internal::concat(
+        "Array index for dimension ", dimension, " is out of bounds: ", first,
+        " >= ", m_extents[dimension])};
   }
 
   /// Linear storage for the array's elements.

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -45,10 +45,18 @@ public:
 
   template<typename... INDEX> ELEMENT const &at(INDEX...... index) const
   {
-    static_assert(std::is_convertible_v<INDEX, std::size_t> and ...);
+    // XXX: Check bounds on all dimensions.
     return m_elts.at(locate(index...));
   }
 
+  /// Access element (without bounds check).
+  /** Return element at given index.  Blindly assumes that the index lies within
+   * the bounds of the array.
+   *
+   * Multi-dimensional indexing using `operator[]` only works in C++23 or
+   * better.  In older versions of C++ it will only work with single-dimensional
+   * arrays.
+   */
   template<typename... INDEX> ELEMENT const &operator[](INDEX... index) const
   {
     return m_elts[locate(index...)];

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -207,7 +207,7 @@ private:
 	    // escaping or encoding, so we don't need to parse it into a
 	    // buffer.  We can just read it as a string_view.
 	    end = pqxx::internal::scan_unquoted_string<ENC, SEPARATOR, '}'>(std::data(data), std::size(data), here);
-	    field = std::string_view{std::data(data) + here, end - here};
+	    std::string_view const field{std::string_view{std::data(data) + here, end - here}};
 	    if (field == "NULL") m_elts.emplace_back(nullness<ELEMENT>::null());
 	    else m_elts.emplace_back(from_string<ELEMENT>(field));
 	  }
@@ -234,6 +234,23 @@ private:
     // XXX: return index[-1] + m_extents[-1] * (index[-2] + m_extents[-2] *
     // (index[-3] + ...))
     return 0; // XXX:
+  }
+
+  // XXX: Make private.
+  // XXX: Can we make dimension a template parameter but still deduce?
+  template<typename... INDEX> constexpr add_index(std::size_t dimension, INDEX... indexes, std::size_t inner) noexcept
+  {
+    if constexpr (dimension == DIMENSIONS)
+    {
+    assert(sizeof...(INDEX) == 0);
+    return inner;
+    }
+    else
+    {
+    assert(dimension < DIMENSIONS);
+    assert(sizeof...(INDEX) > 0);
+    return inner + m_extents[dimension - 1] * add_index(dimension-1, indexes);
+    }
   }
 
   /// Linear storage for the array's elements.

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -27,7 +27,6 @@
 #include "pqxx/internal/encoding_group.hxx"
 #include "pqxx/internal/encodings.hxx"
 
-#include <iostream> // XXX: DEBUG
 
 namespace pqxx
 {
@@ -185,7 +184,6 @@ private:
   template<pqxx::internal::encoding_group ENC>
   void parse(std::string_view data)
   {
-std::clog<<"\n["<<data<<"]\n";// XXX: DEBUG
     static_assert(DIMENSIONS > 0u, "Can't create a zero-dimensional array.");
     auto sz{std::size(data)};
     check_dims(data);

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -43,19 +43,21 @@ public:
     return m_extents;
   }
 
-  template<typename... INDEX> ELEMENT const &at(INDEX...... index) const
+  template<typename... INDEX>
+  ELEMENT const &at(INDEX...... index) const
   {
-    // XXX: Check bounds on all dimensions.
+    static_assert(std::is_convertible_v<INDEX, std::size_t> and ...);
     return m_elts.at(locate(index...));
   }
 
   /// Access element (without bounds check).
-  /** Return element at given index.  Blindly assumes that the index lies within
-   * the bounds of the array.
+  /** Return element at given index.  Blindly assumes that the index lies
+   * within the bounds of the array.  This is likely to be slightly faster than
+   * `at()`.
    *
    * Multi-dimensional indexing using `operator[]` only works in C++23 or
-   * better.  In older versions of C++ it will only work with single-dimensional
-   * arrays.
+   * better.  In older versions of C++ it will work only with
+   * single-dimensional arrays.
    */
   template<typename... INDEX> ELEMENT const &operator[](INDEX... index) const
   {
@@ -65,6 +67,7 @@ public:
 private:
   explicit array(std::string_view data, pqxx::internal::encoding_group enc)
   {
+    // TODO: Can we scan first and allocate the right size vector?
     static_assert(DIMENSIONS > 0, "Can't create a zero-dimensional array.");
     auto constexpr sz{std::size(data)};
     if (sz < DIMENSIONS * 2)

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -312,7 +312,7 @@ private:
     static_assert(
       sizeof...(index) == DIMENSIONS,
       "Indexing array with wrong number of dimensions.");
-    return add_index(index...);
+    return add_index(check_cast<std::size_t>(index, "array index"sv)...);
   }
 
   template<typename... INDEX>
@@ -320,16 +320,15 @@ private:
   add_index(INDEX... indexes, std::size_t inner) const noexcept
   {
     assert(sizeof...(indexes) < DIMENSIONS);
-    auto index{pqxx::check_cast<std::size_t>(inner, "array index"sv)};
     if constexpr (sizeof...(indexes) == 0)
     {
-      return index;
+      return inner;
     }
     else
     {
       // XXX: I've probably got the dimensions count the wrong way around.
       constexpr auto dimension{DIMENSIONS - sizeof...(indexes)};
-      return index + m_extents[dimension - 1] * add_index(indexes...);
+      return inner + m_extents[dimension - 1] * add_index(indexes...);
     }
   }
 

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -264,7 +264,8 @@ private:
         std::size_t end;
         switch (data[here])
         {
-        case '\0': throw failure{"Unexpected zero byte in array."};
+        case '\0': throw conversion_error{"Unexpected zero byte in array."};
+	case ',': throw conversion_error{"Array contains empty field."};
         case '"': {
           // Double-quoted string.  We parse it into a buffer before parsing
           // the resulting string as an element.  This seems wasteful: the

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -345,15 +345,16 @@ private:
   const noexcept
   {
     assert(sizeof...(indexes) < DIMENSIONS);
+    auto index{pqxx::check_cast<std::size_t>(inner, "array index"sv)};
     if constexpr (sizeof...(indexes) == 0)
     {
-      return inner;
+      return index;
     }
     else
     {
       // XXX: I've probably got the dimensions count the wrong way around.
       constexpr auto dimension{DIMENSIONS - sizeof...(indexes)};
-      return inner + m_extents[dimension - 1] * add_index(indexes...);
+      return index + m_extents[dimension - 1] * add_index(indexes...);
     }
   }
 

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -230,10 +230,21 @@ private:
         // dimension, through underflow.
         --dim;
         ++here;
+        // XXX: This block occurs twice.
         if (here < sz) switch (data[here])
         {
         case SEPARATOR:
           ++here;
+          if (here >= sz) throw conversion_error{"Array looks truncated."};
+          switch (data[here])
+          {
+          case SEPARATOR:
+            throw conversion_error{"Array contains double separator."};
+          case '}':
+            throw conversion_error{"Array contains trailing separator."};
+          default:
+            break;
+          }
           break;
         case '}':
           break;
@@ -297,11 +308,22 @@ private:
         }
         }
         here = end;
+        // XXX: This block occurs twice.
         if (here < sz) switch (data[here])
         {
           case SEPARATOR:
             ++here;
-            break;
+            if (here >= sz) throw conversion_error{"Array looks truncated."};
+            switch (data[here])
+            {
+            case SEPARATOR:
+              throw conversion_error{"Array contains double separator."};
+            case '}':
+              throw conversion_error{"Array contains trailing separator."};
+            default:
+              break;
+            }
+             break;
           case '}':
             break;
           default:

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -38,6 +38,8 @@ public:
   /// How many dimensions does this array have?
   constexpr std::size_t dimensions() noexcept { return DIMENSIONS; }
 
+// TODO: Document order of the elements.
+  /// Return the sizes of this array in each of its dimensions.
   std::array<std::size_t, DIMENSIONS> const &sizes() noexcept
   {
     return m_extents;

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -30,16 +30,19 @@
 
 namespace pqxx
 {
+// TODO: Can we storage-optimise this for string_view/zview?
+
 /// An SQL array received from the database.
 /** Parses an SQL array from its text format, making it available as a
  * container of C++-side values.
  */
 template<
-  typename ELEMENT, std::size_t DIMENSIONS = 1,
+  typename ELEMENT, std::size_t DIMENSIONS = 1u,
   char SEPARATOR = array_separator<ELEMENT>>
 class array final
 {
 public:
+// XXX: Optional "reserve()" parameter.
   /// Parse an SQL array, read as text from a pqxx::result or stream.
   /** Uses `conn` only during construction, to find out the text encoding in
    * which it should interpret `data`.
@@ -202,7 +205,6 @@ private:
           if (dim >= (DIMENSIONS - 1))
             throw conversion_error{
               "Array seems to have inconsistent number of dimensions."};
-          // XXX: Are we sure we're supposed to increment here?
           ++extents[dim];
         }
         // (Rolls over to zero if we're coming from the outer dimension.)
@@ -276,7 +278,6 @@ private:
           // indicates that there is some kind of special character in there.
           // So in practice, this optimisation would only apply if the only
           // special characters in the string were commas.
-          ++here;
           end = pqxx::internal::scan_double_quoted_string<ENC>(
             std::data(data), std::size(data), here);
           // TODO: scan_double_quoted_string() with reusable buffer.
@@ -361,7 +362,6 @@ private:
     }
     else
     {
-      // XXX: I've probably got the dimensions count the wrong way around.
       constexpr auto dimension{DIMENSIONS - sizeof...(indexes)};
       return inner + m_extents[dimension - 1] * add_index(indexes...);
     }

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -66,7 +66,6 @@ public:
 
   template<typename... INDEX> ELEMENT const &at(INDEX... index) const
   {
-    // static_assert((std::is_convertible_v<INDEX, std::size_t>) and ...);
     return m_elts.at(locate(index...));
   }
 

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -406,7 +406,8 @@ private:
         " >= ", m_extents[dimension])};
 
     // Now check the rest of the indexes, if any.
-    if constexpr (sizeof...(indexes) > 0) check_bounds(indexes...);
+    if constexpr (sizeof...(indexes) > 0)
+      check_bounds(indexes...);
   }
 
   /// Linear storage for the array's elements.

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -27,6 +27,7 @@
 #include "pqxx/internal/encoding_group.hxx"
 #include "pqxx/internal/encodings.hxx"
 
+
 namespace pqxx
 {
 // TODO: Specialise for string_view/zview, allocate all strings in one buffer.

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -230,6 +230,16 @@ private:
         // dimension, through underflow.
         --dim;
         ++here;
+        if (here < sz) switch (data[here])
+        {
+        case SEPARATOR:
+          ++here;
+          break;
+        case '}':
+          break;
+        default:
+          throw conversion_error{"Unexpected character in array after '}'."};
+        }
       }
       else
       {
@@ -287,11 +297,14 @@ private:
         }
         }
         here = end;
-        if (here < sz)
+        if (here < sz) switch (data[here])
         {
-          if (data[here] == SEPARATOR)
+          case SEPARATOR:
             ++here;
-          else if (data[here] != '}')
+            break;
+          case '}':
+            break;
+          default:
             throw conversion_error{pqxx::internal::concat(
               "Unexpected character in array: ",
               static_cast<unsigned>(static_cast<unsigned char>(data[here])),

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -236,9 +236,10 @@ std::clog<<"\n["<<data<<"]\n";// XXX: DEBUG
           if (dim >= (DIMENSIONS - 1))
             throw conversion_error{
               "Array seems to have inconsistent number of dimensions."};
+	  // XXX: Are we sure we're supposed to increment here?
           ++extents[dim];
         }
-	// (Rolls over to zero we're coming from the outer dimension.)
+	// (Rolls over to zero if we're coming from the outer dimension.)
         ++dim;
         extents[dim] = 0u;
         ++here;
@@ -271,6 +272,7 @@ std::clog<<"\n["<<data<<"]\n";// XXX: DEBUG
         if (dim != DIMENSIONS - 1)
           throw conversion_error{
             "Malformed array: found element where sub-array was expected."};
+	assert(dim != outer);
         ++extents[dim];
 	std::size_t end;
 	switch (data[here])

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -93,7 +93,7 @@ private:
       if (data[i] != '{')
         throw conversion_error{pqxx::internal::concat(
           "Expecting ", DIMENSIONS, "-dimensional array, but found ", i, ".")};
-    if (std::data[DIMENSIONS] == '{')
+    if (data[DIMENSIONS] == '{')
       throw conversion_error{pqxx::internal::concat(
         "Tried to parse ", DIMENSIONS,
         "-dimensional array from array data that has more dimensions.")};

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -230,7 +230,7 @@ private:
     static_assert(
       sizeof...(index) == DIMENSIONS,
       "Indexing array with wrong number of dimensions.");
-    static_assert(std::is_convertible<INDEX, std::size_t> and ...);
+    static_assert(std::is_convertible_v<INDEX, std::size_t> and ...);
     // XXX: return index[-1] + m_extents[-1] * (index[-2] + m_extents[-2] *
     // (index[-3] + ...))
     return 0; // XXX:
@@ -238,7 +238,7 @@ private:
 
   // XXX: Make private.
   // XXX: Can we make dimension a template parameter but still deduce?
-  template<typename... INDEX> constexpr add_index(std::size_t dimension, INDEX... indexes, std::size_t inner) noexcept
+  template<typename... INDEX> constexpr void add_index(std::size_t dimension, INDEX... indexes, std::size_t inner) noexcept
   {
     if constexpr (dimension == DIMENSIONS)
     {

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -30,7 +30,7 @@
 
 namespace pqxx
 {
-// TODO: Can we storage-optimise this for string_view/zview?
+// TODO: Specialise for string_view/zview, allocate all strings in one buffer.
 
 /// An SQL array received from the database.
 /** Parses an SQL array from its text format, making it available as a

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -175,29 +175,28 @@ private:
   std::size_t parse_field_end(std::string_view data, std::size_t here) const
   {
     auto const sz{std::size(data)};
-    if (here < sz) switch (data[here])
-    {
-    case SEPARATOR:
-      ++here;
-      if (here >= sz) throw conversion_error{"Array looks truncated."};
+    if (here < sz)
       switch (data[here])
       {
       case SEPARATOR:
-        throw conversion_error{"Array contains double separator."};
-      case '}':
-        throw conversion_error{"Array contains trailing separator."};
-      default:
+        ++here;
+        if (here >= sz)
+          throw conversion_error{"Array looks truncated."};
+        switch (data[here])
+        {
+        case SEPARATOR:
+          throw conversion_error{"Array contains double separator."};
+        case '}': throw conversion_error{"Array contains trailing separator."};
+        default: break;
+        }
         break;
+      case '}': break;
+      default:
+        throw conversion_error{pqxx::internal::concat(
+          "Unexpected character in array: ",
+          static_cast<unsigned>(static_cast<unsigned char>(data[here])),
+          " where separator or closing brace expected.")};
       }
-      break;
-    case '}':
-      break;
-    default:
-      throw conversion_error{pqxx::internal::concat(
-        "Unexpected character in array: ",
-        static_cast<unsigned>(static_cast<unsigned char>(data[here])),
-        " where separator or closing brace expected.")};
-    }
     return here;
   }
 
@@ -281,7 +280,7 @@ private:
         // dimension, through underflow.
         --dim;
         ++here;
-	here = parse_field_end(data, here);
+        here = parse_field_end(data, here);
       }
       else
       {
@@ -296,7 +295,7 @@ private:
         switch (data[here])
         {
         case '\0': throw conversion_error{"Unexpected zero byte in array."};
-	case ',': throw conversion_error{"Array contains empty field."};
+        case ',': throw conversion_error{"Array contains empty field."};
         case '"': {
           // Double-quoted string.  We parse it into a buffer before parsing
           // the resulting string as an element.  This seems wasteful: the
@@ -339,7 +338,7 @@ private:
         }
         }
         here = end;
-	here = parse_field_end(data, here);
+        here = parse_field_end(data, here);
       }
     }
 

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -374,7 +374,7 @@ public:
   void set_client_encoding(char const encoding[]) &;
 
   /// Get the connection's encoding, as a PostgreSQL-defined code.
-  [[nodiscard]] int PQXX_PRIVATE encoding_id() const;
+  [[nodiscard]] int encoding_id() const;
 
   //@}
 

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -190,6 +190,13 @@ struct PQXX_LIBEXPORT conversion_error : std::domain_error
 };
 
 
+/// Could not convert null value: target type does not support null.
+struct PQXX_LIBEXPORT unexpected_null : conversion_error
+{
+  explicit unexpected_null(std::string const &);
+};
+
+
 /// Could not convert value to string: not enough buffer space.
 struct PQXX_LIBEXPORT conversion_overrun : conversion_error
 {

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -71,6 +71,7 @@ inline std::size_t scan_double_quoted_string(
 }
 
 
+// TODO: Needs version with caller-supplied buffer.
 /// Un-quote and un-escape a double-quoted SQL string.
 template<encoding_group ENC>
 inline std::string parse_double_quoted_string(
@@ -108,8 +109,9 @@ inline std::string parse_double_quoted_string(
 /** Stops when it gets to the end of the input; or when it sees any of the
  * characters in STOP which has not been escaped.
  *
- * For array values, STOP is a comma, a semicolon, or a closing brace.  For
- * a value of a composite type, STOP is a comma or a closing parenthesis.
+ * For array values, STOP is an array element separator (typically comma, or
+ * semicolon), or a closing brace.  For a value of a composite type, STOP is a
+ * comma or a closing parenthesis.
  */
 template<pqxx::internal::encoding_group ENC, char... STOP>
 inline std::size_t
@@ -126,6 +128,7 @@ scan_unquoted_string(char const input[], std::size_t size, std::size_t pos)
 }
 
 
+// XXX: Retire this.  Just construct a string_view directly now!
 /// Parse an unquoted array entry or cfield of a composite-type field.
 template<pqxx::internal::encoding_group ENC>
 inline std::string

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -40,7 +40,7 @@ PQXX_LIBEXPORT encoding_group enc_group(int /* libpq encoding ID */);
 PQXX_LIBEXPORT glyph_scanner_func *get_glyph_scanner(encoding_group);
 
 
-// XXX: Get rid of thise one.  Use compile-time-specialised version instead.
+// XXX: Get rid of this one.  Use compile-time-specialised version instead.
 /// Find any of the ASCII characters `NEEDLE` in `haystack`.
 /** Scans through `haystack` until it finds a single-byte character that
  * matches any value in `NEEDLE`.

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -271,8 +271,8 @@ public:
    * If `func` throws an exception, processing stops at that point and
    * propagates the exception.
    *
-   * @throws usage_error if `func`'s number of parameters does not match the
-   * number of columns in this result.
+   * @throws pqxx::usage_error if `func`'s number of parameters does not match
+   * the number of columns in this result.
    */
   template<typename CALLABLE> inline void for_each(CALLABLE &&func) const;
 

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -111,6 +111,11 @@ pqxx::conversion_error::conversion_error(std::string const &whatarg) :
 {}
 
 
+pqxx::unexpected_null::unexpected_null(std::string const &whatarg) :
+        conversion_error{whatarg}
+{}
+
+
 pqxx::conversion_overrun::conversion_overrun(std::string const &whatarg) :
         conversion_error{whatarg}
 {}

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -525,8 +525,12 @@ void test_array_parses_real_arrays()
 
   auto const twodim_s{tx.query_value<std::string>("SELECT ARRAY[[1], [2]]")};
   pqxx::array<int, 2> twodim_a{twodim_s, conn};
-  PQXX_CHECK_EQUAL(twodim_a.dimensions(), 2u, "Wrong number of dimensions on multi-dimensional array.");
-  PQXX_CHECK_EQUAL(twodim_a.sizes(), (std::array<std::size_t, 2>{2u, 1u}), "Wrong sizes on multidim array.");
+  PQXX_CHECK_EQUAL(
+    twodim_a.dimensions(), 2u,
+    "Wrong number of dimensions on multi-dimensional array.");
+  PQXX_CHECK_EQUAL(
+    twodim_a.sizes(), (std::array<std::size_t, 2>{2u, 1u}),
+    "Wrong sizes on multidim array.");
 }
 
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -499,21 +499,32 @@ void test_array_parses_real_array()
 
   auto const empty_s{tx.query_value<std::string>("SELECT ARRAY[]::integer[]")};
   pqxx::array<int, 1> empty_a{empty_s, conn};
-  PQXX_CHECK_EQUAL(empty_a.dimensions(), 1u, "Unexpected dimension count for empty array.");
-  PQXX_CHECK_EQUAL(empty_a.sizes(), (std::array<std::size_t, 1>{0u}), "Unexpected sizes for empty array.");
+  PQXX_CHECK_EQUAL(
+    empty_a.dimensions(), 1u, "Unexpected dimension count for empty array.");
+  PQXX_CHECK_EQUAL(
+    empty_a.sizes(), (std::array<std::size_t, 1>{0u}),
+    "Unexpected sizes for empty array.");
 
   auto const onedim_s{tx.query_value<std::string>("SELECT ARRAY[0, 1, 2]")};
   pqxx::array<int, 1> onedim_a{onedim_s, conn};
-  PQXX_CHECK_EQUAL(onedim_a.dimensions(), 1u, "Unexpected dimension count for one-dimensional array.");
-  PQXX_CHECK_EQUAL(onedim_a.sizes(), (std::array<std::size_t, 1>{3u}), "Unexpected sizes for one-dimensional array.");
+  PQXX_CHECK_EQUAL(
+    onedim_a.dimensions(), 1u,
+    "Unexpected dimension count for one-dimensional array.");
+  PQXX_CHECK_EQUAL(
+    onedim_a.sizes(), (std::array<std::size_t, 1>{3u}),
+    "Unexpected sizes for one-dimensional array.");
   PQXX_CHECK_EQUAL(onedim_a[0], 0, "Bad data in one-dimensional array.");
-  PQXX_CHECK_EQUAL(onedim_a[2], 2, "Array started off OK but later data was bad.");
+  PQXX_CHECK_EQUAL(
+    onedim_a[2], 2, "Array started off OK but later data was bad.");
 
-  auto const null_s{tx.query_value<std::string>("SELECT ARRAY[NULL]::integer[]")};
-  PQXX_CHECK_THROWS((pqxx::array<int, 1>{null_s, conn}), pqxx::unexpected_null, "Not getting unexpected_null from array parser.");
+  auto const null_s{
+    tx.query_value<std::string>("SELECT ARRAY[NULL]::integer[]")};
+  PQXX_CHECK_THROWS(
+    (pqxx::array<int, 1>{null_s, conn}), pqxx::unexpected_null,
+    "Not getting unexpected_null from array parser.");
   // XXX: Test unexpected nulls.
 
-// XXX: Test multidim.
+  // XXX: Test multidim.
 }
 
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -625,6 +625,7 @@ void test_array_rejects_malformed_twodimensional_arrays()
       "No conversion_error for '" + std::string{bad} + "'.");
 }
 
+// XXX: Test strings with escaping.
 
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -536,12 +536,13 @@ void test_array_parses_real_arrays()
 }
 
 
-void test_array_rejects_malformed_arrays()
+void test_array_rejects_malformed_simple_int_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
     ""sv,
     "null"sv,
+    ","sv,
     "1"sv,
     "{"sv,
     "}"sv,
@@ -556,6 +557,7 @@ void test_array_rejects_malformed_arrays()
     "{1,}"sv,
     "{,1}"sv,
     "{1,{}}"sv,
+    "{x}"sv,
   };
   for (auto bad : bad_arrays)
   {
@@ -563,9 +565,57 @@ void test_array_rejects_malformed_arrays()
       (pqxx::array<int, 1>{bad, conn}), pqxx::conversion_error,
       "No conversion_error for '" + std::string{bad} + "'.");
   }
+}
+
+
+void test_array_rejects_malformed_simple_string_arrays()
+{
+  pqxx::connection conn;
+  std::string_view const bad_arrays[]{
+    ""sv,
+    "null"sv,
+    "1"sv,
+    ","sv,
+    "{"sv,
+    "}"sv,
+    "}{"sv,
+    "{}{"sv,
+    "{{}"sv,
+    "{}}"sv,
+    "{{}}"sv,
+    "{1"sv,
+    "{1,"sv,
+    "{,}"sv,
+    "{1,}"sv,
+    // XXX: This should fail!
+    //"{,1}"sv,
+    "{1,{}}"sv,
+   };
+  for (auto bad : bad_arrays)
+  {
+    PQXX_CHECK_THROWS(
+      (pqxx::array<std::string, 1>{bad, conn}), pqxx::conversion_error,
+      "No conversion_error for '" + std::string{bad} + "'.");
+  }
+}
+
+
+void test_array_rejects_malformed_twodimensional_arrays()
+{
+  pqxx::connection conn;
+  std::string_view const bad_arrays[]{
+    ""sv,
+    "{}"sv,
+    "{null}"sv,
   // XXX:
-  // XXX: Test unexpected nulls.
   // XXX: Test various kinds of irregular arrays.
+  };
+  for (auto bad : bad_arrays)
+  {
+    PQXX_CHECK_THROWS(
+      (pqxx::array<std::string, 2>{bad, conn}), pqxx::conversion_error,
+      "No conversion_error for '" + std::string{bad} + "'.");
+  }
 }
 
 
@@ -582,5 +632,7 @@ PQXX_REGISTER_TEST(test_array_generate);
 PQXX_REGISTER_TEST(test_array_roundtrip);
 PQXX_REGISTER_TEST(test_array_strings);
 PQXX_REGISTER_TEST(test_array_parses_real_arrays);
-PQXX_REGISTER_TEST(test_array_rejects_malformed_arrays);
+PQXX_REGISTER_TEST(test_array_rejects_malformed_simple_int_arrays);
+PQXX_REGISTER_TEST(test_array_rejects_malformed_simple_string_arrays);
+PQXX_REGISTER_TEST(test_array_rejects_malformed_twodimensional_arrays);
 } // namespace

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -504,10 +504,10 @@ void test_array_parses_real_array()
 
   auto const onedim_s{tx.query_value<std::string>("SELECT ARRAY[0, 1, 2]")};
   pqxx::array<int, 1> onedim_a{onedim_s, conn};
-  PQXX_CHECK_EQUAL(empty_a.dimensions(), 1u, "Unexpected dimension count for one-dimensional array.");
-  PQXX_CHECK_EQUAL(empty_a.sizes(), (std::array<std::size_t, 1>{3u}), "Unexpected sizes for one-dimensional array.");
-  PQXX_CHECK_EQUAL(empty_a[0], 0, "Bad data in one-dimensional array.");
-  PQXX_CHECK_EQUAL(empty_a[2], 2, "Array started off OK but later data was bad.");
+  PQXX_CHECK_EQUAL(onedim_a.dimensions(), 1u, "Unexpected dimension count for one-dimensional array.");
+  PQXX_CHECK_EQUAL(onedim_a.sizes(), (std::array<std::size_t, 1>{3u}), "Unexpected sizes for one-dimensional array.");
+  PQXX_CHECK_EQUAL(onedim_a[0], 0, "Bad data in one-dimensional array.");
+  PQXX_CHECK_EQUAL(onedim_a[2], 2, "Array started off OK but later data was bad.");
 
   auto const null_s{tx.query_value<std::string>("SELECT ARRAY[NULL]::integer[]")};
   PQXX_CHECK_THROWS((pqxx::array<int, 1>{null_s, conn}), pqxx::unexpected_null, "Not getting unexpected_null from array parser.");

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -492,7 +492,7 @@ void test_array_strings()
 }
 
 
-void test_array_parses_real_array()
+void test_array_parses_real_arrays()
 {
   pqxx::connection conn;
   pqxx::work tx{conn};
@@ -522,13 +522,21 @@ void test_array_parses_real_array()
   PQXX_CHECK_THROWS(
     (pqxx::array<int, 1>{null_s, conn}), pqxx::unexpected_null,
     "Not getting unexpected_null from array parser.");
-  // XXX: Test unexpected nulls.
 
-  // XXX: Test multidim.
+  auto const twodim_s{tx.query_value<std::string>("SELECT ARRAY[[1], [2]]")};
+  pqxx::array<int, 2> twodim_a{twodim_s, conn};
+  PQXX_CHECK_EQUAL(twodim_a.dimensions(), 2u, "Wrong number of dimensions on multi-dimensional array.");
+  PQXX_CHECK_EQUAL(twodim_a.sizes(), (std::array<std::size_t, 2>{2u, 1u}), "Wrong sizes on multidim array.");
 }
 
 
-// XXX: Test empty array.
+void test_array_rejects_malformed_arrays()
+{
+  // XXX:
+  // XXX: Test unexpected nulls.
+  // XXX: Test various kinds of irregular arrays.
+}
+
 
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);
@@ -542,5 +550,6 @@ PQXX_REGISTER_TEST(test_nested_array_with_multiple_entries);
 PQXX_REGISTER_TEST(test_array_generate);
 PQXX_REGISTER_TEST(test_array_roundtrip);
 PQXX_REGISTER_TEST(test_array_strings);
-PQXX_REGISTER_TEST(test_array_parses_real_array);
+PQXX_REGISTER_TEST(test_array_parses_real_arrays);
+PQXX_REGISTER_TEST(test_array_rejects_malformed_arrays);
 } // namespace

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -630,13 +630,22 @@ void test_array_at_checks_bounds()
     "Negative index does not throw range_error.");
 
   pqxx::array<int, 2> const multi{"{{0,1},{2,3},{4,5}}", conn};
-  PQXX_CHECK_EQUAL(multi.at(0, 0), 0, "Multidim array indexing does not work.");
+  PQXX_CHECK_EQUAL(
+    multi.at(0, 0), 0, "Multidim array indexing does not work.");
   PQXX_CHECK_EQUAL(multi.at(1, 1), 3, "Nonzero multidim indexing goes wrong.");
   PQXX_CHECK_EQUAL(multi.at(2, 1), 5, "Multidim top element went wrong.");
-  PQXX_CHECK_THROWS(multi.at(3, 0), pqxx::range_error, "Out-of-bounds on outer dimension was not detected.");
-  PQXX_CHECK_THROWS(multi.at(0, 2), pqxx::range_error, "Out-of-bounds on inner dimension was not detected.");
-  PQXX_CHECK_THROWS(multi.at(0, -1), pqxx::range_error, "Negative inner index was not detected.");
-  PQXX_CHECK_THROWS(multi.at(-1, 0), pqxx::range_error, "Negative outer index was not detected.");
+  PQXX_CHECK_THROWS(
+    multi.at(3, 0), pqxx::range_error,
+    "Out-of-bounds on outer dimension was not detected.");
+  PQXX_CHECK_THROWS(
+    multi.at(0, 2), pqxx::range_error,
+    "Out-of-bounds on inner dimension was not detected.");
+  PQXX_CHECK_THROWS(
+    multi.at(0, -1), pqxx::range_error,
+    "Negative inner index was not detected.");
+  PQXX_CHECK_THROWS(
+    multi.at(-1, 0), pqxx::range_error,
+    "Negative outer index was not detected.");
 }
 
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -4,6 +4,8 @@
 
 // Test program for libpqxx array parsing.
 
+using namespace std::literals;
+
 namespace pqxx
 {
 template<>
@@ -536,6 +538,31 @@ void test_array_parses_real_arrays()
 
 void test_array_rejects_malformed_arrays()
 {
+  pqxx::connection conn;
+  std::string_view const bad_arrays[]{
+    ""sv,
+    "null"sv,
+    "1"sv,
+    "{"sv,
+    "}"sv,
+    "}{"sv,
+    "{}{"sv,
+    "{{}"sv,
+    "{}}"sv,
+    "{{}}"sv,
+    "{1"sv,
+    "{1,"sv,
+    "{,}"sv,
+    //"{1,}"sv,
+    "{,1}"sv,
+    "{1,{}}"sv,
+  };
+  for (auto bad : bad_arrays)
+  {
+    PQXX_CHECK_THROWS(
+      (pqxx::array<int, 1>{bad, conn}), pqxx::conversion_error,
+      "No conversion_error for '" + std::string{bad} + "'.");
+  }
   // XXX:
   // XXX: Test unexpected nulls.
   // XXX: Test various kinds of irregular arrays.

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -540,13 +540,16 @@ void test_array_parses_real_arrays()
 
   auto const fake_null_s{tx.query_value<std::string>("SELECT ARRAY['NULL']")};
   pqxx::array<std::string> fake_null_a{string_s, conn};
-  PQXX_CHECK_EQUAL(fake_null_a[0], "Hello", "String field 'NULL' came out wrong.");
+  PQXX_CHECK_EQUAL(
+    fake_null_a[0], "Hello", "String field 'NULL' came out wrong.");
 
-  auto const nulls_s{tx.query_value<std::string>("SELECT ARRAY[NULL, 'NULL']")};
+  auto const nulls_s{
+    tx.query_value<std::string>("SELECT ARRAY[NULL, 'NULL']")};
   pqxx::array<std::optional<std::string>> nulls_a{nulls_s, conn};
   PQXX_CHECK(not nulls_a[0].has_value(), "Null string cvame out with value.");
   PQXX_CHECK(nulls_a[1].has_value(), "String 'NULL' came out as null.");
-  PQXX_CHECK_EQUAL(nulls_a[1].value(), "NULL", "String 'NULL' came out wrong.");
+  PQXX_CHECK_EQUAL(
+    nulls_a[1].value(), "NULL", "String 'NULL' came out wrong.");
 }
 
 
@@ -554,24 +557,9 @@ void test_array_rejects_malformed_simple_int_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
-    ""sv,
-    "null"sv,
-    ","sv,
-    "1"sv,
-    "{"sv,
-    "}"sv,
-    "}{"sv,
-    "{}{"sv,
-    "{{}"sv,
-    "{}}"sv,
-    "{{}}"sv,
-    "{1"sv,
-    "{1,"sv,
-    "{,}"sv,
-    "{1,}"sv,
-    "{,1}"sv,
-    "{1,{}}"sv,
-    "{x}"sv,
+    ""sv,    "null"sv, ","sv,    "1"sv,    "{"sv,      "}"sv,
+    "}{"sv,  "{}{"sv,  "{{}"sv,  "{}}"sv,  "{{}}"sv,   "{1"sv,
+    "{1,"sv, "{,}"sv,  "{1,}"sv, "{,1}"sv, "{1,{}}"sv, "{x}"sv,
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(
@@ -584,24 +572,10 @@ void test_array_rejects_malformed_simple_string_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
-    ""sv,
-    "null"sv,
-    "1"sv,
-    ","sv,
-    "{"sv,
-    "}"sv,
-    "}{"sv,
-    "{}{"sv,
-    "{{}"sv,
-    "{}}"sv,
-    "{{}}"sv,
-    "{1"sv,
-    "{1,"sv,
-    "{,}"sv,
-    "{1,}"sv,
-    "{,1}"sv,
-    "{1,{}}"sv,
-   };
+    ""sv,    "null"sv, "1"sv,    ","sv,    "{"sv,      "}"sv,
+    "}{"sv,  "{}{"sv,  "{{}"sv,  "{}}"sv,  "{{}}"sv,   "{1"sv,
+    "{1,"sv, "{,}"sv,  "{1,}"sv, "{,1}"sv, "{1,{}}"sv,
+  };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(
       (pqxx::array<std::string>{bad, conn}), pqxx::conversion_error,
@@ -613,11 +587,9 @@ void test_array_rejects_malformed_twodimensional_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
-    ""sv,
-    "{}"sv,
-    "{null}"sv,
-  // XXX:
-  // XXX: Test various kinds of irregular arrays.
+    ""sv, "{}"sv, "{null}"sv,
+    // XXX:
+    // XXX: Test various kinds of irregular arrays.
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -560,6 +560,7 @@ void test_array_rejects_malformed_simple_int_arrays()
     ""sv,    "null"sv, ","sv,    "1"sv,    "{"sv,      "}"sv,
     "}{"sv,  "{}{"sv,  "{{}"sv,  "{}}"sv,  "{{}}"sv,   "{1"sv,
     "{1,"sv, "{,}"sv,  "{1,}"sv, "{,1}"sv, "{1,{}}"sv, "{x}"sv,
+    "{1,{2,3}}"sv,
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(
@@ -587,9 +588,7 @@ void test_array_rejects_malformed_twodimensional_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
-    ""sv, "{}"sv, "{null}"sv,
-    // XXX: Test irregular array.
-    // XXX: Test null row.
+    ""sv, "{}"sv, "{null}"sv, "{{1}, {2, 3}}"sv,
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -553,7 +553,7 @@ void test_array_rejects_malformed_arrays()
     "{1"sv,
     "{1,"sv,
     "{,}"sv,
-    //"{1,}"sv,
+    "{1,}"sv,
     "{,1}"sv,
     "{1,{}}"sv,
   };

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -557,10 +557,9 @@ void test_array_rejects_malformed_simple_int_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
-    ""sv,    "null"sv, ","sv,    "1"sv,    "{"sv,      "}"sv,
-    "}{"sv,  "{}{"sv,  "{{}"sv,  "{}}"sv,  "{{}}"sv,   "{1"sv,
-    "{1,"sv, "{,}"sv,  "{1,}"sv, "{,1}"sv, "{1,{}}"sv, "{x}"sv,
-    "{1,{2,3}}"sv,
+    ""sv,     "null"sv, ","sv,      "1"sv,    "{"sv,         "}"sv,   "}{"sv,
+    "{}{"sv,  "{{}"sv,  "{}}"sv,    "{{}}"sv, "{1"sv,        "{1,"sv, "{,}"sv,
+    "{1,}"sv, "{,1}"sv, "{1,{}}"sv, "{x}"sv,  "{1,{2,3}}"sv,
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(
@@ -588,7 +587,10 @@ void test_array_rejects_malformed_twodimensional_arrays()
 {
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
-    ""sv, "{}"sv, "{null}"sv, "{{1},{2,3}}"sv,
+    ""sv,
+    "{}"sv,
+    "{null}"sv,
+    "{{1},{2,3}}"sv,
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(
@@ -621,8 +623,11 @@ void test_array_at_checks_bounds()
   pqxx::array<int> const simple{"{0, 1, 2}", conn};
   PQXX_CHECK_EQUAL(simple.at(0), 0, "Array indexing does not work.");
   PQXX_CHECK_EQUAL(simple.at(2), 2, "Nonzero array indexing goes wrong.");
-  PQXX_CHECK_THROWS(simple.at(3), pqxx::range_error, "No bounds checking on array::at().");
-  PQXX_CHECK_THROWS(simple.at(-1), pqxx::range_error, "Negative index does not throw range_error.");
+  PQXX_CHECK_THROWS(
+    simple.at(3), pqxx::range_error, "No bounds checking on array::at().");
+  PQXX_CHECK_THROWS(
+    simple.at(-1), pqxx::range_error,
+    "Negative index does not throw range_error.");
   // XXX: And now for multi-dimensional arrays.
   // XXX: Since indexes can be signed... check that negative index fails.
 }

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -628,8 +628,15 @@ void test_array_at_checks_bounds()
   PQXX_CHECK_THROWS(
     simple.at(-1), pqxx::range_error,
     "Negative index does not throw range_error.");
-  // XXX: And now for multi-dimensional arrays.
-  // XXX: Since indexes can be signed... check that negative index fails.
+
+  pqxx::array<int, 2> const multi{"{{0,1},{2,3},{4,5}}", conn};
+  PQXX_CHECK_EQUAL(multi.at(0, 0), 0, "Multidim array indexing does not work.");
+  PQXX_CHECK_EQUAL(multi.at(1, 1), 3, "Nonzero multidim indexing goes wrong.");
+  PQXX_CHECK_EQUAL(multi.at(2, 1), 5, "Multidim top element went wrong.");
+  PQXX_CHECK_THROWS(multi.at(3, 0), pqxx::range_error, "Out-of-bounds on outer dimension was not detected.");
+  PQXX_CHECK_THROWS(multi.at(0, 2), pqxx::range_error, "Out-of-bounds on inner dimension was not detected.");
+  PQXX_CHECK_THROWS(multi.at(0, -1), pqxx::range_error, "Negative inner index was not detected.");
+  PQXX_CHECK_THROWS(multi.at(-1, 0), pqxx::range_error, "Negative outer index was not detected.");
 }
 
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -587,8 +587,7 @@ void test_array_rejects_malformed_simple_string_arrays()
     "{1,"sv,
     "{,}"sv,
     "{1,}"sv,
-    // XXX: This should fail!
-    //"{,1}"sv,
+    "{,1}"sv,
     "{1,{}}"sv,
    };
   for (auto bad : bad_arrays)

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -492,6 +492,33 @@ void test_array_strings()
 }
 
 
+void test_array_parses_real_array()
+{
+  pqxx::connection conn;
+  pqxx::work tx{conn};
+
+  auto const empty_s{tx.query_value<std::string>("SELECT ARRAY[]::integer[]")};
+  pqxx::array<int, 1> empty_a{empty_s, conn};
+  PQXX_CHECK_EQUAL(empty_a.dimensions(), 1u, "Unexpected dimension count for empty array.");
+  PQXX_CHECK_EQUAL(empty_a.sizes(), (std::array<std::size_t, 1>{0u}), "Unexpected sizes for empty array.");
+
+  auto const onedim_s{tx.query_value<std::string>("SELECT ARRAY[0, 1, 2]")};
+  pqxx::array<int, 1> onedim_a{onedim_s, conn};
+  PQXX_CHECK_EQUAL(empty_a.dimensions(), 1u, "Unexpected dimension count for one-dimensional array.");
+  PQXX_CHECK_EQUAL(empty_a.sizes(), (std::array<std::size_t, 1>{3u}), "Unexpected sizes for one-dimensional array.");
+  PQXX_CHECK_EQUAL(empty_a[0], 0, "Bad data in one-dimensional array.");
+  PQXX_CHECK_EQUAL(empty_a[2], 2, "Array started off OK but later data was bad.");
+
+  auto const null_s{tx.query_value<std::string>("SELECT ARRAY[NULL]::integer[]")};
+  PQXX_CHECK_THROWS((pqxx::array<int, 1>{null_s, conn}), pqxx::unexpected_null, "Not getting unexpected_null from array parser.");
+  // XXX: Test unexpected nulls.
+
+// XXX: Test multidim.
+}
+
+
+// XXX: Test empty array.
+
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);
 PQXX_REGISTER_TEST(test_array_double_quoted_string);
@@ -504,4 +531,5 @@ PQXX_REGISTER_TEST(test_nested_array_with_multiple_entries);
 PQXX_REGISTER_TEST(test_array_generate);
 PQXX_REGISTER_TEST(test_array_roundtrip);
 PQXX_REGISTER_TEST(test_array_strings);
+PQXX_REGISTER_TEST(test_array_parses_real_array);
 } // namespace

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -588,8 +588,8 @@ void test_array_rejects_malformed_twodimensional_arrays()
   pqxx::connection conn;
   std::string_view const bad_arrays[]{
     ""sv, "{}"sv, "{null}"sv,
-    // XXX:
-    // XXX: Test various kinds of irregular arrays.
+    // XXX: Test irregular array.
+    // XXX: Test null row.
   };
   for (auto bad : bad_arrays)
     PQXX_CHECK_THROWS(
@@ -597,7 +597,14 @@ void test_array_rejects_malformed_twodimensional_arrays()
       "No conversion_error for '" + std::string{bad} + "'.");
 }
 
-// XXX: Test strings with escaping.
+
+void test_array_parses_quoted_strings()
+{
+  pqxx::connection conn;
+  pqxx::array<std::string> const a{R"x({"\"'"})x", conn};
+  PQXX_CHECK_EQUAL(a[0], R"x("')x", "String in array did not unescape right.");
+}
+
 
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);
@@ -615,4 +622,5 @@ PQXX_REGISTER_TEST(test_array_parses_real_arrays);
 PQXX_REGISTER_TEST(test_array_rejects_malformed_simple_int_arrays);
 PQXX_REGISTER_TEST(test_array_rejects_malformed_simple_string_arrays);
 PQXX_REGISTER_TEST(test_array_rejects_malformed_twodimensional_arrays);
+PQXX_REGISTER_TEST(test_array_parses_quoted_strings);
 } // namespace


### PR DESCRIPTION
Fixes #590.

A new attempt at array parsing, making more use of promises SQL's array type makes:
* All elements are of the same type, so we build in conversion.
* Arrays are regularly sized: each row is as long as any other.  Each column is as long as any other.
* Rows or columns cannot be null.
* And therefore, an array starts with as many opening braces as it has dimensions.  (Same for closing braces.)