### PR TITLE
Use `std::memcpy()` in `stream_from`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,10 @@
 7.8.0
+ - Streaming large data sets now benchmarks faster than similar C/libpq code!
  - New `array` class for easier parsing of SQL arrays.
  - Use `array_parser` only on comma-separated types, i.e. most of them. (#590)
  - Bumping requirements versions: need postgres 10.
  - Fix `array_parser` bug when parsing semicolon in an unquoted string.
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
- - At last, streaming throughput is faster (on my system) than a regular query.
  - Deprecate `basic_fieldstream` and `fieldstream`.
  - Deprecate `<<` operator inserting a field into an `ostream`.
  - Ran `autoupdate` (because the autotools told me to).

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -316,12 +316,12 @@ inline stream_from::stream_from(
 template<typename Tuple> inline stream_from &stream_from::operator>>(Tuple &t)
 {
   if (m_finished)
-    return *this;
+    PQXX_UNLIKELY return *this;
   static constexpr auto tup_size{std::tuple_size_v<Tuple>};
   m_fields.reserve(tup_size);
   parse_line();
   if (m_finished)
-    return *this;
+    PQXX_UNLIKELY return *this;
 
   if (std::size(m_fields) != tup_size)
     throw usage_error{internal::concat(


### PR DESCRIPTION
This makes streaming queries just very slightly faster.  At most 5% or
so.  Nothing too impressive, but now that streaming queries are beating
similar libpq queries, I find myself really motivated to optimise it!