### PR TITLE
Fix "double free" crash when building as shared.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,7 @@
  - Include `<pqxx/range>` and `<pqxx/time>` headers in `<pqxx/pqxx>`. (#667)
  - Don't use `std::function` as deleter for smart pointers.
  - Work around gcc compile error with regex + address sanitizer + analyzers.
+ - Fix "double free" on exit when built as shared library on Debian. (#681)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -1217,7 +1217,8 @@ template<typename T> inline std::string to_string(T const &value)
 {
   if (is_null(value))
     throw conversion_error{
-      "Attempt to convert null " + type_name<T> + " to a string."};
+      "Attempt to convert null " + std::string{type_name<T>} +
+      " to a string."};
 
   std::string buf;
   // We can't just reserve() space; modifying the terminating zero leads to

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -299,7 +299,7 @@ private:
 #define PQXX_DECLARE_ENUM_CONVERSION(ENUM)                                    \
   template<> struct string_traits<ENUM> : pqxx::internal::enum_traits<ENUM>   \
   {};                                                                         \
-  template<> std::string const type_name<ENUM> { #ENUM }
+  template<> inline std::string_view const type_name<ENUM> { #ENUM }
 
 
 namespace pqxx

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -280,6 +280,10 @@ private:
 } // namespace pqxx::internal
 
 
+// We used to inline type_name<ENUM>, but this triggered a "double free" error
+// on program exit, when libpqxx was built as a shared library on Debian with
+// gcc 12.
+
 /// Macro: Define a string conversion for an enum type.
 /** This specialises the @c pqxx::string_traits template, so use it in the
  * @c ::pqxx namespace.
@@ -295,10 +299,7 @@ private:
 #define PQXX_DECLARE_ENUM_CONVERSION(ENUM)                                    \
   template<> struct string_traits<ENUM> : pqxx::internal::enum_traits<ENUM>   \
   {};                                                                         \
-  template<> inline std::string const type_name<ENUM>                         \
-  {                                                                           \
-#    ENUM                                                                     \
-  }
+  template<> std::string const type_name<ENUM> { #ENUM }
 
 
 namespace pqxx


### PR DESCRIPTION
Fixes #681.

WHen building libpqxx as a shared library on Debian with gcc 12, any program that included libpqxx headers (with a few exceptions) would crash after `main()` returned.

There was an error message:

_free(): double free detected in tcache 2_

The problem turned out to be triggered by the inlining of any specialisation of `pqxx::type_name`, as we did in the macro `PQXX_DECLARE_ENUM_CONVERSION`.  There's a header that uses that macro, thus triggering the problem.