### PR TITLE
WIP: Add MSVC runtime checks in audit mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,21 @@ if(BUILD_TEST)
     add_subdirectory(test)
 endif()
 
-# installation
+
+add_compile_definitions(
+    # In Debug mode, we enable MSVC's iterator debugging.  Other compilers may
+    # support this as well, and it shouldn't do any harm on others, so just
+    # define it regardless of the compiler.
+    $<CONFIG:DEBUG>:_ITERATOR_DEBUG_LEVEL=2
+)
+# XXX: Why can't I make add_compile_options() do anything for me at all?
+add_compile_options(
+-march=wuicxkewl
+    # In Debug mode on MSVC, enable a few compile-time checks.
+    #$<AND:$<CONFIG:DEBUG>,$<CXX_COMPILER_ID:MSVC>>"/Wanalyze /guard:cf"
+)
+
+# Installation
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/libpqxx-config-version.cmake"
     VERSION ${PROJECT_VERSION}

--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,8 @@ then
 	# Run-time check options for Visual Studio.
 	add_compiler_opts_if_ok \
 		/analyze \
-		/D_ITERATOR_DEBUG_LEVEL=2
+		/D_ITERATOR_DEBUG_LEVEL=2 \
+		/guard:cf
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -286,6 +286,17 @@ AC_MSG_RESULT($gcc_pure)
 fi # End of gcc-specific part.
 
 
+# In "audit," enable all runtime checks we can.
+if test "$enable_audit" = "yes"
+then
+	# Run-time check options for Visual Studio.
+	add_compiler_opts_if_ok \
+		/analyze \
+		/D_ITERATOR_DEBUG_LEVEL=2
+fi
+
+
+
 # Check for __cxa_demangle.
 AC_MSG_CHECKING([__cxa_demangle])
 cxa_demangle=yes


### PR DESCRIPTION
I tried adding these on the cmake command line, but that didn't work for some reason.  But really, audit mode is a good place for them.