### PR TITLE
Merge identical encoding groups.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@
  - Remove support for single-quoted array/composite elements.  No such thing!
  - Optimise out a kink in composite field parser.`
  - Work around build warning in MinGW: include `winsock2.h` before `windows.h`.
+ - Drop some redundant encoding groups.
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -209,7 +209,6 @@ private:
     case group::BIG5: parse<group::BIG5>(data); break;
     case group::EUC_CN: parse<group::EUC_CN>(data); break;
     case group::EUC_JP: parse<group::EUC_JP>(data); break;
-    case group::EUC_JIS_2004: parse<group::EUC_JIS_2004>(data); break;
     case group::EUC_KR: parse<group::EUC_KR>(data); break;
     case group::EUC_TW: parse<group::EUC_TW>(data); break;
     case group::GB18030: parse<group::GB18030>(data); break;
@@ -217,7 +216,6 @@ private:
     case group::JOHAB: parse<group::JOHAB>(data); break;
     case group::MULE_INTERNAL: parse<group::MULE_INTERNAL>(data); break;
     case group::SJIS: parse<group::SJIS>(data); break;
-    case group::SHIFT_JIS_2004: parse<group::SHIFT_JIS_2004>(data); break;
     case group::UHC: parse<group::UHC>(data); break;
     case group::UTF8: parse<group::UTF8>(data); break;
     }

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -277,8 +277,6 @@ composite_field_parser<T> specialize_parse_composite_field(encoding_group enc)
     return parse_composite_field<encoding_group::EUC_CN>;
   case encoding_group::EUC_JP:
     return parse_composite_field<encoding_group::EUC_JP>;
-  case encoding_group::EUC_JIS_2004:
-    return parse_composite_field<encoding_group::EUC_JIS_2004>;
   case encoding_group::EUC_KR:
     return parse_composite_field<encoding_group::EUC_KR>;
   case encoding_group::EUC_TW:
@@ -292,8 +290,6 @@ composite_field_parser<T> specialize_parse_composite_field(encoding_group enc)
     return parse_composite_field<encoding_group::MULE_INTERNAL>;
   case encoding_group::SJIS:
     return parse_composite_field<encoding_group::SJIS>;
-  case encoding_group::SHIFT_JIS_2004:
-    return parse_composite_field<encoding_group::SHIFT_JIS_2004>;
   case encoding_group::UHC: return parse_composite_field<encoding_group::UHC>;
   case encoding_group::UTF8:
     return parse_composite_field<encoding_group::UTF8>;

--- a/include/pqxx/internal/encoding_group.hxx
+++ b/include/pqxx/internal/encoding_group.hxx
@@ -25,18 +25,14 @@ enum class encoding_group
   // notably Big5, SJIS, SHIFT_JIS_2004, GP18030, GBK, JOHAB, UHC.
   BIG5,
   EUC_CN,
-  // TODO: Merge EUC_JP and EUC_JIS_2004?
   EUC_JP,
-  EUC_JIS_2004,
   EUC_KR,
   EUC_TW,
   GB18030,
   GBK,
   JOHAB,
   MULE_INTERNAL,
-  // TODO: Merge SJIS and SHIFT_JIS_2004?
   SJIS,
-  SHIFT_JIS_2004,
   UHC,
   UTF8,
 };

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -106,7 +106,7 @@ get_byte(char const buffer[], std::size_t offset) noexcept
 }
 
 
-PQXX_COLD [[noreturn]] void throw_for_encoding_error(
+[[noreturn]] PQXX_COLD void throw_for_encoding_error(
   char const *encoding_name, char const buffer[], std::size_t start,
   std::size_t count)
 {

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -178,7 +178,6 @@ array_parser::specialize_for_encoding(pqxx::internal::encoding_group enc)
     PQXX_ENCODING_CASE(BIG5);
     PQXX_ENCODING_CASE(EUC_CN);
     PQXX_ENCODING_CASE(EUC_JP);
-    PQXX_ENCODING_CASE(EUC_JIS_2004);
     PQXX_ENCODING_CASE(EUC_KR);
     PQXX_ENCODING_CASE(EUC_TW);
     PQXX_ENCODING_CASE(GB18030);
@@ -186,7 +185,6 @@ array_parser::specialize_for_encoding(pqxx::internal::encoding_group enc)
     PQXX_ENCODING_CASE(JOHAB);
     PQXX_ENCODING_CASE(MULE_INTERNAL);
     PQXX_ENCODING_CASE(SJIS);
-    PQXX_ENCODING_CASE(SHIFT_JIS_2004);
     PQXX_ENCODING_CASE(UHC);
     PQXX_ENCODING_CASE(UTF8);
   }

--- a/src/encodings.cxx
+++ b/src/encodings.cxx
@@ -64,7 +64,8 @@ pqxx::internal::encoding_group enc_group(std::string_view encoding_name)
         auto const subtype{encoding_name.substr(4)};
         static constexpr std::array<mapping, 5> subtypes{
           mapping{"CN"sv, pqxx::internal::encoding_group::EUC_CN},
-          mapping{"JIS_2004"sv, pqxx::internal::encoding_group::EUC_JIS_2004},
+	  // We support EUC_JIS_2004 and EUC_JP as identical encodings.
+          mapping{"JIS_2004"sv, pqxx::internal::encoding_group::EUC_JP},
           mapping{"JP"sv, pqxx::internal::encoding_group::EUC_JP},
           mapping{"KR"sv, pqxx::internal::encoding_group::EUC_KR},
           mapping{"TW"sv, pqxx::internal::encoding_group::EUC_TW},
@@ -127,7 +128,7 @@ pqxx::internal::encoding_group enc_group(std::string_view encoding_name)
       break;
     case 'S':
       if (encoding_name == "SHIFT_JIS_2004"sv)
-        return pqxx::internal::encoding_group::SHIFT_JIS_2004;
+        return pqxx::internal::encoding_group::SJIS;
       else if (encoding_name == "SJIS"sv)
         return pqxx::internal::encoding_group::SJIS;
       else if (encoding_name == "SQL_ASCII"sv)
@@ -187,7 +188,6 @@ PQXX_PURE glyph_scanner_func *get_glyph_scanner(encoding_group enc)
     CASE_GROUP(BIG5);
     CASE_GROUP(EUC_CN);
     CASE_GROUP(EUC_JP);
-    CASE_GROUP(EUC_JIS_2004);
     CASE_GROUP(EUC_KR);
     CASE_GROUP(EUC_TW);
     CASE_GROUP(GB18030);
@@ -195,7 +195,6 @@ PQXX_PURE glyph_scanner_func *get_glyph_scanner(encoding_group enc)
     CASE_GROUP(JOHAB);
     CASE_GROUP(MULE_INTERNAL);
     CASE_GROUP(SJIS);
-    CASE_GROUP(SHIFT_JIS_2004);
     CASE_GROUP(UHC);
     PQXX_LIKELY CASE_GROUP(UTF8);
   }


### PR DESCRIPTION
Four Japanese encoding groups were really just two encoding groups.