### PR TITLE
Enable gcc static analysis in maintainer mode.

### DIFF
--- a/configure
+++ b/configure
@@ -17222,7 +17222,27 @@ then
 
 		# "Iffy" g++ options.  Some reasonably current g++-like
 		# compilers may not support these.
+# TODO: Once false positive in std lib is fixed, simplify to "-fanalyzer".
 		add_compiler_opts_if_ok \
+			-Wanalyzer-double-fclose \
+			-Wanalyzer-double-free \
+			-Wanalyzer-exposure-through-output-file \
+			-Wanalyzer-file-leak \
+			-Wanalyzer-free-of-non-heap \
+			-Wanalyzer-malloc-leak \
+			-Wanalyzer-mismatching-deallocation \
+			-Wanalyzer-null-dereference \
+			-Wanalyzer-null-argument \
+			-Wanalyzer-possible-null-argument \
+			-Wanalyzer-shift-count-negative \
+			-Wanalyzer-overflow \
+			-Wanalyzer-stale-setjmp-buffer \
+			-Wanalyzer-unsafe-call-within-signal-handler \
+			-Wanalyzer-use-after-free \
+			-Wanalyzer-use-of-pointer-in-stale-stack-frame \
+			-Wanalyzer-use-of-uninitialized-value \
+			-Wanalyzer-write-to-const \
+			-Wanalyzer-write-to-string-literal \
 			-fnothrow-opt \
 			-Wattribute-alias=2 \
 			-Wextra-semi \

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,27 @@ then
 
 		# "Iffy" g++ options.  Some reasonably current g++-like
 		# compilers may not support these.
+# TODO: Once false positive in std lib is fixed, simplify to "-fanalyzer".
 		add_compiler_opts_if_ok \
+			-Wanalyzer-double-fclose \
+			-Wanalyzer-double-free \
+			-Wanalyzer-exposure-through-output-file \
+			-Wanalyzer-file-leak \
+			-Wanalyzer-free-of-non-heap \
+			-Wanalyzer-malloc-leak \
+			-Wanalyzer-mismatching-deallocation \
+			-Wanalyzer-null-dereference \
+			-Wanalyzer-null-argument \
+			-Wanalyzer-possible-null-argument \
+			-Wanalyzer-shift-count-negative \
+			-Wanalyzer-overflow \
+			-Wanalyzer-stale-setjmp-buffer \
+			-Wanalyzer-unsafe-call-within-signal-handler \
+			-Wanalyzer-use-after-free \
+			-Wanalyzer-use-of-pointer-in-stale-stack-frame \
+			-Wanalyzer-use-of-uninitialized-value \
+			-Wanalyzer-write-to-const \
+			-Wanalyzer-write-to-string-literal \
 			-fnothrow-opt \
 			-Wattribute-alias=2 \
 			-Wextra-semi \


### PR DESCRIPTION
This should allow the compiler to find more bugs.

Unfortunately when I just enabled `-fanalyzer`, it found two potential null dereferences that I don't think I could fix.  I saw no mention of libpqxx code, only standard-library code, which makes it very hard to debug on my end.

Luckily the type was a giveaway: `std::vector<pqxx::zview>`.  The only item of that type is `pqxx::stream_from::m_fields`.  I just deprecated that entire class.

For now, I enabled all documented analyzers in gcc... except that one.