### PR TITLE
Run shellcheck if available.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,7 +30,8 @@ expand_templates() {
 
 # We have two kinds of templates.  One uses our custom templating tool.  And
 # a few others simply have some substitutions done.
-expand_templates "$(find . -name \*.template)"
+# shellcheck disable=SC2046
+expand_templates $(find . -name \*.template)
 substitute include/pqxx/version.hxx.template >include/pqxx/version.hxx
 substitute include/pqxx/doc/mainpage.md.template >include/pqxx/doc/mainpage.md
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -30,7 +30,7 @@ expand_templates() {
 
 # We have two kinds of templates.  One uses our custom templating tool.  And
 # a few others simply have some substitutions done.
-expand_templates $(find -name \*.template)
+expand_templates "$(find . -name \*.template)"
 substitute include/pqxx/version.hxx.template >include/pqxx/version.hxx
 substitute include/pqxx/doc/mainpage.md.template >include/pqxx/doc/mainpage.md
 

--- a/tools/deprecations
+++ b/tools/deprecations
@@ -2,5 +2,4 @@
 set -eu
 
 MARKER='include.*ignore-deprecated-pre'
-FILES="src include tools/*.cxx test config-tests"
-grep -Ircl $MARKER $FILES | sort
+grep -Ircl "$MARKER" src include tools/*.cxx test config-tests | sort

--- a/tools/extract_version
+++ b/tools/extract_version
@@ -42,7 +42,7 @@ EOF
 case "$ARG" in
 ''|-f|--full)
 	# Default: Print full version.
-	cat $srcdir/VERSION
+	cat "$srcdir/VERSION"
 	;;
 
 -h|--help)
@@ -53,21 +53,21 @@ case "$ARG" in
 
 -a|--abi)
 	# Print just the ABI version (major & minor).
-	sed -e 's/^\([^.]*\.[^.]*\)\..*/\1/' $srcdir/VERSION
+	sed -e 's/^\([^.]*\.[^.]*\)\..*/\1/' "$srcdir/VERSION"
 	;;
 
 -M|--major)
 	# Print the major version number.
-	sed -e 's/^\([^.]*\)\..*/\1/' $srcdir/VERSION
+	sed -e 's/^\([^.]*\)\..*/\1/' "$srcdir/VERSION"
 	;;
 
 -m|--minor)
 	# Print the minor version number.
-	sed -e 's/^[^.]*\.\([^.]*\)\..*/\1/' $srcdir/VERSION
+	sed -e 's/^[^.]*\.\([^.]*\)\..*/\1/' "$srcdir/VERSION"
 	;;
 
 *)
-	unknown_arg $ARG
+	unknown_arg "$ARG"
 	exit 1
 	;;
 esac

--- a/tools/format
+++ b/tools/format
@@ -8,13 +8,14 @@
 set -C -u -e
 
 # Reformat C++ files.
-find -name \*.cxx -o -name \*.hxx | xargs clang-format -i
+find . -name '*.[ch]xx' -print0 | xargs -0 clang-format -i
 
 
 # Reformat CMake files.
 WORKDIR=$(mktemp -d)
-virtualenv -q --python=$(which python3) "$WORKDIR/venv"
-. "$WORKDIR/venv/bin/activate"
+virtualenv -q --python="$(which python3)" "$WORKDIR/venv"
+# shellcheck disable=SC1091
+source "$WORKDIR"/venv/bin/activate
 pip install -q six pyaml cmake-format
-(find -name CMakeLists.txt | xargs cmake-format -i) || /bin/true
+(find . -name CMakeLists.txt -print0 | xargs -0 cmake-format -i) || /bin/true
 rm -rf "$WORKDIR"

--- a/tools/lint
+++ b/tools/lint
@@ -19,23 +19,24 @@ ARGS="${1:-}"
 # I'd love to have rich Unicode, but I can live without it.  But we don't want
 # any surprises in contributions.
 check_ascii() {
-    local exotics=$(
-        find . -name \*.cxx -o -name \*.hxx |
-	xargs cat |
+    local exotics
+    exotics="$(
+        find "$SRCDIR" -type f -name '*.[ch].cxx' -print0 |
+        xargs -0 cat |
         tr -d '\011-\176' |
-	wc -c
-    )
-    if [ $exotics != 0 ]
+        wc -c
+    )"
+    if [ "$exotics" != 0 ]
     then
         echo >&2 "There's a non-ASCII character somewhere."
