### PR TITLE
New exception subclass: `protocol_violation`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,7 @@
  - Work around gcc compile error with regex + address sanitizer + analyzers.
  - Fix "double free" on exit when built as shared library on Debian. (#681)
  - Stop including `<ciso646>`; should be built into compilers. (#680)
+ - New `broken_connection` exception subclass: `protocol_violation`. (#686)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/configure
+++ b/configure
@@ -4107,11 +4107,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4153,11 +4153,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -63,12 +63,28 @@ struct PQXX_LIBEXPORT failure : std::runtime_error
  * {
  *   signal(SIGPIPE, SIG_IGN);
  *   // ...
+ * }
  * ```
  */
 struct PQXX_LIBEXPORT broken_connection : failure
 {
   broken_connection();
   explicit broken_connection(std::string const &);
+};
+
+
+/// Exception class for micommunication with th server.
+/** This happens when the conversation between libpq and the server gets messed
+ * up.  There aren't many situations where this happens, but one known instance
+ * is when you call a parameterised or prepared statement with th ewrong number
+ * of parameters.
+ *
+ * So even though this is a `broken_connection`, it signals that retrying is
+ * _not_ likely to make the problem go away.
+ */
+struct PQXX_LIBEXPORT protocol_violation : broken_connection
+{
+  explicit protocol_violation(std::string const &);
 };
 
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -717,6 +717,17 @@ public:
    * `std::basic_string<std::byte>` or `std::basic_string_view<std::byte>`
    * or (in C++20) `std::vector<std::byte>`.  Also, consider large objects on
    * the SQL side and @ref blob on the C++ side.
+   *
+   * @warning Passing the wrong number of parameters to a prepared or
+   * parameterised statement will _break the connection._  The usual exception
+   * that occurs in this situation is @ref pqxx::protocol_violation.  It's a
+   * subclass of @ref pqxx::broken_connection, but where `broken_connection`
+   * usually indicates a networking problem, `protocol_violation` indicates
+   * that the communication with the server has deviated from protocol.  Once
+   * something like that happens, communication is broken and there is nothing
+   * for it but to discard the connection.  A networking problem is usually
+   * worth retrying, but a protocol violation is not.  The same violation will
+   * probably just happen again.
    */
   //@{
 

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -123,7 +123,7 @@ inline auto perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
       // again.
       throw;
     }
-    catch (protocol_violatoin const &)
+    catch (protocol_violation const &)
     {
       // This is a subclass of broken_connection, but it's not one where
       // retrying is likely to do us any good.

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -123,6 +123,12 @@ inline auto perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
       // again.
       throw;
     }
+    catch (protocol_violatoin const &)
+    {
+      // This is a subclass of broken_connection, but it's not one where
+      // retrying is likely to do us any good.
+      throw;
+    }
     catch (broken_connection const &)
     {
       // Connection failed.  May be worth retrying, if the transactor opens its

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -30,6 +30,11 @@ pqxx::broken_connection::broken_connection(std::string const &whatarg) :
 {}
 
 
+pqxx::protocol_violation::protocol_violation(std::string const &whatarg) :
+	broken_connection{whatarg}
+{}
+
+
 pqxx::variable_set_to_null::variable_set_to_null() :
         variable_set_to_null{
           "Attempt to set a variable to null.  This is not allowed."}

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -207,7 +207,9 @@ void PQXX_COLD pqxx::result::throw_sql_error(
     switch (code[1])
     {
     case 'A': throw feature_not_supported{Err, Query, code};
-    case '8': throw broken_connection{Err};
+    case '8':
+      if (equal(code, "08P01")) throw protocol_violation{Err};
+      throw broken_connection{Err};
     case 'L':
     case 'P': throw insufficient_privilege{Err, Query, code};
     }

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -329,6 +329,27 @@ void test_placeholders_generates_names()
 }
 
 
+void test_wrong_number_of_params()
+{
+  pqxx::connection conn;
+  pqxx::transaction tx1{conn};
+  conn.prepare("broken1", "SELECT $1::int + $2::int");
+  PQXX_CHECK_THROWS(
+	tx1.exec_prepared("broken1", 10),
+	pqxx::protocol_violation,
+	"Incomplete params no longer thrws protocol violation.");
+  tx1.abort();
+
+  pqxx::transaction tx2{conn};
+  conn.prepare("broken2", "SELECT $1::int + $2::int");
+  PQXX_CHECK_THROWS(
+	tx1.exec_prepared("broken2", 5, 4, 3),
+	pqxx::protocol_violation,
+	"Passing too many params no longer thrws protocol violation.");
+}
+
+
 PQXX_REGISTER_TEST(test_prepared_statements);
 PQXX_REGISTER_TEST(test_placeholders_generates_names);
+PQXX_REGISTER_TEST(test_wrong_number_of_params);
 } // namespace

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -331,21 +331,25 @@ void test_placeholders_generates_names()
 
 void test_wrong_number_of_params()
 {
-  pqxx::connection conn;
-  pqxx::transaction tx1{conn};
-  conn.prepare("broken1", "SELECT $1::int + $2::int");
-  PQXX_CHECK_THROWS(
+  {
+    pqxx::connection conn1;
+    pqxx::transaction tx1{conn1};
+    conn1.prepare("broken1", "SELECT $1::int + $2::int");
+    PQXX_CHECK_THROWS(
 	tx1.exec_prepared("broken1", 10),
 	pqxx::protocol_violation,
 	"Incomplete params no longer thrws protocol violation.");
-  tx1.abort();
+  }
 
-  pqxx::transaction tx2{conn};
-  conn.prepare("broken2", "SELECT $1::int + $2::int");
-  PQXX_CHECK_THROWS(
-	tx1.exec_prepared("broken2", 5, 4, 3),
+  {
+    pqxx::connection conn2;
+    pqxx::transaction tx2{conn2};
+    conn2.prepare("broken2", "SELECT $1::int + $2::int");
+    PQXX_CHECK_THROWS(
+	tx2.exec_prepared("broken2", 5, 4, 3),
 	pqxx::protocol_violation,
 	"Passing too many params no longer thrws protocol violation.");
+  }
 }
 
 

--- a/test/unit/test_transactor.cxx
+++ b/test/unit/test_transactor.cxx
@@ -41,7 +41,7 @@ void test_transactor_newstyle_retries_broken_connection()
   auto const &callback{[&counter] {
     ++counter;
     if (counter == 1)
-      throw pqxx::broken_connection();
+      throw pqxx::broken_connection{};
     return counter;
   }};
 


### PR DESCRIPTION
See #686.  This is not a full implementation of what is suggested there. But it will enable a program to avoid the problem of catching a `broken_connection` and retrying ad infinitum.