### PR TITLE
Forbid conversion of certain types.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,7 @@
  - New `broken_connection` exception subclass: `protocol_violation`. (#686)
  - Retired unused `blob_already_exists` exception class. (#686)
  - Support for `PQinitOpenSSL()`. (#678)
+ - Slightly more helpful error for unsupported conversions. (#695)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -264,37 +264,6 @@ template<> struct string_traits<bool>
 template<> inline constexpr bool is_unquoted_safe<bool>{true};
 
 
-/// We don't support conversion to/from `char` types.
-/** Why are these disallowed?  Because they are ambiguous.  It's not inherently
- * clear whether we should treat values of these types as text or as small
- * integers.  Either choice would lead to bugs.
- */
-template<>
-struct string_traits<char>
-        : internal::disallowed_ambiguous_char_conversion<char>
-{};
-
-/// We don't support conversion to/from `char` types.
-/** Why are these disallowed?  Because they are ambiguous.  It's not inherently
- * clear whether we should treat values of these types as text or as small
- * integers.  Either choice would lead to bugs.
- */
-template<>
-struct string_traits<signed char>
-        : internal::disallowed_ambiguous_char_conversion<signed char>
-{};
-
-/// We don't support conversion to/from `char` types.
-/** Why are these disallowed?  Because they are ambiguous.  It's not inherently
- * clear whether we should treat values of these types as text or as small
- * integers.  Either choice would lead to bugs.
- */
-template<>
-struct string_traits<unsigned char>
-        : internal::disallowed_ambiguous_char_conversion<unsigned char>
-{};
-
-
 template<typename T> struct nullness<std::optional<T>>
 {
   static constexpr bool has_null = true;

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -220,38 +220,44 @@ template<typename TYPE> struct string_traits
 
 
 /// Nonexistent function to indicate a disallowed type conversion.
-/** There are some C++ types that you may want to convert to or from SQL values,
- * but which libpqxx deliberately does not support.  For example, `char` is one
- * of these: we define no conversions for that type because it is not inherently
- * clear whether the corresponding SQL type should be a single-character string,
- * a small integer, a raw byte value, etc.
+/** There is no implementation for this function, so any reference to it will
+ * fail to link.  The error message will mention the function name and its
+ * template argument, as a deliberate message to an application developer that
+ * their code is attempting to use a deliberately unsupported conversion.
+ *
+ * There are some C++ types that you may want to convert to or from SQL values,
+ * but which libpqxx deliberately does not support.  Take `char` for example: we
+ * define no conversions for that type because it is not inherently clear
+ * whether whether the corresponding SQL type should be a single-character
+ * string, a small integer, a raw byte value, etc.  The intention could differ
+ * from one call site to the next.
  *
  * If an application attempts to convert these types, we try to make sure that
  * the compiler will issue an error involving this function name, and mention
  * the type, as a hint as to the reason.
  */
 template<typename TYPE> [[noreturn]]
-void help_forbidden_conversion() noexcept;
+void oops_forbidden_conversion() noexcept;
 
 
 /// String traits for a forbidden type conversion.
 /** If you have a C++ type for which you explicitly wish to forbid SQL
  * conversion, you can derive a @ref pqxx::string_traits specialisation for
  * that type from this struct.  Any attempt to convert the type will then fail
- * to build, and produce an error mentioning @ref help_forbidden_conversion.
+ * to build, and produce an error mentioning @ref oops_forbidden_conversion.
  */
 template<typename TYPE> struct forbidden_conversion
 {
   static constexpr bool converts_to_string{false};
   static constexpr bool converts_from_string{false};
   [[noreturn]] static zview to_buf(char *, char *, TYPE const &)
-  { help_forbidden_conversion<TYPE>(); }
+  { oops_forbidden_conversion<TYPE>(); }
   [[noreturn]] static char *into_buf(char *, char *, TYPE const &)
-  { help_forbidden_conversion<TYPE>(); }
+  { oops_forbidden_conversion<TYPE>(); }
   [[noreturn]] static TYPE from_string(std::string_view)
-  { help_forbidden_conversion<TYPE>(); }
+  { oops_forbidden_conversion<TYPE>(); }
   [[noreturn]] static std::size_t size_buffer(TYPE const &) noexcept
-  { help_forbidden_conversion<TYPE>(); }
+  { oops_forbidden_conversion<TYPE>(); }
 };
 
 

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -219,6 +219,113 @@ template<typename TYPE> struct string_traits
 };
 
 
+/// Nonexistent function to indicate a disallowed type conversion.
+/** There are some C++ types that you may want to convert to or from SQL values,
+ * but which libpqxx deliberately does not support.  For example, `char` is one
+ * of these: we define no conversions for that type because it is not inherently
+ * clear whether the corresponding SQL type should be a single-character string,
+ * a small integer, a raw byte value, etc.
+ *
+ * If an application attempts to convert these types, we try to make sure that
+ * the compiler will issue an error involving this function name, and mention
+ * the type, as a hint as to the reason.
+ */
+template<typename TYPE> [[noreturn]]
+void help_forbidden_conversion() noexcept;
+
+
+/// String traits for a forbidden type conversion.
+/** If you have a C++ type for which you explicitly wish to forbid SQL
+ * conversion, you can derive a @ref pqxx::string_traits specialisation for
+ * that type from this struct.  Any attempt to convert the type will then fail
+ * to build, and produce an error mentioning @ref help_forbidden_conversion.
+ */
+template<typename TYPE> struct forbidden_conversion
+{
+  static constexpr bool converts_to_string{false};
+  static constexpr bool converts_from_string{false};
+  [[noreturn]] static zview to_buf(char *, char *, TYPE const &)
+  { help_forbidden_conversion<TYPE>(); }
+  [[noreturn]] static char *into_buf(char *, char *, TYPE const &)
+  { help_forbidden_conversion<TYPE>(); }
+  [[noreturn]] static TYPE from_string(std::string_view)
+  { help_forbidden_conversion<TYPE>(); }
+  [[noreturn]] static std::size_t size_buffer(TYPE const &) noexcept
+  { help_forbidden_conversion<TYPE>(); }
+};
+
+
+/// You cannot convert a `char` to/from SQL.
+/** Converting this type may seem simple enough, but it's ambiguous: Did you
+ * mean the `char` value as a small integer?  If so, did you mean it to be
+ * signed or unsigned?  (The C++ Standard allows the system to implement `char`
+ * as either a signed type or an unsigned type.)  Or were you thinking of a
+ * single-character string (and if so, using what encoding)?  Or perhaps it's
+ * just a raw byte value?
+ *
+ * If you meant it as an integer, use an appropriate integral type such as
+ * `int` or `short` or `unsigned int` etc.
+ *
+ * If you wanted a single-character string, use `std::string_view` (or a
+ * similar type such as `std::string`).
+ *
+ * Or if you had a raw byte in mind, try `std::basic_string_view<std::byte>`
+ * instead.
+ */
+template<> struct string_traits<char> : forbidden_conversion<char> {};
+
+
+
+/// You cannot convert an `unsigned char` to/from SQL.
+/** Converting this type may seem simple enough, but it's ambiguous: Did you
+ * mean the `char` value as a small integer?  Or were you thinking of a
+ * single-character string (and if so, using what encoding)?  Or perhaps it's
+ * just a raw byte value?
+ *
+ * If you meant it as an integer, use an appropriate integral type such as
+ * `int` or `short` or `unsigned int` etc.
+ *
+ * If you wanted a single-character string, use `std::string_view` (or a
+ * similar type such as `std::string`).
+ *
+ * Or if you had a raw byte in mind, try `std::basic_string_view<std::byte>`
+ * instead.
+ */
+template<>
+struct string_traits<unsigned char> : forbidden_conversion<unsigned char> {};
+
+
+
+/// You cannot convert a `signed char` to/from SQL.
+/** Converting this type may seem simple enough, but it's ambiguous: Did you
+ * mean the value as a small integer?  Or were you thinking of a
+ * single-character string (and if so, in what encoding)?  Or perhaps it's just
+ * a raw byte value?
+ *
+ * If you meant it as an integer, use an appropriate integral type such as
+ * `int` or `short` etc.
+ *
+ * If you wanted a single-character string, use `std::string_view` (or a
+ * similar type such as `std::string`).
+ *
+ * Or if you had a raw byte in mind, try `std::basic_string_view<std::byte>`
+ * instead.
+ */
+template<>
+struct string_traits<signed char> : forbidden_conversion<signed char> {};
+
+
+
+/// You cannot convert a `std::byte` to/from SQL.
+/** To convert a raw byte value, use a `std::basic_string_view<std::byte>`.
+ *
+ * For example, to convert a byte `b` from C++ to SQL, convert the value
+ * `std::basic_string_view<std::byte>{&b, 1}` instead.
+ */
+template<>
+struct string_traits<std::byte> : forbidden_conversion<std::byte> {};
+
+
 /// Nullness: Enums do not have an inherent null value.
 template<typename ENUM>
 struct nullness<ENUM, std::enable_if_t<std::is_enum_v<ENUM>>> : no_null<ENUM>

--- a/test/test_types.hxx
+++ b/test/test_types.hxx
@@ -19,37 +19,7 @@
 
 namespace pqxx
 {
-template<> struct nullness<std::byte> : no_null<std::byte>
-{};
-
-
-constexpr static auto hex_digit{"0123456789abcdef"};
-
-
-template<> struct string_traits<std::byte>
-{
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{false};
-
-  static std::size_t size_buffer(std::byte const &) { return 3; }
-
-  static zview to_buf(char *begin, char *end, std::byte const &value)
-  {
-    if (pqxx::internal::cmp_less(end - begin, size_buffer(value)))
-      throw pqxx::conversion_overrun{
-        "Not enough buffer to convert std::byte."};
-    auto uc{static_cast<unsigned char>(value)};
-    begin[0] = hex_digit[uc >> 4];
-    begin[1] = hex_digit[uc & 0x0f];
-    return zview{begin, 2u};
-  }
-
-  static char *into_buf(char *begin, char *end, std::byte const &value)
-  {
-    auto view{to_buf(begin, end, value)};
-    return begin + std::size(view);
-  }
-};
+template<> struct nullness<std::byte> : no_null<std::byte> {};
 } // namespace pqxx
 
 

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -178,8 +178,7 @@ void test_blob_read_reads_data()
 
 
 /// Cast a `char` or `std::byte` to `unsigned int`.
-template<typename BYTE>
-unsigned get_byte(BYTE val)
+template<typename BYTE> inline unsigned byte_val(BYTE val)
 {
   using uchar_t = unsigned char;
   return unsigned(uchar_t(val));
@@ -210,9 +209,9 @@ void test_blob_read_span()
   PQXX_CHECK_EQUAL(
     std::size(output), 2u, "Got unexpected buf size from blob::read().");
   PQXX_CHECK_EQUAL(
-    get_byte(output[0]), get_byte('u'), "Unexpected byte from blob::read().");
+    byte_val(output[0]), byte_val('u'), "Unexpected byte from blob::read().");
   PQXX_CHECK_EQUAL(
-    get_byte(output[1]), get_byte('v'), "Unexpected byte from blob::read().");
+    byte_val(output[1]), byte_val('v'), "Unexpected byte from blob::read().");
 
   string_buf.resize(100);
   output = b.read(std::span<std::byte>{string_buf.data(), 1});
@@ -220,7 +219,7 @@ void test_blob_read_span()
     std::size(output), 1u,
     "Did blob::read() follow string size instead of span size?");
   PQXX_CHECK_EQUAL(
-    get_byte(output[0]), get_byte('w'), "Unexpected byte from blob::read().");
+    byte_val(output[0]), byte_val('w'), "Unexpected byte from blob::read().");
 
   std::vector<std::byte> vec_buf;
   vec_buf.resize(2);
@@ -228,14 +227,14 @@ void test_blob_read_span()
   PQXX_CHECK_EQUAL(
     std::size(output2), 2u, "Got unexpected buf size from blob::read().");
   PQXX_CHECK_EQUAL(
-    get_byte(output2[0]), get_byte('x'), "Unexpected byte from blob::read().");
+    byte_val(output2[0]), byte_val('x'), "Unexpected byte from blob::read().");
   PQXX_CHECK_EQUAL(
-    get_byte(output2[1]), get_byte('y'), "Unexpected byte from blob::read().");
+    byte_val(output2[1]), byte_val('y'), "Unexpected byte from blob::read().");
 
   vec_buf.resize(100);
   output2 = b.read(vec_buf);
   PQXX_CHECK_EQUAL(std::size(output2), 1u, "Weird things happened at EOF.");
