### PR TITLE
Stop including `<ciso646>`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@
  - Don't use `std::function` as deleter for smart pointers.
  - Work around gcc compile error with regex + address sanitizer + analyzers.
  - Fix "double free" on exit when built as shared library on Debian. (#681)
+ - Stop including `<ciso646>`; should be built into compilers. (#680)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/internal/header-pre.hxx
+++ b/include/pqxx/internal/header-pre.hxx
@@ -52,13 +52,6 @@
 // Workarounds & definitions that need to be included even in library's headers
 #include "pqxx/config-public-compiler.h"
 
-// C++20: No longer needed.
-// Enable ISO-646 alternative operaotr representations: "and" instead of "&&"
-// etc. on older compilers.  C++20 removes this header.
-#if __has_include(<ciso646>)
-#  include <ciso646>
-#endif
-
 
 #if defined(PQXX_HAVE_GCC_PURE)
 /// Declare function "pure": no side effects, only reads globals and its args.


### PR DESCRIPTION
Fixes #680.

C++17 compilers should not need this header.  (Visual Studio complains if we include this anyway, even if it's only in the case where the file actually exists.  It suggests a way to disable that warning, but it does not seem to work.)