### PR TITLE
Fix bad `zview` string conversion.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 7.8.2
+ - Fix broken `to_buf()` on `zview`. (#728)
 7.8.1
  - Regenerate build files. Should fix ARM Mac build. (#715)
  - Reinstate `<ciso646>` that MSVC can't live with or without. (#713)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -684,7 +684,8 @@ template<> struct string_traits<zview>
 
   static std::string_view to_buf(char *begin, char *end, zview const &value)
   {
-    return {into_buf(begin, end, value), std::size(value)};
+    char *const stop{into_buf(begin, end, value)};
+    return {begin, static_cast<std::size_t>(stop - begin - 1)};
   }
 
   /// Don't convert to this type; it has nowhere to store its contents.

--- a/test/unit/test_zview.cxx
+++ b/test/unit/test_zview.cxx
@@ -12,5 +12,40 @@ void test_zview_literal()
   PQXX_CHECK_EQUAL(("foo"_zv), pqxx::zview{"foo"}, "zview literal is broken.");
 }
 
+
+void test_zview_converts_to_string()
+{
+  using pqxx::operator"" _zv;
+  using traits = pqxx::string_traits<pqxx::zview>;
+
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string("hello"_zv),
+    std::string{"hello"},
+    "to_string on zview failed.");
+
+  char buf[100];
+
+  auto const v{traits::to_buf(std::begin(buf), std::end(buf), "myview"_zv)};
+  PQXX_CHECK_EQUAL(
+    std::string{v},
+    std::string{"myview"},
+    "to_buf on zview failed.");
+
+  auto const p{traits::into_buf(std::begin(buf), std::end(buf), "moreview"_zv)};
+  PQXX_CHECK_NOT_EQUAL(
+    p,
+    std::begin(buf),
+    "into_buf on zview returns beginning of buffer.");
+  PQXX_CHECK(
+    p > std::begin(buf) and p < std::end(buf),
+    "into_buf on zview did not store in buffer.");
+  PQXX_CHECK(*(p - 1) == '\0', "into_buf on zview wasted space.");
+  PQXX_CHECK(*(p - 2) == 'w', "into_buf on zview has extraneous data.");
+  PQXX_CHECK_EQUAL(
+    std::string(buf), std::string{"moreview"}, "into_buf on zview failed.");
+}
+
+
 PQXX_REGISTER_TEST(test_zview_literal);
+PQXX_REGISTER_TEST(test_zview_converts_to_string);
 } // namespace

--- a/test/unit/test_zview.cxx
+++ b/test/unit/test_zview.cxx
@@ -26,10 +26,7 @@ void test_zview_converts_to_string()
   char buf[100];
 
   auto const v{traits::to_buf(std::begin(buf), std::end(buf), "myview"_zv)};
-  PQXX_CHECK_EQUAL(
-    std::string{v},
-    std::string{"myview"},
-    "to_buf on zview failed.");
+  PQXX_CHECK_EQUAL(std::string{v}, "myview", "to_buf on zview failed.");
 
   auto const p{traits::into_buf(std::begin(buf), std::end(buf), "moreview"_zv)};
   PQXX_CHECK_NOT_EQUAL(
@@ -41,8 +38,7 @@ void test_zview_converts_to_string()
     "into_buf on zview did not store in buffer.");
   PQXX_CHECK(*(p - 1) == '\0', "into_buf on zview wasted space.");
   PQXX_CHECK(*(p - 2) == 'w', "into_buf on zview has extraneous data.");
-  PQXX_CHECK_EQUAL(
-    std::string(buf), std::string{"moreview"}, "into_buf on zview failed.");
+  PQXX_CHECK_EQUAL(std::string(buf), "moreview", "into_buf on zview failed.");
 }
 
 


### PR DESCRIPTION
Fixes one part of #728: the `to_buf()` for `zview` was broken.