### PR TITLE
Use a custom std::char_traits<byte> for implementations lacking a generic implementation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,13 @@
  - Implement conversion from `string_view` to string. (#728)
  - Rename `splitconfig` to `splitconfig.py`. (#763)
  - Document need for conversions more clearly, link to docs. (#757)
+ - `std::basic_string<std::byte>` and `std::basic_string_view<std::byte>` have
+   been replaced with `pqxx::bytes` and `pqxx::bytes_view` respectively to
+   support the removal of generic `std::char_traits` in libc++ 19. Users must
+   switch to these aliases to support versions from libc++ 18 onward.
+   In a future major release that start requiring C++20 these are likely to
+   become aliases for `std::vector<std::byte>` and `std::span<std::byte>` to
+   better match the intent of the interfaces. (#726)
 7.8.1
  - Regenerate build files. Should fix ARM Mac build. (#715)
  - Reinstate `<ciso646>` that MSVC can't live with or without. (#713)

--- a/include/pqxx/binarystring.hxx
+++ b/include/pqxx/binarystring.hxx
@@ -30,9 +30,8 @@ template<> struct string_traits<binarystring>;
 
 /// Binary data corresponding to PostgreSQL's "BYTEA" binary-string type.
 /** @ingroup escaping-functions
- * @deprecated Use @c std::basic_string<std::byte> and
- * @c std::basic_string_view<std::byte> for binary data.  In C++20 or better,
- * any @c contiguous_range of @c std::byte will do.
+ * @deprecated Use @c bytes and @c bytes_view for binary data.  In C++20 or
+ * better, any @c contiguous_range of @c std::byte will do.
  *
  * This class represents a binary string as stored in a field of type @c bytea.
  *
@@ -59,7 +58,7 @@ class PQXX_LIBEXPORT binarystring
 {
 public:
   using char_type = unsigned char;
-  using value_type = std::char_traits<char_type>::char_type;
+  using value_type = char_type;
   using size_type = std::size_t;
   using difference_type = long;
   using const_reference = value_type const &;
@@ -174,10 +173,10 @@ public:
     return reinterpret_cast<std::byte const *>(get());
   }
 
-  /// Read data as a @c std::basic_string_view<std::byte>.
-  [[nodiscard]] std::basic_string_view<std::byte> bytes_view() const
+  /// Read data as a @c bytes_view.
+  [[nodiscard]] pqxx::bytes_view bytes_view() const
   {
-    return std::basic_string_view<std::byte>{bytes(), size()};
+    return pqxx::bytes_view{bytes(), size()};
   }
 
 private:

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -104,7 +104,7 @@ public:
    * @warning The underlying protocol only supports reads up to 2GB at a time.
    * If you need to read more, try making repeated calls to @ref append_to_buf.
    */
-  std::size_t read(std::basic_string<std::byte> &buf, std::size_t size);
+  std::size_t read(bytes &buf, std::size_t size);
 
 #if defined(PQXX_HAVE_SPAN)
   /// Read up to `std::size(buf)` bytes from the object.
@@ -145,8 +145,7 @@ public:
    *
    * Returns the filled portion of `buf`.  This may be empty.
    */
-  template<typename ALLOC>
-  std::basic_string_view<std::byte> read(std::vector<std::byte, ALLOC> &buf)
+  template<typename ALLOC> bytes_view read(std::vector<std::byte, ALLOC> &buf)
   {
     return {std::data(buf), raw_read(std::data(buf), std::size(buf))};
   }
@@ -234,14 +233,12 @@ public:
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
-  static oid from_buf(
-    dbtransaction &tx, std::basic_string_view<std::byte> data, oid id = 0);
+  static oid from_buf(dbtransaction &tx, bytes_view data, oid id = 0);
 
   /// Append `data` to binary large object.
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
-  static void append_from_buf(
-    dbtransaction &tx, std::basic_string_view<std::byte> data, oid id);
+  static void append_from_buf(dbtransaction &tx, bytes_view data, oid id);
 
   /// Read client-side file and store it server-side as a binary large object.
   [[nodiscard]] static oid from_file(dbtransaction &, char const path[]);
@@ -283,9 +280,7 @@ public:
   /** You could easily do this yourself using the @ref open_r and @ref read
    * functions, but it can save you a bit of code to do it this way.
    */
-  static void to_buf(
-    dbtransaction &, oid, std::basic_string<std::byte> &,
-    std::size_t max_size);
+  static void to_buf(dbtransaction &, oid, bytes &, std::size_t max_size);
 
   /// Read part of the binary large object with `id`, and append it to `buf`.
   /** Use this to break up a large read from one binary large object into one
@@ -295,8 +290,8 @@ public:
    * `append_max` says how much to try and read in one go.
    */
   static std::size_t append_to_buf(
-    dbtransaction &tx, oid id, std::int64_t offset,
-    std::basic_string<std::byte> &buf, std::size_t append_max);
+    dbtransaction &tx, oid id, std::int64_t offset, bytes &buf,
+    std::size_t append_max);
 
   /// Write a binary large object's contents to a client-side file.
   static void to_file(dbtransaction &, oid, char const path[]);

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -732,7 +732,7 @@ public:
         "Not enough room to escape binary string of ", size, " byte(s): need ",
         needed, " bytes of buffer space, but buffer size is ", space, ".")};
 
-    std::basic_string_view<std::byte> view{std::data(data), std::size(data)};
+    bytes_view view{std::data(data), std::size(data)};
     auto const out{std::data(buffer)};
     // Actually, in the modern format, we know beforehand exactly how many
     // bytes we're going to fill.  Just leave out the trailing zero.
@@ -747,13 +747,12 @@ public:
 
   /// Escape binary string for use as SQL string literal on this connection.
   /** You can also just use @ref esc with a binary string. */
-  [[nodiscard]] std::string esc_raw(std::basic_string_view<std::byte>) const;
+  [[nodiscard]] std::string esc_raw(bytes_view) const;
 
 #if defined(PQXX_HAVE_SPAN)
   /// Escape binary string for use as SQL string literal, into `buffer`.
   /** You can also just use @ref esc with a binary string. */
-  [[nodiscard]] std::string
-  esc_raw(std::basic_string_view<std::byte>, std::span<char> buffer) const;
+  [[nodiscard]] std::string esc_raw(bytes_view, std::span<char> buffer) const;
 #endif
 
 #if defined(PQXX_HAVE_CONCEPTS)
@@ -762,8 +761,7 @@ public:
   template<binary DATA>
   [[nodiscard]] std::string esc_raw(DATA const &data) const
   {
-    return esc_raw(
-      std::basic_string_view<std::byte>{std::data(data), std::size(data)});
+    return esc_raw(bytes_view{std::data(data), std::size(data)});
   }
 #endif
 
@@ -785,17 +783,16 @@ public:
    * "bytea" escape format, used prior to PostgreSQL 9.0, is no longer
    * supported.)
    */
-  [[nodiscard]] std::basic_string<std::byte>
-  unesc_bin(std::string_view text) const
+  [[nodiscard]] bytes unesc_bin(std::string_view text) const
   {
-    std::basic_string<std::byte> buf;
+    bytes buf;
     buf.resize(pqxx::internal::size_unesc_bin(std::size(text)));
     pqxx::internal::unesc_bin(text, buf.data());
     return buf;
   }
 
   /// Escape and quote a string of binary data.
-  std::string quote_raw(std::basic_string_view<std::byte>) const;
+  std::string quote_raw(bytes_view) const;
 
 #if defined(PQXX_HAVE_CONCEPTS)
   /// Escape and quote a string of binary data.
@@ -803,8 +800,7 @@ public:
   template<binary DATA>
   [[nodiscard]] std::string quote_raw(DATA const &data) const
   {
-    return quote_raw(
-      std::basic_string_view<std::byte>{std::data(data), std::size(data)});
+    return quote_raw(bytes_view{std::data(data), std::size(data)});
   }
 #endif
 
@@ -856,8 +852,7 @@ public:
 
   // TODO: Make "into buffer" variant to eliminate a string allocation.
   /// Escape and quote binary data for use as a BYTEA value in SQL statement.
-  [[nodiscard]] std::string
-  quote(std::basic_string_view<std::byte> bytes) const;
+  [[nodiscard]] std::string quote(bytes_view bytes) const;
 
   // TODO: Make "into buffer" variant to eliminate a string allocation.
   /// Escape string for literal LIKE match.
@@ -920,7 +915,7 @@ public:
   unesc_raw(char const text[]) const;
 
   /// Escape and quote a string of binary data.
-  [[deprecated("Use quote(std::basic_string_view<std::byte>).")]] std::string
+  [[deprecated("Use quote(bytes_view).")]] std::string
   quote_raw(unsigned char const bin[], std::size_t len) const;
   //@}
 

--- a/include/pqxx/doc/accessing-results.md
+++ b/include/pqxx/doc/accessing-results.md
@@ -67,10 +67,10 @@ commands: `SELECT`, `VALUES`, or an `INSERT`, `UPDATE`, or `DELETE` with a
 ](https://www.postgresql.org/docs/current/sql-copy.html).
 
 **Three,** when you convert a field to a "view" type (such as
-`std::string_view` or `std::basic_string_view<std::byte>`), the view points to
-underlying data which only stays valid until you iterate to the next row or
-exit the loop.  So if you want to use that data for longer than a single
-iteration of the streaming loop, you'll have to store it somewhere yourself.
+`std::string_view` or `pqxx::bytes_view`), the view points to underlying data
+which only stays valid until you iterate to the next row or exit the loop.  So
+if you want to use that data for longer than a single iteration of the
+streaming loop, you'll have to store it somewhere yourself.
 
 Now for the good news.  Streaming does make it very easy to query data and loop
 over it, and often faster than with the "query" or "exec" functions:

--- a/include/pqxx/doc/binary-data.md
+++ b/include/pqxx/doc/binary-data.md
@@ -9,13 +9,12 @@ Generally you'll want to use `BYTEA` for reasonably-sized values, and large
 objects for very large values.
 
 That's the database side.  On the C++ side, in libpqxx, all binary data must be
-either `std::basic_string<std::byte>` or `std::basic_string_view<std::byte>`;
-or if you're building in C++20 or better, anything that's a block of
-contiguous `std::byte` in memory.
+either `pqxx::bytes` or `pqxx::bytes_view`; or if you're building in C++20 or
+better, anything that's a block of contiguous `std::byte` in memory.
 
 So for example, if you want to write a large object, you'd create a
 `pqxx::blob` object.  And you might use that to write data in the form of
-`std::basic_string_view<std::byte>`.
+`pqxx::bytes_view`.
 
 Your particular binary data may look different though.  You may have it in a
 `std::string`, or a `std::vector<unsigned char>`, or a pointer to `char`
@@ -24,7 +23,7 @@ different widths).  Sometimes that's your choice, or sometimes some other
 library will dictate what form it takes.
 
 So long as it's _basically_ still a block of bytes though, you can use
-`pqxx::binary_cast` to construct a `std::basic_string_view<std::byte>` from it.
+`pqxx::binary_cast` to construct a `pqxx::bytes_view` from it.
 
 There are two forms of `binary_cast`.  One takes a single argument that must
 support `std::data()` and `std::size()`:

