### PR TITLE
Retire unused `blob_already_exists` exception.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,7 @@
  - Fix "double free" on exit when built as shared library on Debian. (#681)
  - Stop including `<ciso646>`; should be built into compilers. (#680)
  - New `broken_connection` exception subclass: `protocol_violation`. (#686)
+ - Retired unused `blob_already_exists` exception class. (#686)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -458,11 +458,6 @@ struct PQXX_LIBEXPORT plpgsql_too_many_rows : plpgsql_error
   {}
 };
 
-struct PQXX_LIBEXPORT blob_already_exists : failure
-{
-  explicit blob_already_exists(std::string const &);
-};
-
 /**
  * @}
  */

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -129,8 +129,3 @@ pqxx::conversion_overrun::conversion_overrun(std::string const &whatarg) :
 pqxx::range_error::range_error(std::string const &whatarg) :
         out_of_range{whatarg}
 {}
-
-
-pqxx::blob_already_exists::blob_already_exists(std::string const &whatarg) :
-        failure{whatarg}
-{}


### PR DESCRIPTION
This came up in #686.