### PR TITLE
Inline cursor `all()`/`backwards_all()`.

### DIFF
--- a/include/pqxx/cursor.hxx
+++ b/include/pqxx/cursor.hxx
@@ -101,12 +101,14 @@ public:
    */
   //@{
 
-  // TODO: Make constexpr inline (but breaks ABI).
   /// Special value: read until end.
   /** @return Maximum value for result::difference_type, so the cursor will
    * attempt to read the largest possible result set.
    */
-  [[nodiscard]] static difference_type all() noexcept;
+  [[nodiscard]] static constexpr difference_type all() noexcept
+  {
+    return (std::numeric_limits<int>::max)() - 1;
+  }
 
   /// Special value: read one row only.
   /** @return Unsurprisingly, 1.
@@ -125,7 +127,10 @@ public:
   /// Special value: read backwards from current position back to origin.
   /** @return Minimum value for result::difference_type.
    */
-  [[nodiscard]] static difference_type backward_all() noexcept;
+  [[nodiscard]] static constexpr difference_type backward_all() noexcept
+  {
+    return (std::numeric_limits<int>::min)() + 1;
+  }
 
   //@}
 

--- a/src/cursor.cxx
+++ b/src/cursor.cxx
@@ -24,22 +24,6 @@
 #include "pqxx/internal/header-post.hxx"
 
 
-pqxx::cursor_base::difference_type pqxx::cursor_base::all() noexcept
-{
-  // Implemented out-of-line so we don't fall afoul of Visual Studio defining
-  // min() and max() macros, which turn this expression into malformed code:
-  return std::numeric_limits<int>::max() - 1;
-}
-
-
-pqxx::cursor_base::difference_type pqxx::cursor_base::backward_all() noexcept
-{
-  // Implemented out-of-line so we don't fall afoul of Visual Studio defining
-  // min() and max() macros, which turn this expression into malformed code:
-  return std::numeric_limits<int>::min() + 1;
-}
-
-
 pqxx::cursor_base::cursor_base(
   connection &context, std::string_view Name, bool embellish_name) :
         m_name{embellish_name ? context.adorn_name(Name) : Name}


### PR DESCRIPTION
These were defined out-of-line in order to work around an incredibly long-standing Visual C++ bug: the trouble mentioning any function called `min()` or `max()` without preparatory preprocessor magic.

There is another way to work around this: parenthesise the function name.  Using this lets us declare the functions as inline, `constexpr`, and `noexcept` which should make them a little more efficient.