### PR TITLE
Check for errors after poll/select/WSAPoll.

### DIFF
--- a/configitems
+++ b/configitems
@@ -17,8 +17,8 @@ PQXX_HAVE_PATH	public	compiler
 PQXX_HAVE_POLL       internal        compiler
 PQXX_HAVE_SLEEP_FOR	internal	compiler
 PQXX_HAVE_SPAN	public	compiler
-PQXX_HAVE_STRERROR_R	internal	compiler
-PQXX_HAVE_STRERROR_S	internal	compiler
+PQXX_HAVE_STRERROR_R	public	compiler
+PQXX_HAVE_STRERROR_S	public	compiler
 PQXX_HAVE_THREAD_LOCAL       internal        compiler
 PQXX_HAVE_UNREACHABLE	public	compiler
 PQXX_HAVE_YEAR_MONTH_DAY	public	compiler

--- a/include/pqxx/cursor.hxx
+++ b/include/pqxx/cursor.hxx
@@ -123,7 +123,6 @@ public:
     return -1;
   }
 
-  // TODO: Make constexpr inline (but breaks ABI).
   /// Special value: read backwards from current position back to origin.
   /** @return Minimum value for result::difference_type.
    */

--- a/src/wait.cxx
+++ b/src/wait.cxx
@@ -2,6 +2,8 @@
  */
 #include "pqxx-source.hxx"
 
+#include <array>
+
 // For WSAPoll().
 // Normally we'd do this *after* including <thread>, but MinGW complains: it
 // issues a warning telling us to include winsock2.h before windows.h.


### PR DESCRIPTION
This was never urgent, because if waiting for a socket fails, the operation which the caller is waiting to perform will normally also fail.  (And if not... why report an error really?)

But, it's probably nicer to check for errors and report them.