### PR TITLE
Make more `zview` constructors `noexcept`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  - Use `array_parser` only on comma-separated types, i.e. most of them. (#590)
  - Bumping requirements versions: need postgres 10.
  - Fix `array_parser` bug when parsing semicolon in an unquoted string.
+ - Make some `zview` constructors `noexcept` if `string_view` does it.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - At last, streaming throughput is faster (on my system) than a regular query.
  - Deprecate `basic_fieldstream` and `fieldstream`.

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -40,12 +40,14 @@ public:
   constexpr zview() noexcept = default;
 
   /// Convenience overload: construct using pointer and signed length.
-  constexpr zview(char const text[], std::ptrdiff_t len) :
+  constexpr zview(char const text[], std::ptrdiff_t len)
+    noexcept(noexcept(std::string_view{text, 0u})) :
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
   /// Convenience overload: construct using pointer and signed length.
-  constexpr zview(char text[], std::ptrdiff_t len) :
+  constexpr zview(char text[], std::ptrdiff_t len)
+    noexcept(noexcept(std::string_view{text, 0u})):
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
@@ -73,7 +75,8 @@ public:
    * do it many times, it's probably better to create the `zview` once and
    * re-use it.
    */
-  constexpr zview(char const str[]) : std::string_view{str} {}
+  constexpr zview(char const str[]) noexcept(noexcept(std::string_view{str})) :
+          std::string_view{str} {}
 
   /// Construct a `zview` from a string literal.
   /** A C++ string literal ("foo") normally looks a lot like a pointer to

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -41,13 +41,13 @@ public:
 
   /// Convenience overload: construct using pointer and signed length.
   constexpr zview(char const text[], std::ptrdiff_t len)
-    noexcept(noexcept(std::string_view{text, 0u})) :
+    noexcept(noexcept(std::string_view{text, static_cast<std::size_t>(len)})) :
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
   /// Convenience overload: construct using pointer and signed length.
   constexpr zview(char text[], std::ptrdiff_t len)
-    noexcept(noexcept(std::string_view{text, 0u})):
+    noexcept(noexcept(std::string_view{text, static_cast<std::size_t>(len)})):
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 


### PR DESCRIPTION
This is a silly problem to have.  In a way it's good.  Sometimes gcc
warns (and in my development builds, warnings are errors!) that some
`zview` constructors throw no errors, and would I perhaps like to slap
a `noexcept` on them?

A _fine_ idea, were it not for the facts that (1) `pqxx::zview` extends
`std::string_view`, and (2) the corresponding `string_view` constructor
does not have the `noexcept`.  So... can I make that promise myself?

Turns out I can.  Looking at gcc's `string_view` implementation I see
that it does declare those constructors as `noexcept`.  All I had to do
was declare my constructors as "`noexcept` provided that `string_view`
is okay with it.")