--- a/include/pqxx/doc/prepared-statement.md
+++ b/include/pqxx/doc/prepared-statement.md
@@ -121,5 +121,5 @@ data as the `BYTEA` type, or in binary large objects ("blobs").
 
 In libpqxx, you represent binary data as a range of `std::byte`.  They must be
 contiguous in memory, so that libpqxx can pass pointers to the underlying C
-library.  So you might use `std::basic_string<std::byte>`, or
-`std::basic_string_view<std::byte>`, or `std::vector<std::byte>`.
+library.  So you might use `pqxx::bytes`, or `pqxx::bytes_view`, or
+`std::vector<std::byte>`.

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -121,7 +121,7 @@ public:
    *
    * Do not use this for BYTEA values, or other binary values.  To read those,
    * convert the value to your desired type using `to()` or `as()`.  For
-   * example: `f.as<std::basic_string<std::byte>>()`.
+   * example: `f.as<pqx::bytes>()`.
    */
   [[nodiscard]] PQXX_PURE char const *c_str() const &;
 

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -872,8 +872,8 @@ inline constexpr bool is_unquoted_safe<std::shared_ptr<T>>{
 
 
 template<>
-struct nullness<std::basic_string<std::byte>>
-        : no_null<std::basic_string<std::byte>>
+struct nullness<bytes>
+        : no_null<bytes>
 {};
 
 
@@ -916,7 +916,7 @@ template<binary DATA> struct string_traits<DATA>
   static DATA from_string(std::string_view text)
   {
     auto const size{pqxx::internal::size_unesc_bin(std::size(text))};
-    std::basic_string<std::byte> buf;
+    bytes buf;
     buf.resize(size);
     pqxx::internal::unesc_bin(text, reinterpret_cast<std::byte *>(buf.data()));
     return buf;
@@ -925,25 +925,25 @@ template<binary DATA> struct string_traits<DATA>
 #endif // PQXX_HAVE_CONCEPTS
 
 
-template<> struct string_traits<std::basic_string<std::byte>>
+template<> struct string_traits<bytes>
 {
   static constexpr bool converts_to_string{true};
   static constexpr bool converts_from_string{true};
 
   static std::size_t
-  size_buffer(std::basic_string<std::byte> const &value) noexcept
+  size_buffer(bytes const &value) noexcept
   {
     return internal::size_esc_bin(std::size(value));
   }
 
   static zview
-  to_buf(char *begin, char *end, std::basic_string<std::byte> const &value)
+  to_buf(char *begin, char *end, bytes const &value)
   {
     return generic_to_buf(begin, end, value);
   }
 
   static char *
-  into_buf(char *begin, char *end, std::basic_string<std::byte> const &value)
+  into_buf(char *begin, char *end, bytes const &value)
   {
     auto const budget{size_buffer(value)};
     if (internal::cmp_less(end - begin, budget))
@@ -953,10 +953,10 @@ template<> struct string_traits<std::basic_string<std::byte>>
     return begin + budget;
   }
 
-  static std::basic_string<std::byte> from_string(std::string_view text)
+  static bytes from_string(std::string_view text)
   {
     auto const size{pqxx::internal::size_unesc_bin(std::size(text))};
-    std::basic_string<std::byte> buf;
+    bytes buf;
     buf.resize(size);
     pqxx::internal::unesc_bin(text, reinterpret_cast<std::byte *>(buf.data()));
     return buf;
@@ -965,37 +965,37 @@ template<> struct string_traits<std::basic_string<std::byte>>
 
 
 template<>
-inline constexpr format param_format(std::basic_string<std::byte> const &)
+inline constexpr format param_format(bytes const &)
 {
   return format::binary;
 }
 
 
 template<>
-struct nullness<std::basic_string_view<std::byte>>
-        : no_null<std::basic_string_view<std::byte>>
+struct nullness<bytes_view>
+        : no_null<bytes_view>
 {};
 
 
-template<> struct string_traits<std::basic_string_view<std::byte>>
+template<> struct string_traits<bytes_view>
 {
   static constexpr bool converts_to_string{true};
   static constexpr bool converts_from_string{false};
 
   static std::size_t
-  size_buffer(std::basic_string_view<std::byte> const &value) noexcept
+  size_buffer(bytes_view const &value) noexcept
   {
     return internal::size_esc_bin(std::size(value));
   }
 
   static zview to_buf(
-    char *begin, char *end, std::basic_string_view<std::byte> const &value)
+    char *begin, char *end, bytes_view const &value)
   {
     return generic_to_buf(begin, end, value);
   }
 
   static char *into_buf(
-    char *begin, char *end, std::basic_string_view<std::byte> const &value)
+    char *begin, char *end, bytes_view const &value)
   {
     auto const budget{size_buffer(value)};
     if (internal::cmp_less(end - begin, budget))
@@ -1009,7 +1009,7 @@ template<> struct string_traits<std::basic_string_view<std::byte>>
 };
 
 template<>
-inline constexpr format param_format(std::basic_string_view<std::byte> const &)
+inline constexpr format param_format(bytes_view const &)
 {
   return format::binary;
 }

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -98,14 +98,13 @@ public:
   /** The underlying data must stay valid for as long as the `params`
    * remains active.
    */
-  void append(std::basic_string_view<std::byte>) &;
+  void append(bytes_view) &;
 
   /// Append a non-null binary parameter.
   /** Copies the underlying data into internal storage.  For best efficiency,
-   * use the `std::basic_string_view<std::byte>` variant if you can, or
-   * `std::move()`.
+   * use the `pqxx::bytes_view` variant if you can, or `std::move()`.
    */
-  void append(std::basic_string<std::byte> const &) &;
+  void append(bytes const &) &;
 
 #if defined(PQXX_HAVE_CONCEPTS)
   /// Append a non-null binary parameter.
@@ -114,13 +113,12 @@ public:
    */
   template<binary DATA> void append(DATA const &data) &
   {
-    append(
-      std::basic_string_view<std::byte>{std::data(data), std::size(data)});
+    append(bytes_view{std::data(data), std::size(data)});
   }
 #endif // PQXX_HAVE_CONCEPTS
 
   /// Append a non-null binary parameter.
-  void append(std::basic_string<std::byte> &&) &;
+  void append(bytes &&) &;
 
   /// @deprecated Append binarystring parameter.
   /** The binarystring must stay valid for as long as the `params` remains
@@ -197,9 +195,8 @@ private:
   // The way we store a parameter depends on whether it's binary or text
   // (most types are text), and whether we're responsible for storing the
   // contents.
-  using entry = std::variant<
-    std::nullptr_t, zview, std::string, std::basic_string_view<std::byte>,
-    std::basic_string<std::byte>>;
+  using entry =
+    std::variant<std::nullptr_t, zview, std::string, bytes_view, bytes>;
   std::vector<entry> m_params;
 
   static constexpr std::string_view s_overflow{

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -280,8 +280,7 @@ template<typename TYPE> struct forbidden_conversion
  * If you wanted a single-character string, use `std::string_view` (or a
  * similar type such as `std::string`).
  *
- * Or if you had a raw byte in mind, try `std::basic_string_view<std::byte>`
- * instead.
+ * Or if you had a raw byte in mind, try `pqxx::bytes_view` instead.
  */
 template<> struct string_traits<char> : forbidden_conversion<char>
 {};
@@ -299,8 +298,7 @@ template<> struct string_traits<char> : forbidden_conversion<char>
  * If you wanted a single-character string, use `std::string_view` (or a
  * similar type such as `std::string`).
  *
- * Or if you had a raw byte in mind, try `std::basic_string_view<std::byte>`
- * instead.
+ * Or if you had a raw byte in mind, try `pqxx::bytes_view` instead.
  */
 template<>
 struct string_traits<unsigned char> : forbidden_conversion<unsigned char>
@@ -319,8 +317,7 @@ struct string_traits<unsigned char> : forbidden_conversion<unsigned char>
  * If you wanted a single-character string, use `std::string_view` (or a
  * similar type such as `std::string`).
  *
- * Or if you had a raw byte in mind, try `std::basic_string_view<std::byte>`
- * instead.
+ * Or if you had a raw byte in mind, try `pqxx::bytes_view` instead.
  */
 template<>
 struct string_traits<signed char> : forbidden_conversion<signed char>
@@ -328,10 +325,10 @@ struct string_traits<signed char> : forbidden_conversion<signed char>
 
 
 /// You cannot convert a `std::byte` to/from SQL.
-/** To convert a raw byte value, use a `std::basic_string_view<std::byte>`.
+/** To convert a raw byte value, use a `bytes_view`.
  *
  * For example, to convert a byte `b` from C++ to SQL, convert the value
- * `std::basic_string_view<std::byte>{&b, 1}` instead.
+ * `pqxx::bytes_view{&b, 1}` instead.
  */
 template<> struct string_traits<std::byte> : forbidden_conversion<std::byte>
 {};

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -166,10 +166,7 @@ public:
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
-  [[nodiscard]] std::basic_string<std::byte> unesc_bin(zview text)
-  {
-    return conn().unesc_bin(text);
-  }
+  [[nodiscard]] bytes unesc_bin(zview text) { return conn().unesc_bin(text); }
 
   /// Unescape binary data, e.g. from a table field or notification payload.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
@@ -187,7 +184,7 @@ public:
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
-  [[nodiscard]] std::basic_string<std::byte> unesc_bin(char const text[])
+  [[nodiscard]] bytes unesc_bin(char const text[])
   {
     return conn().unesc_bin(text);
   }
@@ -199,22 +196,21 @@ public:
     return conn().quote(t);
   }
 
-  [[deprecated(
-    "Use std::basic_string<std::byte> instead of binarystring.")]] std::string
+  [[deprecated("Use bytes instead of binarystring.")]] std::string
   quote(binarystring const &t) const
   {
     return conn().quote(t.bytes_view());
   }
 
   /// Binary-escape and quote a binary string for use as an SQL constant.
-  [[deprecated("Use quote(std::basic_string_view<std::byte>).")]] std::string
+  [[deprecated("Use quote(pqxx::bytes_view).")]] std::string
   quote_raw(unsigned char const bin[], std::size_t len) const
   {
     return quote(binary_cast(bin, len));
   }
 
   /// Binary-escape and quote a binary string for use as an SQL constant.
-  [[deprecated("Use quote(std::basic_string_view<std::byte>).")]] std::string
+  [[deprecated("Use quote(pqxx::bytes_view).")]] std::string
   quote_raw(zview bin) const;
 
 #if defined(PQXX_HAVE_CONCEPTS)
@@ -867,10 +863,9 @@ public:
    * a zero byte, the last byte in the value will be the one just before the
    * zero.  If you need a zero byte, you're dealing with binary strings, not
    * regular strings.  Represent binary strings on the SQL side as `BYTEA`
-   * (or as large objects).  On the C++ side, use types like
-   * `std::basic_string<std::byte>` or `std::basic_string_view<std::byte>`
-   * or (in C++20) `std::vector<std::byte>`.  Also, consider large objects on
-   * the SQL side and @ref blob on the C++ side.
+   * (or as large objects).  On the C++ side, use types like `pqxx::bytes` or
+   * `pqxx::bytes_view` or (in C++20) `std::vector<std::byte>`.  Also, consider
+   * large objects on the SQL side and @ref blob on the C++ side.
    *
    * @warning Passing the wrong number of parameters to a prepared or
    * parameterised statement will _break the connection._  The usual exception

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -151,8 +151,7 @@ std::size_t pqxx::blob::raw_read(std::byte buf[], std::size_t size)
 }
 
 
-std::size_t
-pqxx::blob::read(std::basic_string<std::byte> &buf, std::size_t size)
+std::size_t pqxx::blob::read(bytes &buf, std::size_t size)
 {
   buf.resize(size);
   auto const received{raw_read(std::data(buf), size)};
@@ -228,8 +227,7 @@ std::int64_t pqxx::blob::seek_end(std::int64_t offset)
 }
 
 
-pqxx::oid pqxx::blob::from_buf(
-  dbtransaction &tx, std::basic_string_view<std::byte> data, oid id)
+pqxx::oid pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id)
 {
   oid actual_id{create(tx, id)};
   try
@@ -259,8 +257,7 @@ pqxx::oid pqxx::blob::from_buf(
 }
 
 
-void pqxx::blob::append_from_buf(
-  dbtransaction &tx, std::basic_string_view<std::byte> data, oid id)
+void pqxx::blob::append_from_buf(dbtransaction &tx, bytes_view data, oid id)
 {
   if (std::size(data) > chunk_limit)
     throw range_error{
@@ -272,16 +269,15 @@ void pqxx::blob::append_from_buf(
 
 
 void pqxx::blob::to_buf(
-  dbtransaction &tx, oid id, std::basic_string<std::byte> &buf,
-  std::size_t max_size)
+  dbtransaction &tx, oid id, bytes &buf, std::size_t max_size)
 {
   open_r(tx, id).read(buf, max_size);
 }
 
 
 std::size_t pqxx::blob::append_to_buf(
-  dbtransaction &tx, oid id, std::int64_t offset,
-  std::basic_string<std::byte> &buf, std::size_t append_max)
+  dbtransaction &tx, oid id, std::int64_t offset, bytes &buf,
+  std::size_t append_max)
 {
   if (append_max > chunk_limit)
     throw range_error{

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -941,8 +941,7 @@ pqxx::connection::esc_raw(unsigned char const bin[], std::size_t len) const
 }
 
 
-std::string
-pqxx::connection::esc_raw(std::basic_string_view<std::byte> bin) const
+std::string pqxx::connection::esc_raw(bytes_view bin) const
 {
   return pqxx::internal::esc_bin(bin);
 }
@@ -980,8 +979,7 @@ pqxx::connection::quote_raw(unsigned char const bin[], std::size_t len) const
 }
 
 
-std::string
-pqxx::connection::quote_raw(std::basic_string_view<std::byte> bytes) const
+std::string pqxx::connection::quote_raw(bytes_view bytes) const
 {
   return internal::concat("'", esc_raw(bytes), "'::bytea");
 }
@@ -993,7 +991,7 @@ std::string PQXX_COLD pqxx::connection::quote(binarystring const &b) const
 }
 
 
-std::string pqxx::connection::quote(std::basic_string_view<std::byte> b) const
+std::string pqxx::connection::quote(bytes_view b) const
 {
   return internal::concat("'", esc_raw(b), "'::bytea");
 }

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -60,19 +60,19 @@ void pqxx::params::append(params const &value) &
 }
 
 
