### PR TITLE
Fallback to pkg-config when libpq is not found with CMake.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -23,11 +23,16 @@ if(NOT PostgreSQL_FOUND)
         cmake_policy(SET CMP0074 NEW)
     endif()
 
-    find_package(PostgreSQL REQUIRED)
+    find_package(PostgreSQL)
 
     if(POLICY CMP0074)
         cmake_policy(POP)
     endif()
+endif()
+
+if(NOT PostgreSQL_FOUND)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(PostgreSQL REQUIRED libpq)
 endif()
 
 check_function_exists("poll" PQXX_HAVE_POLL)


### PR DESCRIPTION
Hi,

I think CMake support for libpq is quite new and not available on all systems. It might become obsolete at some point, but for now it might be desirable to offer a fallback for finding libpq with pkg-config, which should be available on many systems.

I am not exactly sure why a policy is required for PostgreSQL, so I moved the new stuff to a separate block.

Best regards,
Sebastian