### PR TITLE
Iterate `pqxx::array`.

### DIFF
--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -85,7 +85,7 @@ public:
 
   template<typename... INDEX> ELEMENT const &at(INDEX... index) const
   {
-    assert(sizeof...(index) == DIMENSIONS);
+    static_assert(sizeof...(index) == DIMENSIONS);
     check_bounds(index...);
     return m_elts.at(locate(index...));
   }
@@ -101,7 +101,7 @@ public:
    */
   template<typename... INDEX> ELEMENT const &operator[](INDEX... index) const
   {
-    assert(sizeof...(index) == DIMENSIONS);
+    static_assert(sizeof...(index) == DIMENSIONS);
     return m_elts[locate(index...)];
   }
 
@@ -433,10 +433,10 @@ private:
     }
     else
     {
-      assert(sizeof...(indexes) < DIMENSIONS);
+      static_assert(sizeof...(indexes) < DIMENSIONS);
       // (Offset by 1 here because the outer dimension is not in there.)
       constexpr auto dimension{DIMENSIONS - (sizeof...(indexes) + 1)};
-      assert(dimension < DIMENSIONS);
+      static_assert(dimension < DIMENSIONS);
       return first * m_factors[dimension] + add_index(indexes...);
     }
   }
@@ -448,10 +448,10 @@ private:
   constexpr void check_bounds(OUTER outer, INDEX... indexes) const
   {
     std::size_t const first{check_cast<std::size_t>(outer, "array index"sv)};
-    assert(sizeof...(indexes) < DIMENSIONS);
+    static_assert(sizeof...(indexes) < DIMENSIONS);
     // (Offset by 1 here because the outer dimension is not in there.)
     constexpr auto dimension{DIMENSIONS - (sizeof...(indexes) + 1)};
-    assert(dimension < DIMENSIONS);
+    static_assert(dimension < DIMENSIONS);
     if (first >= m_extents[dimension])
       throw range_error{pqxx::internal::concat(
         "Array index for dimension ", dimension, " is out of bounds: ", first,

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -105,6 +105,57 @@ public:
     return m_elts[locate(index...)];
   }
 
+  /// Begin iteration of individual elements.
+  /** If this is a multi-dimensional array, iteration proceeds in row-major
+   * order.  So for example, a two-dimensional array `a` would start at
+   * `a[0, 0]`, then `a[0, 1]`, and so on.  Once it reaches the end of that
+   * first row, it moves on to element `a[1, 0]`, and continues from there.
+   */
+  constexpr auto cbegin() const noexcept { return m_elts.cbegin(); }
+  /// Return end point of iteration.
+  constexpr auto cend() const noexcept { return m_elts.cend(); }
+  /// Begin reverse iteration.
+  constexpr auto crbegin() const noexcept { return m_elts.crbegin(); }
+  /// Return end point of reverse iteration.
+  constexpr auto crend() const noexcept { return m_elts.crend(); }
+
+  /// Number of elements in the array.
+  /** This includes all elements, in all dimensions.  Therefore it is the
+   * product of all values in `sizes()`.
+   */
+  constexpr std::size_t size() const noexcept { return m_elts.size(); }
+
+  /// Number of elements in the array (as a signed number).
+  /** This includes all elements, in all dimensions.  Therefore it is the
+   * product of all values in `sizes()`.
+   *
+   * In principle, the size could get so large that it had no signed
+   * equivalent.  If that can ever happen, this is your own problem and
+   * behaviour is undefined.
+   *
+   * In practice however, I don't think `ssize()` could ever overflow.  You'd
+   * need an array where each element takes up just one byte, such as Booleans,
+   * filling up more than half your address space.  But the input string for
+   * that array would need at least two bytes per value: one for the value, one
+   * for the separating comma between elements.  So even then you wouldn't have
+   * enough address space to create the array, even if your system allowed you
+   * to use your full address space.
+   */
+  constexpr auto ssize() const noexcept
+  {
+    return static_cast<std::ptrdiff_t>(size());
+  }
+
+  /// Refer to the first element, if any.
+  /** If the array is empty, dereferencing this results in undefined behaviour.
+   */
+  constexpr auto front() const noexcept { return m_elts.front(); }
+
+  /// Refer to the last element, if any.
+  /** If the array is empty, dereferencing this results in undefined behaviour.
+   */
+  constexpr auto back() const noexcept { return m_elts.back(); }
+
 private:
   /// Throw an error if `data` is not a `DIMENSIONS`-dimensional SQL array.
   /** Sanity-checks two aspects of the array syntax: the opening braces at the


### PR DESCRIPTION
Further to the work on #590.

Implementing simple array iteration.  And when I say "simple," I really mean the simplest I could do: storage-order iteration, going through all dimensions.

The alternative would be to define something like a multidimensional subrange, and iterate over those.  In the two-dimensional case, that would be like iterating a `result` to get `row` elements, and then iterating each `row` to get the `field` elements.  But would it really be all that useful?  It's a lot of code overhead and cognitive load, both on the libpqxx side and on the application side.  I don't want all that complexity again — streaming queries have gotten us away from that for query results and it's been wonderful.  Plus, in practice, all you may want is to iterate over a one-dimensional array.  Or you may just want to visit all elements and not care at all about the order.

It may become easier once we have `std::mdspan`.  Depending on the conventions that form, we may have a problem on our hands with `size()`: is that going to be the size including all elements, or is it just the size along the outer of the dimensions?  The latter seems almost arbitrary.  We'll have to cross that bridge when we come to it.