### PR TITLE
Deprecate `fieldstream` (and `basic_fieldstream`).

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - At last, streaming throughput is faster (on my system) than a regular query.
  - Deprecate `basic_fieldstream` and `fieldstream`.
+ - Deprecate `<<` operator inserting a field into an `ostream`.
  - Ran `autoupdate` (because the autotools told me to).
  - Documentation tweak. (#584)
  - Typo in README.md. (#586)

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@
  - Fix array parsing bug when parsing semicolon in an unquoted string.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - At last, streaming throughput is faster (on my system) than a regular query.
+ - Deprecate `basic_fieldstream` and `fieldstream`.
  - Ran `autoupdate` (because the autotools told me to).
  - Documentation tweak. (#584)
  - Typo in README.md. (#586)

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -476,8 +476,12 @@ private:
 using fieldstream = basic_fieldstream<char>;
 
 
-/// Write a result field to any type of stream
-/** This can be convenient when writing a field to an output stream.  More
+/// Write a result field to any type of stream.
+/** @deprecated The C++ streams library is not great to work with.  In
+ * particular, error handling is easy to get wrong.  So you're probably better
+ * off doing this by hand.
+ *
+ * This can be convenient when writing a field to an output stream.  More
  * importantly, it lets you write a field to e.g. a `stringstream` which you
  * can then use to read, format and convert the field in ways that to() does
  * not support.
@@ -498,6 +502,7 @@ using fieldstream = basic_fieldstream<char>;
  * ```
  */
 template<typename CHAR>
+[[deprecated("Do this by hand, probably with better error checking.")]]
 inline std::basic_ostream<CHAR> &
 operator<<(std::basic_ostream<CHAR> &s, field const &value)
 {

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -436,11 +436,16 @@ private:
 
 
 /// Input stream that gets its data from a result field
-/** Use this class exactly as you would any other istream to read data from a
- * field.  All formatting and streaming operations of `std::istream` are
- * supported.  What you'll typically want to use, however, is the fieldstream
- * alias (which defines a @ref basic_fieldstream for `char`).  This is similar
- * to how e.g. `std::ifstream` relates to `std::basic_ifstream`.
+/** @deprecated To convert a field's value string to some other type, e.g. to
+ * an `int`, use the field's `as<...>()` member function.  To read a field
+ * efficiently just as a string, use its `c_str()` or its
+ * `as<std::string_vview>()`.
+ *
+ * Works like any other istream to read data from a field.  It supports all
+ * formatting and streaming operations of `std::istream`.  For convenience
+ * there is a fieldstream alias, which defines a @ref basic_fieldstream for
+ * `char`.  This is similar to how e.g. `std::ifstream` relates to
+ * `std::basic_ifstream`.
  *
  * This class has only been tested for the char type (and its default traits).
  */
@@ -456,6 +461,7 @@ public:
   using pos_type = typename traits_type::pos_type;
   using off_type = typename traits_type::off_type;
 
+  [[deprecated("Use field::as<...>() or field::c_str().")]]
   basic_fieldstream(field const &f) : super{nullptr}, m_buf{f}
   {
     super::init(&m_buf);
@@ -465,7 +471,10 @@ private:
   field_streambuf<CHAR, TRAITS> m_buf;
 };
 
+
+/// @deprecated Read a field using `field::as<...>()` or `field::c_str()`.
 using fieldstream = basic_fieldstream<char>;
+
 
 /// Write a result field to any type of stream
 /** This can be convenient when writing a field to an output stream.  More

--- a/include/pqxx/transaction_focus.hxx
+++ b/include/pqxx/transaction_focus.hxx
@@ -22,7 +22,7 @@ namespace pqxx
  * that a given libpqxx class is derived from it.
  *
  * Pipelines, SQL statements, and data streams are examples of classes derived
- * from `transaction_focus`.  For any given transaction, only one object of
+ * from `transaction_focus`.  In any given transaction, only one object of
  * such a class can be active at any given time.
  */
 class PQXX_LIBEXPORT transaction_focus

--- a/test/test46.cxx
+++ b/test/test46.cxx
@@ -22,7 +22,9 @@ void test_046()
 
   // Read the value into a stringstream.
   std::stringstream I;
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   I << R[0];
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 
   // Now convert the stringstream into a numeric type
   long L{}, L2{};
@@ -33,7 +35,9 @@ void test_046()
 
   float F{}, F2{};
   std::stringstream I2;
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   I2 << R[0];
+#include "pqxx/internal/ignore-deprecated-post.hxx"
   I2 >> F;
   R[0].to(F2);
   PQXX_CHECK_BOUNDS(F2, F - 0.01, F + 0.01, "Bad floating-point result.");

--- a/test/test74.cxx
+++ b/test/test74.cxx
@@ -12,6 +12,7 @@ namespace
 {
 void test_074()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   connection conn;
   work tx{conn};
 
@@ -65,6 +66,7 @@ void test_074()
   PQXX_CHECK_BOUNDS(
     long_double_pi, roughpi - 0.00001, roughpi + 0.00001,
     "long double changed in conversion.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 } // namespace
 


### PR DESCRIPTION
There are several reasons for this:

First, of course, I doubt many projects use them.  On top of that they don't add all that much value: it'd be easy enough to do the same things _ad hoc._

And the C++ streams library is a bit whacky.  It needs an overhaul. Time to take a step back and decouple from details that may soon change.

Implementing stream classes is complicated, poorly documented, prone to mistakes, hard in maintenance.  And _using_ streams has similar problems, especially when it comes to error handling and unexpected conditions.  It's easy to get wrong.

Finally, besides pointless operator overloading it also adds pointless inheritance.  It's just not carrying that weight.