-  PQXX_CHECK_EQUAL(get_byte(output2[0]), get_byte('z'), "Bad data at EOF.");
+  PQXX_CHECK_EQUAL(byte_val(output2[0]), byte_val('z'), "Bad data at EOF.");
 #endif // PQXX_HAVE_SPAN
 }
 
@@ -255,7 +254,7 @@ void test_blob_reads_vector()
     std::size(out), std::size(content),
     "Got wrong length back when reading as vector.");
   PQXX_CHECK_EQUAL(
-    get_byte(out[0]), get_byte('a'), "Got bad data when reading as vector.");
+    byte_val(out[0]), byte_val('a'), "Got bad data when reading as vector.");
 }
 
 
@@ -313,9 +312,9 @@ void test_blob_writes_span()
   PQXX_CHECK_EQUAL(
     std::size(out), 3u, "Did not get expected number of bytes back.");
   PQXX_CHECK_EQUAL(
-    get_byte(out[0]), get_byte('f'), "Data did not come back right.");
+    byte_val(out[0]), byte_val('f'), "Data did not come back right.");
   PQXX_CHECK_EQUAL(
-    get_byte(out[2]), get_byte('l'), "Data started right, ended wrong!");
+    byte_val(out[2]), byte_val('l'), "Data started right, ended wrong!");
 #endif // PQXX_HAVE_SPAN
 }
 
