### PR TITLE
Permit conversion to string of `std::string_view`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 7.8.2
  - Fix broken `to_buf()` on `zview`. (#728)
  - Support `PQfsize()` and `PQfmod()`. (#727)
+ - Implement conversion from `string_view` to string. (#728)
 7.8.1
  - Regenerate build files. Should fix ARM Mac build. (#715)
  - Reinstate `<ciso646>` that MSVC can't live with or without. (#713)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -651,6 +651,13 @@ template<> struct string_traits<std::string_view>
     return begin + std::size(value) + 1;
   }
 
+  static zview to_buf(char *begin, char *end, std::string_view const &value)
+  {
+    // You'd think we could just return the same view but alas, there's no
+    // zero-termination on a string_view.
+    return generic_to_buf(begin, end, value);
+  }
+
   /// Don't convert to this type; it has nowhere to store its contents.
   static std::string_view from_string(std::string_view) = delete;
 };

--- a/test/unit/test_string_conversion.cxx
+++ b/test/unit/test_string_conversion.cxx
@@ -198,10 +198,13 @@ void test_string_view_conversion()
   PQXX_CHECK(
     *(end - 2) == 'w', "string_view into_buf is in the wrong place.");
 
-  pqxx::zview out{
-    traits::to_buf(std::begin(buf), std::end(buf), "another!"sv)};
+  std::string_view org{"another!"sv};
+  pqxx::zview out{traits::to_buf(std::begin(buf), std::end(buf), org)};
   PQXX_CHECK_EQUAL(
     std::string{out}, "another!"s, "string_view to_buf returned wrong data.");
+  PQXX_CHECK(
+    std::data(out) != std::data(org),
+    "string_view to_buf returned original view, which may not be terminated.");
 }
 
 


### PR DESCRIPTION
Fixes #728.

I've been reluctant to implement this because it could pose a larger
runtime cost than the caller might expect.  We need to copy the whole
underlying string into the available buffer just to ensure termination.

But as the bug shows, users may need the conversion in order to pass
arrays of `string_view` as statement parameters.