### PR TITLE
Support moving of `stream_to`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,8 @@
  - Slightly more helpful error for unsupported conversions. (#695)
  - Replace some C++ feature tests with C++20 feature macros.
  - Give `stream_to` a move constructor. (#706)
+ - Support move in `stream_to`. (#706)
+>>>>>>> 42a46214 (Support move assignment as well.)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,7 @@
  - Support for `PQinitOpenSSL()`. (#678)
  - Slightly more helpful error for unsupported conversions. (#695)
  - Replace some C++ feature tests with C++20 feature macros.
+ - Give `stream_to` a move constructor. (#706)
 7.7.4
  - `transaction_base::for_each()` is now called `for_stream()`. (#580)
  - New `transaction_base::for_query()` is similar, but non-streaming. (#580)

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -84,6 +84,9 @@ public:
   /// Execute `query` on `tx`, stream results.
   inline stream_query(transaction_base &tx, std::string_view query);
 
+  stream_query(stream_query &&) = delete;
+  stream_query &operator=(stream_query &&) = delete;
+
   ~stream_query() noexcept
   {
     try

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -137,7 +137,7 @@ stream_query<TYPE...>::read_line() &
 {
   assert(not done());
 
-  internal::gate::connection_stream_from gate{m_trans.conn()};
+  internal::gate::connection_stream_from gate{m_trans->conn()};
   try
   {
     auto line{gate.read_copy_line()};

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -55,6 +55,9 @@ public:
 
   pipeline(pipeline const &) = delete;
   pipeline &operator=(pipeline const &) = delete;
+  pipeline(pipeline &&) = delete;
+  pipeline &operator=(pipeline &&) = delete;
+
 
   /// Start a pipeline.
   explicit pipeline(transaction_base &t) : transaction_focus{t, s_classname}

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -81,6 +81,9 @@ public:
   using raw_line =
     std::pair<std::unique_ptr<char, void(*)(void const *)>, std::size_t>;
 
+  stream_from(stream_from &&) = delete;
+  stream_from &operator=(stream_from &&) = delete;
+
   /// Factory: Execute query, and stream the results.
   /** The query can be a SELECT query or a VALUES query; or it can be an
    * UPDATE, INSERT, or DELETE with a RETURNING clause.

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -189,6 +189,16 @@ public:
     transaction_base &, std::string_view table_name, Iter columns_begin,
     Iter columns_end);
 
+  explicit stream_to(stream_to &&other) :
+    // (This first step only moves the transaction_focus base-class object.)
+    transaction_focus{std::move(other)},
+    m_finished{other.m_finished},
+    m_buffer{std::move(other.m_buffer)},
+    m_field_buf{std::move(other.m_field_buf)},
+    m_finder{other.m_finder}
+  {
+    other.m_finished = true;
+  }
   ~stream_to() noexcept;
 
   /// Does this stream still need to @ref complete()?

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -112,7 +112,7 @@ pqxx::stream_from::raw_line pqxx::stream_from::get_raw_line()
 {
   if (*this)
   {
-    internal::gate::connection_stream_from gate{m_trans.conn()};
+    internal::gate::connection_stream_from gate{m_trans->conn()};
     try
     {
       raw_line line{gate.read_copy_line()};

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -70,7 +70,7 @@ pqxx::stream_to::~stream_to() noexcept
 
 void pqxx::stream_to::write_raw_line(std::string_view text)
 {
-  internal::gate::connection_stream_to{m_trans.conn()}.write_copy_line(text);
+  internal::gate::connection_stream_to{m_trans->conn()}.write_copy_line(text);
 }
 
 
@@ -119,7 +119,7 @@ void pqxx::stream_to::complete()
   {
     m_finished = true;
     unregister_me();
-    internal::gate::connection_stream_to{m_trans.conn()}.end_copy_write();
+    internal::gate::connection_stream_to{m_trans->conn()}.end_copy_write();
   }
 }
 

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -518,7 +518,7 @@ std::string pqxx::transaction_base::description() const
 
 void pqxx::transaction_focus::register_me()
 {
-  pqxx::internal::gate::transaction_transaction_focus{m_trans}.register_focus(
+  pqxx::internal::gate::transaction_transaction_focus{*m_trans}.register_focus(
     this);
   m_registered = true;
 }
@@ -526,7 +526,7 @@ void pqxx::transaction_focus::register_me()
 
 void pqxx::transaction_focus::unregister_me() noexcept
 {
-  pqxx::internal::gate::transaction_transaction_focus{m_trans}
+  pqxx::internal::gate::transaction_transaction_focus{*m_trans}
     .unregister_focus(this);
   m_registered = false;
 }
@@ -535,6 +535,6 @@ void pqxx::transaction_focus::unregister_me() noexcept
 void pqxx::transaction_focus::reg_pending_error(
   std::string const &err) noexcept
 {
-  pqxx::internal::gate::transaction_transaction_focus{m_trans}
+  pqxx::internal::gate::transaction_transaction_focus{*m_trans}
     .register_pending_error(err);
 }


### PR DESCRIPTION
Fixes #706.

Finally biting the bullet and supporting moves of `transaction_focus`, which requires dealing with that backpointer from the transaction back to the focus object.