### PR TITLE
Use libpq's feature test macros.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -33,10 +33,6 @@ endif()
 check_function_exists("poll" PQXX_HAVE_POLL)
 
 set(CMAKE_REQUIRED_LIBRARIES pq)
-check_symbol_exists(
-	PQenterPipelineMode
-	"${PostgreSQL_INCLUDE_DIR}/libpq-fe.h"
-	PQXX_HAVE_PQ_PIPELINE)
 
 cmake_determine_compile_features(CXX)
 cmake_policy(SET CMP0057 NEW)

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -123,7 +123,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
+	config.sub install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/configitems
+++ b/configitems
@@ -15,7 +15,6 @@ PQXX_HAVE_LIKELY	public	compiler
 PQXX_HAVE_MULTIDIMENSIONAL_SUBSCRIPT	public	compiler
 PQXX_HAVE_PATH	public	compiler
 PQXX_HAVE_POLL       internal        compiler
-PQXX_HAVE_PQ_PIPELINE	internal	libpq
 PQXX_HAVE_SLEEP_FOR	internal	compiler
 PQXX_HAVE_SPAN	public	compiler
 PQXX_HAVE_STRERROR_R	internal	compiler

--- a/configure
+++ b/configure
@@ -18523,36 +18523,8 @@ fi
 
 
 
-# "Pipeline mode" was introduced in libpq 14.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libpq pipeline mode" >&5
-printf %s "checking for libpq pipeline mode... " >&6; }
-have_pq_pipeline=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include<libpq-fe.h>
-int
-main (void)
-{
-
-			extern PGconn *conn;
-			PQenterPipelineMode(conn)
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"
-then :
-
-printf "%s\n" "#define PQXX_HAVE_PQ_PIPELINE 1" >>confdefs.h
-
-else $as_nop
-  have_pq_pipeline=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_pq_pipeline" >&5
-printf "%s\n" "$have_pq_pipeline" >&6; }
+# TODO: PQresultMemorySize()
+# TODO: Use feature test macros in libpq-fe.h, should be faster & easier.
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for usable std::filesystem::path" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -619,25 +619,6 @@ occurring in the file.
 	${with_postgres_libpath})
 
 
-# "Pipeline mode" was introduced in libpq 14.
-AC_MSG_CHECKING([for libpq pipeline mode])
-have_pq_pipeline=yes
-AC_COMPILE_IFELSE(
-	[AC_LANG_PROGRAM(
-		[#include<libpq-fe.h>],
-		[
-			extern PGconn *conn;
-			PQenterPipelineMode(conn)
-		]
-	)],
-	AC_DEFINE(
-		[PQXX_HAVE_PQ_PIPELINE],
-		1,
-		[Define if libpq has pipeline mode (since pg 14).]),
-	[have_pq_pipeline=no])
-AC_MSG_RESULT($have_pq_pipeline)
-
-
 # TODO: PQresultMemorySize()
 # TODO: Use feature test macros in libpq-fe.h, should be faster & easier.
 

--- a/include/pqxx/config.h.in
+++ b/include/pqxx/config.h.in
@@ -90,9 +90,6 @@
 /* Define if poll() is available. */
 #undef PQXX_HAVE_POLL
 
-/* Define if libpq has pipeline mode (since pg 14). */
-#undef PQXX_HAVE_PQ_PIPELINE
-
 /* Define if std::this_thread::sleep_for works. */
 #undef PQXX_HAVE_SLEEP_FOR
 


### PR DESCRIPTION
As of libpq 14, libpq-fe.h defines macros for features available in its libpq version.  That means we won't be needing a `configure` check for `PQenterPipelineMode()` after all: we can just `#ifdef` it.