### PR TITLE
Add `<pqxx/range>` & `<pqxx/time>` headers to `<pqxx/pqxx>`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 7.7.5
  - Fix missing internal headers in `configure`-based install. (#657)
+ - Include `<pqxx/range>` and `<pqxx/time>` headers in `<pqxx/pqxx>`. (#667)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/pqxx
+++ b/include/pqxx/pqxx
@@ -14,6 +14,7 @@
 #include "pqxx/params.hxx"
 #include "pqxx/pipeline.hxx"
 #include "pqxx/prepared_statement.hxx"
+#include "pqxx/range.hxx"
 #include "pqxx/result.hxx"
 #include "pqxx/internal/result_iterator.hxx"
 #include "pqxx/internal/result_iter.hxx"
@@ -22,6 +23,7 @@
 #include "pqxx/stream_from.hxx"
 #include "pqxx/stream_to.hxx"
 #include "pqxx/subtransaction.hxx"
+#include "pqxx/time.hxx"
 #include "pqxx/transaction.hxx"
 #include "pqxx/transactor.hxx"
 


### PR DESCRIPTION
Fixes #667 in the 7.7 series.