@@ -385,21 +384,21 @@ void test_blob_seek_sets_positions()
   b.seek_rel(3);
   b.read(buf, 1u);
   PQXX_CHECK_EQUAL(
-    get_byte(buf[0]), get_byte(3),
+    byte_val(buf[0]), byte_val(3),
     "seek_rel() from beginning did not take us to the right position.");
 
   b.seek_abs(2);
   b.read(buf, 1u);
   PQXX_CHECK_EQUAL(
-    get_byte(buf[0]),
-    get_byte(2),
+    byte_val(buf[0]),
+    byte_val(2),
     "seek_abs() did not take us to the right position.");
 
   b.seek_end(-2);
   b.read(buf, 1u);
   PQXX_CHECK_EQUAL(
-    get_byte(buf[0]),
-    get_byte(8),
+    byte_val(buf[0]),
+    byte_val(8),
     "seek_end() did not take us to the right position.");
 }
 

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -177,6 +177,15 @@ void test_blob_read_reads_data()
 }
 
 
+/// Cast a `char` or `std::byte` to `unsigned int`.
+template<typename BYTE>
+unsigned get_byte(BYTE val)
+{
+  using uchar_t = unsigned char;
+  return unsigned(uchar_t(val));
+}
+
+
 void test_blob_read_span()
 {
 #if defined(PQXX_HAVE_SPAN)
@@ -201,9 +210,9 @@ void test_blob_read_span()
   PQXX_CHECK_EQUAL(
     std::size(output), 2u, "Got unexpected buf size from blob::read().");
   PQXX_CHECK_EQUAL(
-    output[0], std::byte{'u'}, "Unexpected byte from blob::read().");
+    get_byte(output[0]), get_byte('u'), "Unexpected byte from blob::read().");
   PQXX_CHECK_EQUAL(
-    output[1], std::byte{'v'}, "Unexpected byte from blob::read().");
+    get_byte(output[1]), get_byte('v'), "Unexpected byte from blob::read().");
 
   string_buf.resize(100);
   output = b.read(std::span<std::byte>{string_buf.data(), 1});
