### PR TITLE
Fix `std::functional` problems.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@
  - If CMake can't find libpq, fall back to pkg-config. (#664)
  - Work around spurious compile error on g++ pre-gcc-10. (#665)
  - Include `<pqxx/range>` and `<pqxx/time>` headers in `<pqxx/pqxx>`. (#667)
+ - Don't use `std::function` as deleter for smart pointers.
+ - Work around gcc compile error with regex + address sanitizer + analyzers.
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <ctime>
-#include <functional>
 #include <initializer_list>
 #include <list>
 #include <map>
@@ -1056,7 +1055,7 @@ private:
   void PQXX_PRIVATE unregister_transaction(transaction_base *) noexcept;
 
   friend struct internal::gate::connection_stream_from;
-  std::pair<std::unique_ptr<char, std::function<void(char *)>>, std::size_t>
+  std::pair<std::unique_ptr<char, void(*)(void const *)>, std::size_t>
   read_copy_line();
 
   friend class internal::gate::connection_stream_to;

--- a/include/pqxx/internal/libpq-forward.hxx
+++ b/include/pqxx/internal/libpq-forward.hxx
@@ -25,6 +25,9 @@ using PGconn = pg_conn;
 using PGresult = pg_result;
 using PGnotify = pgNotify;
 using PQnoticeProcessor = void (*)(void *, char const *);
+
+/// Wrapper for `PQfreemem()`, but with C++ linkage.
+void pqfreemem(void const *);
 } // namespace pqxx::internal::pq
 
 namespace pqxx

--- a/include/pqxx/internal/libpq-forward.hxx
+++ b/include/pqxx/internal/libpq-forward.hxx
@@ -25,9 +25,6 @@ using PGconn = pg_conn;
 using PGresult = pg_result;
 using PGnotify = pgNotify;
 using PQnoticeProcessor = void (*)(void *, char const *);
-
-/// Wrapper for `PQfreemem()`, but with C++ linkage.
-void pqfreemem(void const *);
 } // namespace pqxx::internal::pq
 
 namespace pqxx

--- a/include/pqxx/internal/statement_parameters.hxx
+++ b/include/pqxx/internal/statement_parameters.hxx
@@ -14,7 +14,6 @@
 #define PQXX_H_STATEMENT_PARAMETER
 
 #include <cstring>