-	exit 1
+        exit 1
     fi
 }
 
 
 # This version must be at the top of the NEWS file.
 check_news_version() {
-    if ! head -n1 $SRCDIR/NEWS | grep -q "^$PQXXVERSION\$"
+    if ! head -n1 "$SRCDIR/NEWS" | grep -q "^$PQXXVERSION\$"
     then
         cat <<EOF >&2
 Version $PQXXVERSION is not at the top of NEWS.
@@ -48,19 +49,20 @@ EOF
 # Count number of times header $1 is included from each of given input files.
 # Output is lines of <filename>:<count>, one line per file, sorted.
 count_includes() {
-    local HEADER_NAME WS PAT
+    local HEADER_NAME PAT
     HEADER_NAME="$1"
     shift
-    WS="[[:space:]]*"
-    PAT="^${WS}#${WS}include${WS}[<\"]$HEADER_NAME[>\"]"
+    PAT='^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"]'"$HEADER_NAME"'[>"]'
     # It's OK for the grep to fail.
-    (grep -c "$PAT" $* || /bin/true) | sort
+    find "$SRCDIR/include/pqxx" -type f -print0 |
+        ( xargs -0 grep -c "$PAT" || /bin/true ) |
+	sort
 }
 
 
 # Check that any includes of $1-pre.hxx are matched by $1-post.hxx ones.
 match_pre_post_headers() {
-    local NAME TEMPDIR PRE POST HEADERS
+    local NAME TEMPDIR PRE POST
     NAME="$1"
     TEMPDIR="$(mktemp -d)"
     if test -z "$TEMPDIR"
@@ -70,11 +72,8 @@ match_pre_post_headers() {
     fi
     PRE="$TEMPDIR/pre"
     POST="$TEMPDIR/post"
-    HEADERS=$(find include/pqxx/* -type f | grep -v '\.swp$')
-    count_includes \
-        $SRCDIR/NAME-pre.hxx $HEADERS >"$PRE"
-    count_includes \
-        $SRCDIR/NAME-post.hxx $HEADERS >"$POST"
+    count_includes "$SRCDIR/$NAME-pre.hxx" >"$PRE"
+    count_includes "$SRCDIR/$NAME-post.hxx" >"$POST"
     DIFF="$(diff "$PRE" "$POST")" || /bin/true
     rm -r -- "$TEMPDIR"
     if test -n "$DIFF"
@@ -104,29 +103,29 @@ cpplint() {
     then
         if [ -e compile_flags ]
         then
-	    # Pick out relevant flags, but leave out the rest.
-	    # If we're not compiling with clang, compile_flags may contain
-	    # options that clang-tidy doesn't recognise.
+            # Pick out relevant flags, but leave out the rest.
+            # If we're not compiling with clang, compile_flags may contain
+            # options that clang-tidy doesn't recognise.
             dialect="$(grep -o -- '-std=[^[:space:]]*' compile_flags || true)"
-	    includes="$(
-	        grep -o -- '-I[[:space:]]*[^[:space:]]*' compile_flags ||
-		true)"
+            includes="$(
+                grep -o -- '-I[[:space:]]*[^[:space:]]*' compile_flags ||
+                true)"
         else
             dialect=""
-	    includes=""
+            includes=""
         fi
 
-	cxxflags="$dialect $includes"
+        cxxflags="$dialect $includes"
 
 # TODO: Please, is there any way we can parallelise this?
 # TODO: I'd like cppcoreguidelines-*, but it's a tsunami of false positives.
 # TODO: Some useful checks in abseil-*, but it recommends "use our library."
 # TODO: Check test/, but tolerate some of the dubious stuff tests do.
         clang-tidy \
-            $(find $SRCDIR/src $SRCDIR/tools -name \*.cxx) \
+            "$(find "$SRCDIR"/src "$SRCDIR"/tools -name \*.cxx)" \
             --checks=boost-*, \
             -- \
-            -I$SRCDIR/include -Iinclude $cxxflags
+            -I"$SRCDIR/include" -Iinclude "$cxxflags"
     fi
 
     # Run Facebook's "infer" static analyser, if available.
@@ -134,10 +133,10 @@ cpplint() {
     if which infer >/dev/null
     then
         # This will work in an out-of-tree build, but either way it does
-	# require a successful "configure", or a cmake with the "make"
-	# generator.
-        infer capture -- make -j$(nproc)
-	infer run
+        # require a successful "configure", or a cmake with the "make"
+        # generator.
+        infer capture -- make -j"$(nproc)"
+        infer run
     fi
 }
 
@@ -147,12 +146,27 @@ pylint() {
     echo "Skipping pocketlint; it's not up to date with Python3."
     # if which pocketlint >/dev/null
     # then
-    # 	pocketlint $PYFILES
+    #    pocketlint $PYFILES
     # fi
 
     if which pyflakes3 >/dev/null
     then
-        pyflakes3 $PYFILES
+        pyflakes3 "$PYFILES"
+    fi
+}
+
+
+shelllint() {
+    local TLS="deprecations extract_version format lint todo update-copyright"
+    if which shellcheck >/dev/null
+    then
+        shellcheck "$SRCDIR/autogen.sh"
+        for s in $TLS
+        do
+            shellcheck "$SRCDIR/tools/$s"
+        done
+    else
+        echo "No shellcheck found.  Skipping."
     fi
 }
 
@@ -171,7 +185,7 @@ main() {
     do
         case $arg in
         -h|--help)
-	    cat <<EOF
+            cat <<EOF
 Perform static checks on libpqxx build tree.
 
 Usage:
@@ -182,17 +196,18 @@ EOF
             exit 0
         ;;
         -f|--full)
-	    full="yes"
+            full="yes"
         ;;
         *)
-	    echo >&2 "Unknown argument: '$arg'"
-	    exit 1
+            echo >&2 "Unknown argument: '$arg'"
+            exit 1
         ;;
         esac
     done
 
     check_ascii
     pylint
+    shelllint
     check_news_version
     check_compiler_internal_headers
     markdownlint

--- a/tools/todo
+++ b/tools/todo
@@ -8,11 +8,8 @@ set -e -u -o pipefail
 # TODO: Make location-independent?
 find_source() {
     echo configure.ac
-    find . -name \*.cxx -o -name \*.hxx | sed -e 's|^\./||' | sort
-    for f in $(ls tools)
-    do
-        echo tools/$f
-    done
+    find . -name '*.[ch]xx' | sed -e 's|^\./||' | sort
+    echo tools/*
 }
 
 
@@ -23,7 +20,9 @@ FILES=${*:-$(find_source)}
 # (This function adds the colon.  That way, the search statement itself won't
 # show up in the search.)
 search_for() {
-    grep $1: $2
+    local key="$1:"
+    shift
+    find_source | xargs grep "$key"
 }
 
 


### PR DESCRIPTION
Adds `shellcheck` to lint script.  And fixes up pre-existing lint.