### PR TITLE
Unimportant ciso646-related tweaks.

### DIFF
--- a/config-tests/sleep_for.cxx
+++ b/config-tests/sleep_for.cxx
@@ -10,10 +10,6 @@
  * here.
  */
 
-#if __has_include(<ciso646>)
-#  include <ciso646>
-#endif
-
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>

--- a/include/pqxx/internal/header-pre.hxx
+++ b/include/pqxx/internal/header-pre.hxx
@@ -52,6 +52,7 @@
 // Workarounds & definitions that need to be included even in library's headers
 #include "pqxx/config-public-compiler.h"
 
+// C++20: No longer needed.
 // Enable ISO-646 alternative operaotr representations: "and" instead of "&&"
 // etc. on older compilers.  C++20 removes this header.
 #if __has_include(<ciso646>)


### PR DESCRIPTION
C++20 removes the `<ciso646>` header.  Prior to that, it was something you included "just in case."