### PR TITLE
Work around mysterious warning.

### DIFF
--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -149,8 +149,8 @@ void test_transaction_query01()
   pqxx::connection c;
   pqxx::work w{c};
 
-  std::optional<std::tuple<int>> o;
-  o = w.query01<int>("SELECT * FROM generate_series(1, 1) AS i WHERE i = 5");
+  std::optional<std::tuple<int>> o{
+    w.query01<int>("SELECT * FROM generate_series(1, 1) AS i WHERE i = 5")};
   PQXX_CHECK(not o.has_value(), "Why did we get a row?");
   o = w.query01<int>("SELECT * FROM generate_series(8, 8)");
   PQXX_CHECK(o.has_value(), "Why did we not get a row?");


### PR DESCRIPTION
Got a strange "may be used uninitialized" warning while compiling on Debian with gcc 10.2.1, in maintainer mode.  This fixes it.