### PR TITLE
Handle status code for starting replication.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
  - Bumping requirements versions: need postgres 10.
  - Fix `array_parser` bug when parsing semicolon in an unquoted string.
  - Make some `zview` constructors `noexcept` if `string_view` does it.
+ - Handle result status code for starting streaming replication.  (#456)
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - Deprecate `basic_fieldstream` and `fieldstream`.
  - Deprecate `<<` operator inserting a field into an `ostream`.

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@
  - Bumping requirements versions: need postgres 10.
  - Fix `array_parser` bug when parsing semicolon in an unquoted string.
  - Make some `zview` constructors `noexcept` if `string_view` does it.
- - Handle result status code for starting streaming replication.  (#456)
+ - Handle result status code for starting streaming replication.  (#631)
  - Faster text decoding in `stream_from`, and escaping in `stream_to`.  (#601)
  - Deprecate `basic_fieldstream` and `fieldstream`.
  - Deprecate `<<` operator inserting a field into an `ostream`.

--- a/config-tests/sleep_for.cxx
+++ b/config-tests/sleep_for.cxx
@@ -20,7 +20,7 @@
 #include <thread>
 
 #if __has_include(<winsock2.h>)
-#include <winsock2.h>
+#  include <winsock2.h>
 #endif
 #if __has_include(<ws2tcpip.h>)
 #  include <ws2tcpip.h>

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -266,7 +266,8 @@ private:
     // Dirty trick: just count the number of bytes that look as if they may be
     // separators.  At the very worst we may overestimate by a factor of two or
     // so, in exceedingly rare cases, on some encodings.
-    auto const separators{std::count(std::begin(data), std::end(data), SEPARATOR)};
+    auto const separators{
+      std::count(std::begin(data), std::end(data), SEPARATOR)};
     // The number of dimensions makes no difference here.  It's still one
     // separator between consecutive elements, just possibly with some extra
     // braces as well.

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -461,8 +461,9 @@ public:
   using pos_type = typename traits_type::pos_type;
   using off_type = typename traits_type::off_type;
 
-  [[deprecated("Use field::as<...>() or field::c_str().")]]
-  basic_fieldstream(field const &f) : super{nullptr}, m_buf{f}
+  [[deprecated("Use field::as<...>() or field::c_str().")]] basic_fieldstream(
+    field const &f) :
+          super{nullptr}, m_buf{f}
   {
     super::init(&m_buf);
   }
@@ -502,9 +503,10 @@ using fieldstream = basic_fieldstream<char>;
  * ```
  */
 template<typename CHAR>
-[[deprecated("Do this by hand, probably with better error checking.")]]
-inline std::basic_ostream<CHAR> &
-operator<<(std::basic_ostream<CHAR> &s, field const &value)
+[[deprecated(
+  "Do this by hand, probably with better error checking.")]] inline std::
+  basic_ostream<CHAR> &
+  operator<<(std::basic_ostream<CHAR> &s, field const &value)
 {
   s.write(value.c_str(), std::streamsize(std::size(value)));
   return s;

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -89,7 +89,7 @@ inline std::string parse_double_quoted_string(
   // TODO: Use find_char<...>().
   using scanner = glyph_scanner<ENC>;
   auto here{scanner::call(input, end, pos)},
-       next{scanner::call(input, end, here)};
+    next{scanner::call(input, end, here)};
   while (here < end - 1)
   {
     // A backslash here is always an escape.  So is a double-quote, since we're
@@ -213,7 +213,8 @@ inline void parse_composite_field(
   default: {
     auto const stop{scan_unquoted_string<ENC, ',', ')', ']'>(
       std::data(input), std::size(input), pos)};
-    field = from_string<T>(std::string_view{std::data(input) + pos, stop - pos});
+    field =
+      from_string<T>(std::string_view{std::data(input) + pos, stop - pos});
     pos = stop;
   }
   break;

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -282,7 +282,8 @@ find_ascii_char(std::string_view haystack, std::size_t here)
     // for a match at each byte in the text, because it's faster than finding
     // character boundaries first.  But in these encodings, a multichar byte
     // never contains any bytes in the ASCII range at all.
-    if ((... or (data[here] == NEEDLE))) return here;
+    if ((... or (data[here] == NEEDLE)))
+      return here;
 
     // Nope, no hit.  Move on.
     here = next;

--- a/include/pqxx/internal/libpq-forward.hxx
+++ b/include/pqxx/internal/libpq-forward.hxx
@@ -9,7 +9,7 @@
  * mistake, or contact the author.
  */
 #if !defined(PQXX_H_LIBPQ_FORWARD)
-#define PQXX_H_LIBPQ_FORWARD
+#  define PQXX_H_LIBPQ_FORWARD
 
 extern "C"
 {

--- a/include/pqxx/version.hxx
+++ b/include/pqxx/version.hxx
@@ -9,11 +9,11 @@
  * mistake, or contact the author.
  */
 #if !defined(PQXX_H_VERSION)
-#define PQXX_H_VERSION
+#  define PQXX_H_VERSION
 
-#if !defined(PQXX_HEADER_PRE)
-#error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
-#endif
+#  if !defined(PQXX_HEADER_PRE)
+#    error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
+#  endif
 
 /// Full libpqxx version string.
 #  define PQXX_VERSION "7.8.0"

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -40,14 +40,14 @@ public:
   constexpr zview() noexcept = default;
 
   /// Convenience overload: construct using pointer and signed length.
-  constexpr zview(char const text[], std::ptrdiff_t len)
-    noexcept(noexcept(std::string_view{text, static_cast<std::size_t>(len)})) :
+  constexpr zview(char const text[], std::ptrdiff_t len) noexcept(
+    noexcept(std::string_view{text, static_cast<std::size_t>(len)})) :
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
   /// Convenience overload: construct using pointer and signed length.
-  constexpr zview(char text[], std::ptrdiff_t len)
-    noexcept(noexcept(std::string_view{text, static_cast<std::size_t>(len)})):
+  constexpr zview(char text[], std::ptrdiff_t len) noexcept(
+    noexcept(std::string_view{text, static_cast<std::size_t>(len)})) :
           std::string_view{text, static_cast<std::size_t>(len)}
   {}
 
@@ -76,7 +76,8 @@ public:
    * re-use it.
    */
   constexpr zview(char const str[]) noexcept(noexcept(std::string_view{str})) :
-          std::string_view{str} {}
+          std::string_view{str}
+  {}
 
   /// Construct a `zview` from a string literal.
   /** A C++ string literal ("foo") normally looks a lot like a pointer to

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -320,15 +320,26 @@ std::string pqxx::result::status_error() const
 
   case PGRES_COPY_OUT: // Copy Out (from server) data transfer started.
   case PGRES_COPY_IN:  // Copy In (to server) data transfer started.
+  case PGRES_COPY_BOTH: // Copy In/Out.  Used for streaming replication.
     break;
+
+  case PGRES_PIPELINE_SYNC: // Pipeline mode synchronisation point.
+  case PGRES_PIPELINE_ABORTED: // Previous command in pipeline failed.
+    throw feature_not_supported{"Not supported yet: libpq pipelines."};
 
   case PGRES_BAD_RESPONSE: // The server's response was not understood.
   case PGRES_NONFATAL_ERROR:
-  case PGRES_FATAL_ERROR: err = PQresultErrorMessage(m_data.get()); break;
+  case PGRES_FATAL_ERROR:
+    PQXX_UNLIKELY
+    err = PQresultErrorMessage(m_data.get());
+    break;
+
+  case PGRES_SINGLE_TUPLE:
+    throw feature_not_supported{"Not supported: single-row mode."};
 
   default:
     throw internal_error{internal::concat(
-      "pqxx::result: Unrecognized response code ",
+      "pqxx::result: Unrecognized result status code ",
       PQresultStatus(m_data.get()))};
   }
   return err;

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -318,12 +318,12 @@ std::string pqxx::result::status_error() const
   case PGRES_TUPLES_OK:   // The query successfully executed.
     break;
 
-  case PGRES_COPY_OUT: // Copy Out (from server) data transfer started.
-  case PGRES_COPY_IN:  // Copy In (to server) data transfer started.
+  case PGRES_COPY_OUT:  // Copy Out (from server) data transfer started.
+  case PGRES_COPY_IN:   // Copy In (to server) data transfer started.
   case PGRES_COPY_BOTH: // Copy In/Out.  Used for streaming replication.
     break;
 
-  case PGRES_PIPELINE_SYNC: // Pipeline mode synchronisation point.
+  case PGRES_PIPELINE_SYNC:    // Pipeline mode synchronisation point.
   case PGRES_PIPELINE_ABORTED: // Previous command in pipeline failed.
     throw feature_not_supported{"Not supported yet: libpq pipelines."};
 

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -190,8 +190,7 @@ char unescape_char(char escaped)
     return '\t';
   case 'v': // Vertical tab.
     return '\v';
-  default:
-    break;
+  default: break;
   }
   // Regular character ("self-escaped").
   return escaped;

--- a/test/test_types.hxx
+++ b/test/test_types.hxx
@@ -2,19 +2,19 @@
  * Custom types for testing & libpqxx support those types
  */
 #if !defined(PQXX_H_TEST_TYPES)
-#define PQXX_H_TEST_TYPES
+#  define PQXX_H_TEST_TYPES
 
-#include <pqxx/strconv>
+#  include <pqxx/strconv>
 
-#include <cstdint>
-#include <cstdio>
-#include <cstring>
-#include <exception>
-#include <iomanip>
-#include <regex>
-#include <sstream>
-#include <string>
-#include <vector>
+#  include <cstdint>
+#  include <cstdio>
+#  include <cstring>
+#  include <exception>
+#  include <iomanip>
+#  include <regex>
+#  include <sstream>
+#  include <string>
+#  include <vector>
 
 
 namespace pqxx


### PR DESCRIPTION
See #456.  Starting streaming replication was not something people were using libpqxx for.  There's a new (well... _relatively_ of course) result status code for that, which we weren't handling yet.

Also added the other "new" status codes, and more helpful errors.