-#include <functional>
 #include <iterator>
 #include <string>
 #include <vector>

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -79,7 +79,7 @@ class stream_query_end_iterator
 template<typename... TYPE> class stream_query : transaction_focus
 {
 public:
-  using line_handle = std::unique_ptr<char, std::function<void(char *)>>;
+  using line_handle = std::unique_ptr<char, void(*)(void const *)>;
 
   /// Execute `query` on `tx`, stream results.
   inline stream_query(transaction_base &tx, std::string_view query);

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -44,7 +44,12 @@ template<typename... TYPE> class stream_query_input_iterator
 public:
   using value_type = std::tuple<TYPE...>;
 
-  explicit stream_query_input_iterator(stream_t &home) : m_home(home)
+  explicit stream_query_input_iterator(stream_t &home) :
+    m_home(home),
+    m_line{
+      typename stream_query<TYPE...>::line_handle(
+        nullptr, pqxx::internal::pq::pqfreemem)
+    }
   {
     consume_line();
   }

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -18,7 +18,6 @@
 #endif
 
 #include <cassert>
-#include <functional>
 #include <variant>
 
 #include "pqxx/connection.hxx"
@@ -80,7 +79,7 @@ class PQXX_LIBEXPORT stream_from : transaction_focus
 {
 public:
   using raw_line =
-    std::pair<std::unique_ptr<char, std::function<void(char *)>>, std::size_t>;
+    std::pair<std::unique_ptr<char, void(*)(void const *)>, std::size_t>;
 
   /// Factory: Execute query, and stream the results.
   /** The query can be a SELECT query or a VALUES query; or it can be an

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -593,4 +593,11 @@ error_string(int err_num, std::array<char, BYTES> &buffer)
 #endif
 }
 } // namespace pqxx::internal
+
+
+namespace pqxx::internal::pq
+{
+/// Wrapper for `PQfreemem()`, with C++ linkage.
+PQXX_LIBEXPORT void pqfreemem(void const *) noexcept;
+} // namespace pqxx::internal::pq
 #endif

--- a/src/binarystring.cxx
+++ b/src/binarystring.cxx
@@ -49,8 +49,8 @@ PQXX_COLD pqxx::binarystring::binarystring(field const &F)
 {
   unsigned char const *data{
     reinterpret_cast<unsigned char const *>(F.c_str())};
-  m_buf =
-    std::shared_ptr<unsigned char>{PQunescapeBytea(data, &m_size), PQfreemem};
+  m_buf = std::shared_ptr<unsigned char>{
+    PQunescapeBytea(data, &m_size), pqxx::internal::pq::pqfreemem};
   if (m_buf == nullptr)
     throw std::bad_alloc{};
 }

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -80,16 +80,6 @@ extern "C"
 using namespace std::literals;
 
 
-namespace pqxx::internal::pq
-{
-/// Wrapper for `PQfreemem`, with C++ linkage.
-void pqfreemem(void const *ptr)
-{
-  PQfreemem(const_cast<void *>(ptr));
-}
-} // namespace pqxx::internal::pq
-
-
 std::string PQXX_COLD
 pqxx::encrypt_password(char const user[], char const password[])
 {

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -79,11 +79,22 @@ extern "C"
 
 using namespace std::literals;
 
+
+namespace pqxx::internal::pq
+{
+/// Wrapper for `PQfreemem`, with C++ linkage.
+void pqfreemem(void const *ptr)
+{
+  PQfreemem(const_cast<void *>(ptr));
+}
+} // namespace pqxx::internal::pq
+
+
 std::string PQXX_COLD
 pqxx::encrypt_password(char const user[], char const password[])
 {
-  std::unique_ptr<char, std::function<void(char *)>> p{
-    PQencryptPassword(password, user), PQfreemem};
+  std::unique_ptr<char, void(*)(void const *)> p{
+    PQencryptPassword(password, user), pqxx::internal::pq::pqfreemem};
   return {p.get()};
 }
 
@@ -464,10 +475,20 @@ bool pqxx::connection::is_busy() const noexcept
 }
 
 
+namespace
+{
+/// Wrapper for `PQfreeCancel`, with C++ linkage.
+void wrap_pgfreecancel(PGcancel *ptr)
+{
+  PQfreeCancel(ptr);
+}
+} // namespace
+
+
 void PQXX_COLD pqxx::connection::cancel_query()
 {
-  using pointer = std::unique_ptr<PGcancel, std::function<void(PGcancel *)>>;
-  pointer cancel{PQgetCancel(m_conn), PQfreeCancel};
+  std::unique_ptr<PGcancel, void(*)(PGcancel *)> cancel{
+    PQgetCancel(m_conn), wrap_pgfreecancel};
   if (cancel == nullptr)
     PQXX_UNLIKELY
   throw std::bad_alloc{};
@@ -529,13 +550,13 @@ pqxx::connection::set_verbosity(error_verbosity verbosity) &noexcept
 namespace
 {
 /// Unique pointer to PGnotify.
-using notify_ptr = std::unique_ptr<PGnotify, std::function<void(PGnotify *)>>;
+using notify_ptr = std::unique_ptr<PGnotify, void(*)(void const *)>;
 
 
 /// Get one notification from a connection, or null.
 notify_ptr get_notif(pqxx::internal::pq::PGconn *conn)
 {
-  return notify_ptr(PQnotifies(conn), PQfreemem);
+  return notify_ptr(PQnotifies(conn), pqxx::internal::pq::pqfreemem);
 }
 } // namespace
 
@@ -680,8 +701,8 @@ std::string pqxx::connection::encrypt_password(
   char const user[], char const password[], char const *algorithm)
 {
   auto const buf{PQencryptPasswordConn(m_conn, password, user, algorithm)};
-  std::unique_ptr<char const, std::function<void(char const *)>> ptr{
-    buf, [](char const *x) { PQfreemem(const_cast<char *>(x)); }};
+  std::unique_ptr<char const, void(*)(void const *)> ptr{
+    buf, pqxx::internal::pq::pqfreemem};
   return std::string(ptr.get());
 }
 
@@ -800,7 +821,7 @@ void pqxx::connection::unregister_transaction(transaction_base *t) noexcept
 }
 
 
-std::pair<std::unique_ptr<char, std::function<void(char *)>>, std::size_t>
+std::pair<std::unique_ptr<char, void(*)(void const *)>, std::size_t>
 pqxx::connection::read_copy_line()
 {
   char *buf{nullptr};
@@ -817,7 +838,10 @@ pqxx::connection::read_copy_line()
 
   case -1: // End of COPY.
     make_result(PQgetResult(m_conn), q, *q);
-    return {};
+    return std::make_pair(
+      std::unique_ptr<char, void(*)(void const *)>{
+        nullptr, pqxx::internal::pq::pqfreemem},
+	0u);
 
   case 0: // "Come back later."
     throw internal_error{"table read inexplicably went asynchronous"};
@@ -828,7 +852,8 @@ pqxx::connection::read_copy_line()
       // Line size includes a trailing zero, which we ignore.
       auto const text_len{static_cast<std::size_t>(line_len) - 1};
       return std::make_pair(
-        std::unique_ptr<char, std::function<void(char *)>>{buf, PQfreemem},
+        std::unique_ptr<char, void(*)(void const *)>{
+	  buf, pqxx::internal::pq::pqfreemem},
         text_len);
     }
   }
@@ -939,8 +964,8 @@ std::string PQXX_COLD pqxx::connection::unesc_raw(char const text[]) const
     std::size_t len;
     auto bytes{const_cast<unsigned char *>(
       reinterpret_cast<unsigned char const *>(text))};
-    std::unique_ptr<unsigned char, std::function<void(unsigned char *)>> const
-      ptr{PQunescapeBytea(bytes, &len), PQfreemem};
+    std::unique_ptr<unsigned char, void(*)(void const *)> const
+      ptr{PQunescapeBytea(bytes, &len), pqxx::internal::pq::pqfreemem};
     return std::string{ptr.get(), ptr.get() + len};
   }
 }
@@ -974,9 +999,9 @@ std::string pqxx::connection::quote(std::basic_string_view<std::byte> b) const
 
 std::string pqxx::connection::quote_name(std::string_view identifier) const
 {
-  std::unique_ptr<char, std::function<void(char *)>> buf{
+  std::unique_ptr<char, void(*)(void const *)> buf{
     PQescapeIdentifier(m_conn, identifier.data(), std::size(identifier)),
-    PQfreemem};
+    pqxx::internal::pq::pqfreemem};
   if (buf.get() == nullptr)
     PQXX_UNLIKELY
   throw failure{err_msg()};
@@ -1152,6 +1177,13 @@ char const *get_default(PQconninfoOption const &opt) noexcept
   // The environment variable is the prevailing default.
   return var;
 }
+
+
+/// Wrapper for `PQconninfoFree()`, with C++ linkage.
+void pqconninfofree(PQconninfoOption *ptr)
+{
+  PQconninfoFree(ptr);
+}
 } // namespace
 
 
@@ -1161,9 +1193,8 @@ std::string pqxx::connection::connection_string() const
     PQXX_UNLIKELY
   throw usage_error{"Can't get connection string: connection is not open."};
 
-  std::unique_ptr<
-    PQconninfoOption, std::function<void(PQconninfoOption *)>> const params{
-    PQconninfo(m_conn), PQconninfoFree};
+  std::unique_ptr<PQconninfoOption, void(*)(PQconninfoOption *)>
+    const params{PQconninfo(m_conn), pqconninfofree};
   if (params.get() == nullptr)
     PQXX_UNLIKELY
   throw std::bad_alloc{};

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -128,7 +128,8 @@ pqxx::stream_from::raw_line pqxx::stream_from::get_raw_line()
   }
   else
   {
-    return {};
+    return std::make_pair(
+      std::unique_ptr<char, void(*)(void const *)>{nullptr, nullptr}, 0u);
   }
 }
 

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -198,6 +198,8 @@ namespace pqxx::internal::pq
 {
 void pqfreemem(void const *ptr) noexcept
 {
+  // Why is it OK to const_cast here?  Because this is the C equivalent to a
+  // destructor.  Those apply to const objects as well as non-const ones.
   PQfreemem(const_cast<void *>(ptr));
 }
 } // namespace pqxx::internal::pq

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -192,3 +192,12 @@ pqxx::internal::unesc_bin(std::string_view escaped_data)
   unesc_bin(escaped_data, buf.data());
   return buf;
 }
+
+
+namespace pqxx::internal::pq
+{
+void pqfreemem(void const *ptr) noexcept
+{
+  PQfreemem(const_cast<void *>(ptr));
+}
+} // namespace pqxx::internal::pq

--- a/test/test_types.hxx
+++ b/test/test_types.hxx
@@ -133,10 +133,11 @@ template<> struct string_traits<ipv4>
     std::size_t start{0};
     for (int i{0}; i < 4; ++i)
     {
-      std::string_view digits{&text[start], ends[i] - start};
+      auto idx{static_cast<std::size_t>(i)};
+      std::string_view digits{&text[start], ends[idx] - start};
       auto value{pqxx::from_string<uint32_t>(digits)};
       ts.set_byte(i, value);
-      start = ends[i] + 1;
+      start = ends[idx] + 1;
     }
     return ts;
   }

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -420,7 +420,7 @@ namespace
 /** This is just here to stop Visual Studio from advertising its own
  * alternative.
  */
-std::unique_ptr<FILE, std::function<int(FILE *)>>
+std::unique_ptr<FILE, int(*)(FILE *)>
 my_fopen(char const *path, char const *mode)
 {
 #if defined(_MSC_VER)


### PR DESCRIPTION
Thanks @KayEss for pointing out that I shouldn't be using a `std::function` as a deleter for a `std::unique_ptr`.  Using ordinary function pointers instead.

Also, finally figured out how to work around a bunch of gcc compile errors when I combined...
* The address sanitizer or "asan" (`-fsanitize=address`).
* Warnings as errors (`-Werror`).
* Uninitialized analyzer (`-Wanalyzer-use-of-uninitialized-value`).

Unfortunately, the combination of audit mode (`--enable-audit` in the `configure` script) and maintainer mode (`--enable-maintainer-mode` in the `configure` script) got us into exactly that combination.

It would seem that there's a problem with gcc.  It doesn't happen in clang.  I worked around it by replacing the one regex in the code with a manual parsing loop like I used to have.