### PR TITLE
Skip pointless compiler option checks.

### DIFF
--- a/configure
+++ b/configure
@@ -17339,6 +17339,7 @@ then
 			-Wctor-dtor-privacy \
 			-Wendif-labels \
 			-Wextra \
+			-Wextra-semi \
 			-Wfloat-equal \
 			-Wformat=2 \
 			-Wformat-security \
@@ -17354,7 +17355,8 @@ then
 			-Wsign-promo \
 			-Wundef \
 			-Wunused \
-			-Wwrite-strings
+			-Wwrite-strings \
+			-Wzero-as-null-pointer-constant \
 
 		# "Iffy" g++ options.  Some reasonably current g++-like
 		# compilers may not support these.
@@ -17381,14 +17383,12 @@ then
 			-Wanalyzer-write-to-string-literal \
 			-fnothrow-opt \
 			-Wattribute-alias=2 \
-			-Wextra-semi \
 			-Wlogical-op \
 			-Wmismatched-tags \
 			-Wnoexcept \
 			-Wredundant-tags \
 			-Wrestrict \
 			-Wstringop-overflow \
-			-Wzero-as-null-pointer-constant \
 			-Warray-bounds=2 \
 			-Wduplicated-branches \
 			-Wduplicated-cond \
@@ -18651,7 +18651,6 @@ fi
 
 
 # TODO: PQresultMemorySize()
-# TODO: Use feature test macros in libpq-fe.h, should be faster & easier.
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for usable std::filesystem::path" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,7 @@ then
 			-Wctor-dtor-privacy \
 			-Wendif-labels \
 			-Wextra \
+			-Wextra-semi \
 			-Wfloat-equal \
 			-Wformat=2 \
 			-Wformat-security \
@@ -160,7 +161,8 @@ then
 			-Wsign-promo \
 			-Wundef \
 			-Wunused \
-			-Wwrite-strings
+			-Wwrite-strings \
+			-Wzero-as-null-pointer-constant \
 
 		# "Iffy" g++ options.  Some reasonably current g++-like
 		# compilers may not support these.
@@ -187,14 +189,12 @@ then
 			-Wanalyzer-write-to-string-literal \
 			-fnothrow-opt \
 			-Wattribute-alias=2 \
-			-Wextra-semi \
 			-Wlogical-op \
 			-Wmismatched-tags \
 			-Wnoexcept \
 			-Wredundant-tags \
 			-Wrestrict \
 			-Wstringop-overflow \
-			-Wzero-as-null-pointer-constant \
 			-Warray-bounds=2 \
 			-Wduplicated-branches \
 			-Wduplicated-cond \
@@ -632,7 +632,6 @@ occurring in the file.
 
 
 # TODO: PQresultMemorySize()
-# TODO: Use feature test macros in libpq-fe.h, should be faster & easier.
 
 
 AC_MSG_CHECKING([for usable std::filesystem::path])


### PR DESCRIPTION
In "maintainer mode," with a gcc-compatible compiler, the configure script tries to enable lots of warning options.  Some of these have been present in gcc and clang forever, so we just add them blindly.  Others it tries out first, to see whether the compiler accepts them.

A few of these are now old enough that I'll just enable them.  Shaves a fraction of a second off the configure step.