@@ -211,7 +220,7 @@ void test_blob_read_span()
     std::size(output), 1u,
     "Did blob::read() follow string size instead of span size?");
   PQXX_CHECK_EQUAL(
-    output[0], std::byte{'w'}, "Unexpected byte from blob::read().");
+    get_byte(output[0]), get_byte('w'), "Unexpected byte from blob::read().");
 
   std::vector<std::byte> vec_buf;
   vec_buf.resize(2);
@@ -219,14 +228,14 @@ void test_blob_read_span()
   PQXX_CHECK_EQUAL(
     std::size(output2), 2u, "Got unexpected buf size from blob::read().");
   PQXX_CHECK_EQUAL(
-    output2[0], std::byte{'x'}, "Unexpected byte from blob::read().");
+    get_byte(output2[0]), get_byte('x'), "Unexpected byte from blob::read().");
   PQXX_CHECK_EQUAL(
-    output2[1], std::byte{'y'}, "Unexpected byte from blob::read().");
+    get_byte(output2[1]), get_byte('y'), "Unexpected byte from blob::read().");
 
   vec_buf.resize(100);
   output2 = b.read(vec_buf);
   PQXX_CHECK_EQUAL(std::size(output2), 1u, "Weird things happened at EOF.");
-  PQXX_CHECK_EQUAL(output2[0], std::byte{'z'}, "Bad data at EOF.");
+  PQXX_CHECK_EQUAL(get_byte(output2[0]), get_byte('z'), "Bad data at EOF.");
 #endif // PQXX_HAVE_SPAN
 }
 
