### PR TITLE
Add `<pqxx/range>` and `<pqxx/time>` headers to `<pqxx/pqxx>`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,7 @@
  - Drop some redundant encoding groups.
  - If CMake can't find libpq, fall back to pkg-config. (#664)
  - Work around spurious compile error on g++ pre-gcc-10. (#665)
+ - Include `<pqxx/range>` and `<pqxx/time>` headers in `<pqxx/pqxx>`. (#667)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -123,7 +123,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub install-sh ltmain.sh missing mkinstalldirs
+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/include/pqxx/pqxx
+++ b/include/pqxx/pqxx
@@ -14,6 +14,7 @@
 #include "pqxx/params.hxx"
 #include "pqxx/pipeline.hxx"
 #include "pqxx/prepared_statement.hxx"
+#include "pqxx/range.hxx"
 #include "pqxx/result.hxx"
 #include "pqxx/internal/result_iterator.hxx"
 #include "pqxx/internal/result_iter.hxx"
@@ -22,6 +23,7 @@
 #include "pqxx/stream_from.hxx"
 #include "pqxx/stream_to.hxx"
 #include "pqxx/subtransaction.hxx"
+#include "pqxx/time.hxx"
 #include "pqxx/transaction.hxx"
 #include "pqxx/transactor.hxx"
 


### PR DESCRIPTION
Fixes #667.