-void pqxx::params::append(std::basic_string_view<std::byte> value) &
+void pqxx::params::append(bytes_view value) &
 {
   m_params.emplace_back(value);
 }
 
 
-void pqxx::params::append(std::basic_string<std::byte> const &value) &
+void pqxx::params::append(bytes const &value) &
 {
   m_params.emplace_back(value);
 }
 
 
-void pqxx::params::append(std::basic_string<std::byte> &&value) &
+void pqxx::params::append(bytes &&value) &
 {
   m_params.emplace_back(std::move(value));
 }

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -123,8 +123,7 @@ constexpr int nibble(int c) noexcept
 } // namespace
 
 
-void pqxx::internal::esc_bin(
-  std::basic_string_view<std::byte> binary_data, char buffer[]) noexcept
+void pqxx::internal::esc_bin(bytes_view binary_data, char buffer[]) noexcept
 {
   auto here{buffer};
   *here++ = '\\';
@@ -142,8 +141,7 @@ void pqxx::internal::esc_bin(
 }
 
 
-std::string
-pqxx::internal::esc_bin(std::basic_string_view<std::byte> binary_data)
+std::string pqxx::internal::esc_bin(bytes_view binary_data)
 {
   auto const bytes{size_esc_bin(std::size(binary_data))};
   std::string buf;
@@ -183,11 +181,10 @@ void pqxx::internal::unesc_bin(
 }
 
 
-std::basic_string<std::byte>
-pqxx::internal::unesc_bin(std::string_view escaped_data)
+pqxx::bytes pqxx::internal::unesc_bin(std::string_view escaped_data)
 {
   auto const bytes{size_unesc_bin(std::size(escaped_data))};
-  std::basic_string<std::byte> buf;
+  pqxx::bytes buf;
   buf.resize(bytes);
   unesc_bin(escaped_data, buf.data());
   return buf;

--- a/test/test62.cxx
+++ b/test/test62.cxx
@@ -23,7 +23,7 @@ void test_062()
 
   tx.exec0("CREATE TEMP TABLE pqxxbin (binfield bytea)");
 
-  std::string const Esc{tx.esc_raw(std::basic_string<std::byte>{
+  std::string const Esc{tx.esc_raw(bytes{
     reinterpret_cast<std::byte const *>(std::data(TestStr)),
     std::size(TestStr)})};
 
@@ -32,15 +32,15 @@ void test_062()
   result R{tx.exec("SELECT * from pqxxbin")};
   tx.exec0("DELETE FROM pqxxbin");
 
-  auto const B{R.at(0).at(0).as<std::basic_string<std::byte>>()};
+  auto const B{R.at(0).at(0).as<bytes>()};
 
   PQXX_CHECK(not std::empty(B), "Binary string became empty in conversion.");
 
   PQXX_CHECK_EQUAL(
     std::size(B), std::size(TestStr), "Binary string was mangled.");
 
-  std::basic_string<std::byte>::const_iterator c;
-  std::basic_string<std::byte>::size_type i;
+  bytes::const_iterator c;
+  bytes::size_type i;
   for (i = 0, c = std::begin(B); i < std::size(B); ++i, ++c)
   {
     PQXX_CHECK(c != std::end(B), "Premature end to binary string.");

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -66,10 +66,9 @@ void test_binarystring()
   PQXX_CHECK_EQUAL(
     std::size(b), std::size(simple), "Escaping confuses length.");
 
-  std::string const simple_escaped{
-    tx.esc_raw(std::basic_string_view<std::byte>{
-      reinterpret_cast<std::byte const *>(std::data(simple)),
-      std::size(simple)})};
+  std::string const simple_escaped{tx.esc_raw(pqxx::bytes_view{
+    reinterpret_cast<std::byte const *>(std::data(simple)),
+    std::size(simple)})};
   for (auto c : simple_escaped)
   {
     auto const uc{static_cast<unsigned char>(c)};
@@ -152,8 +151,7 @@ void test_binarystring_stream()
   to.complete();
 
   auto ptr{reinterpret_cast<std::byte const *>(std::data(data))};
-  auto expect{
-    tx.quote(std::basic_string_view<std::byte>{ptr, std::size(data)})};
+  auto expect{tx.quote(pqxx::bytes_view{ptr, std::size(data)})};
   PQXX_CHECK(
     tx.query_value<bool>("SELECT bin = " + expect + " FROM pqxxbinstream"),
     "binarystring did not stream_to properly.");
@@ -187,10 +185,8 @@ void test_binarystring_array_stream()
 
   auto ptr1{reinterpret_cast<std::byte const *>(std::data(data1))},
     ptr2{reinterpret_cast<std::byte const *>(std::data(data2))};
-  auto expect1{
-    tx.quote(std::basic_string_view<std::byte>{ptr1, std::size(data1)})},
-    expect2{
-      tx.quote(std::basic_string_view<std::byte>{ptr2, std::size(data2)})};
+  auto expect1{tx.quote(pqxx::bytes_view{ptr1, std::size(data1)})},
+    expect2{tx.quote(pqxx::bytes_view{ptr2, std::size(data2)})};
   PQXX_CHECK(
     tx.query_value<bool>("SELECT vec[1] = " + expect1 + " FROM pqxxbinstream"),
     "Bytea in array came out wrong.");

--- a/test/unit/test_escape.cxx
+++ b/test/unit/test_escape.cxx
@@ -94,10 +94,10 @@ void test_quote_name(pqxx::transaction_base &t)
 void test_esc_raw_unesc_raw(pqxx::transaction_base &t)
 {
   constexpr char binary[]{"1\0023\\4x5"};
-  std::basic_string<std::byte> const data(
+  pqxx::bytes const data(
     reinterpret_cast<std::byte const *>(binary), std::size(binary));
-  std::string const escaped{t.esc_raw(
-    std::basic_string_view<std::byte>{std::data(data), std::size(binary)})};
+  std::string const escaped{
+    t.esc_raw(pqxx::bytes_view{std::data(data), std::size(binary)})};
 
   for (auto const i : escaped)
   {
@@ -168,7 +168,7 @@ void test_esc_escapes_into_buffer()
   auto escaped_text{tx.esc(text, buffer)};
   PQXX_CHECK_EQUAL(escaped_text, "Ain''t", "Escaping into buffer went wrong.");
 
-  std::basic_string<std::byte> const data{std::byte{0x22}, std::byte{0x43}};
+  pqxx::bytes const data{std::byte{0x22}, std::byte{0x43}};
   auto escaped_data(tx.esc(data, buffer));
   PQXX_CHECK_EQUAL(escaped_data, "\\x2243", "Binary data escaped wrong.");
 #endif
@@ -202,8 +202,7 @@ void test_binary_esc_checks_buffer_length()
   pqxx::work tx{conn};
 
   std::string buf;
-  std::basic_string<std::byte> bin{
-    std::byte{'b'}, std::byte{'o'}, std::byte{'o'}};
+  pqxx::bytes bin{std::byte{'b'}, std::byte{'o'}, std::byte{'o'}};
 
   buf.resize(2 * std::size(bin) + 3);
   pqxx::ignore_unused(tx.esc(bin, buf));

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -184,10 +184,10 @@ void test_binary()
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 
   {
-    std::basic_string<std::byte> bytes{
+    pqxx::bytes bytes{
       reinterpret_cast<std::byte const *>(raw_bytes), std::size(raw_bytes)};
     auto bp{tx.exec_prepared1("EchoBin", bytes)};
-    auto bval{bp[0].as<std::basic_string<std::byte>>()};
+    auto bval{bp[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       (std::string_view{
         reinterpret_cast<char const *>(bval.c_str()), std::size(bval)}),
@@ -195,15 +195,15 @@ void test_binary()
   }
 
   // Now try it with a complex type that ultimately uses the conversions of
-  // std::basic_string<std::byte>, but complex enough that the call may
-  // convert the data to a text string on the libpqxx side.  Which would be
-  // okay, except of course it's likely to be slower.
+  // pqx::bytes, but complex enough that the call may convert the data to a
+  // text string on the libpqxx side.  Which would be okay, except of course
+  // it's likely to be slower.
 
   {
-    auto ptr{std::make_shared<std::basic_string<std::byte>>(
+    auto ptr{std::make_shared<pqxx::bytes>(
       reinterpret_cast<std::byte const *>(raw_bytes), std::size(raw_bytes))};
     auto rp{tx.exec_prepared1("EchoBin", ptr)};
-    auto pval{rp[0].as<std::basic_string<std::byte>>()};
+    auto pval{rp[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       (std::string_view{
         reinterpret_cast<char const *>(pval.c_str()), std::size(pval)}),
@@ -211,11 +211,11 @@ void test_binary()
   }
 
   {
-    auto opt{std::optional<std::basic_string<std::byte>>{
+    auto opt{std::optional<pqxx::bytes>{
       std::in_place, reinterpret_cast<std::byte const *>(raw_bytes),
       std::size(raw_bytes)}};
     auto op{tx.exec_prepared1("EchoBin", opt)};
-    auto oval{op[0].as<std::basic_string<std::byte>>()};
+    auto oval{op[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       (std::string_view{
         reinterpret_cast<char const *>(oval.c_str()), std::size(oval)}),
@@ -223,12 +223,12 @@ void test_binary()
   }
 
 #if defined(PQXX_HAVE_CONCEPTS)
-  // By the way, it doesn't have to be a std::basic_string.  Any contiguous
-  // range will do.
+  // By the way, it doesn't have to be a pqxx::bytes.  Any contiguous range
+  // will do.
   {
     std::vector<std::byte> data{std::byte{'x'}, std::byte{'v'}};
     auto op{tx.exec_prepared1("EchoBin", data)};
-    auto oval{op[0].as<std::basic_string<std::byte>>()};
+    auto oval{op[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       std::size(oval), 2u, "Binary data came back as wrong length.");
     PQXX_CHECK_EQUAL(static_cast<int>(oval[0]), int('x'), "Wrong data.");


### PR DESCRIPTION
Not sure what style you'd prefer the docstrings in (`byte_string` or `pqxx::byte_string`).  

We could also name these `pqxx::bytes` and `pqxx::bytes_view` to allow switching to `std::vector<std::byte>` and `std::span<std::byte>` in the next major version that bumps the C++ requirement without ending up with incorrect names for them.

---
Standard does not require a generic implementation. libc++ has deprecated its in version 18 and will remove it in version 19.

Replace with type aliases that will use a custom char_traits for libc++ 18 and newer. This is made conditional for libc++ 18 and newer only as this is a source breaking change.

Fixes: #726 