@@ -246,7 +255,7 @@ void test_blob_reads_vector()
     std::size(out), std::size(content),
     "Got wrong length back when reading as vector.");
   PQXX_CHECK_EQUAL(
-    out[0], std::byte{'a'}, "Got bad data when reading as vector.");
+    get_byte(out[0]), get_byte('a'), "Got bad data when reading as vector.");
 }
 
 
@@ -303,8 +312,10 @@ void test_blob_writes_span()
   auto out{b.read(std::span<std::byte>{buf.data(), 4u})};
   PQXX_CHECK_EQUAL(
     std::size(out), 3u, "Did not get expected number of bytes back.");
-  PQXX_CHECK_EQUAL(out[0], std::byte{'f'}, "Data did not come back right.");
-  PQXX_CHECK_EQUAL(out[2], std::byte{'l'}, "Data started right, ended wrong!");
+  PQXX_CHECK_EQUAL(
+    get_byte(out[0]), get_byte('f'), "Data did not come back right.");
+  PQXX_CHECK_EQUAL(
+    get_byte(out[2]), get_byte('l'), "Data started right, ended wrong!");
 #endif // PQXX_HAVE_SPAN
 }
 
@@ -374,18 +385,22 @@ void test_blob_seek_sets_positions()
   b.seek_rel(3);
   b.read(buf, 1u);
   PQXX_CHECK_EQUAL(
-    buf[0], std::byte{3},
+    get_byte(buf[0]), get_byte(3),
     "seek_rel() from beginning did not take us to the right position.");
 
   b.seek_abs(2);
   b.read(buf, 1u);
   PQXX_CHECK_EQUAL(
-    buf[0], std::byte{2}, "seek_abs() did not take us to the right position.");
+    get_byte(buf[0]),
+    get_byte(2),
+    "seek_abs() did not take us to the right position.");
 
   b.seek_end(-2);
   b.read(buf, 1u);
   PQXX_CHECK_EQUAL(
-    buf[0], std::byte{8}, "seek_end() did not take us to the right position.");
+    get_byte(buf[0]),
+    get_byte(8),
+    "seek_end() did not take us to the right position.");
 }
 
 

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -180,8 +180,7 @@ void test_blob_read_reads_data()
 /// Cast a `char` or `std::byte` to `unsigned int`.
 template<typename BYTE> inline unsigned byte_val(BYTE val)
 {
-  using uchar_t = unsigned char;
-  return unsigned(uchar_t(val));
+  return unsigned(static_cast<unsigned char>(val));
 }
 
 


### PR DESCRIPTION
Should help with problems like #695.

This is really just an attempt to produce slightly more helpful errors when clients try to convert types that libpqxx deliberately does not support, such as `char`.  We're talking about conversions that leave too much to the imagination: a `char` can be signed integral value, or an unsigned integral value, or a byte of text in some encoding.