### PR TITLE
Run `ruff`.  Also, `pip install` Python linters.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
           command: apt install -y lsb-release python3 cmake postgresql libpq-dev
             postgresql-server-dev-all build-essential autoconf dh-autoreconf
             autoconf-archive automake cppcheck clang shellcheck
+	    python3-virtualenv
       - run:
           name: Identify
           command: lsb_release -a && c++ --version && clang++ --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Install
           command: apt install -y lsb-release python3 cmake postgresql libpq-dev
             postgresql-server-dev-all build-essential autoconf dh-autoreconf
-            autoconf-archive automake cppcheck clang
+            autoconf-archive automake cppcheck clang shellcheck
       - run:
           name: Identify
           command: lsb_release -a && c++ --version && clang++ --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: apt install -y lsb-release python3 cmake postgresql libpq-dev
             postgresql-server-dev-all build-essential autoconf dh-autoreconf
             autoconf-archive automake cppcheck clang shellcheck
-	    python3-virtualenv
+            python3-virtualenv
       - run:
           name: Identify
           command: lsb_release -a && c++ --version && clang++ --version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build
         run: |
             gcc --version
-            sudo apt-get install -y postgresql
+            sudo apt-get install -y postgresql virtualenv
             sudo service postgresql start
             sudo su postgres -c "createuser --createdb $(whoami)"
             createdb "$(whoami)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
             # Using clang because currently the gcc build fails with an
             # address sanitizer (asan) link error.
             ./configure --enable-maintainer-mode --enable-audit --disable-documentation --disable-static CXXFLAGS='-O1 -std=c++17' CXX=clang++
-            make -j4 check
+            make -j4 check || (cat test-suite.log && exit 1)
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/tools/lint
+++ b/tools/lint
@@ -56,7 +56,7 @@ count_includes() {
     # It's OK for the grep to fail.
     find "$SRCDIR/include/pqxx" -type f -print0 |
         ( xargs -0 grep -c "$PAT" || /bin/true ) |
-	sort
+        sort
 }
 
 
@@ -142,9 +142,31 @@ cpplint() {
 
 
 pylint() {
-    if which pyflakes3 >/dev/null
+    local venv
+
+    if ! which pyflakes3 -o ! which ruff >/dev/null
     then
-        pyflakes3 "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
+        venv="$(mktemp -d)"
+        virtualenv "$venv"
+	# shellcheck disable=SC1091
+        . "$venv/bin/activate"
+    fi
+    if ! which pyflakes3 >/dev/null
+    then
+        pip install pyflakes
+    fi
+    if ! which ruff >/dev/null
+    then
+        pip install ruff
+    fi
+
+    pyflakes3 "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
+    ruff "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
+
+    if test -n "$venv"
+    then
+	deactivate
+	rm -r "$venv"
     fi
 }
 

--- a/tools/lint
+++ b/tools/lint
@@ -144,14 +144,14 @@ cpplint() {
 pylint() {
     local venv
 
-    if ! which pyflakes3 -o ! which ruff >/dev/null
+    if ! which pyflakes -o ! which ruff >/dev/null
     then
         venv="$(mktemp -d)"
         virtualenv "$venv"
-	# shellcheck disable=SC1091
+        # shellcheck disable=SC1091
         . "$venv/bin/activate"
     fi
-    if ! which pyflakes3 >/dev/null
+    if ! which pyflakes -a ! which pyflakes3 >/dev/null
     then
         pip install pyflakes
     fi
@@ -160,13 +160,19 @@ pylint() {
         pip install ruff
     fi
 
-    pyflakes3 "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
+    if which pyflakes
+    then
+        pyflakes "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
+    else
+        pyflakes3 "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
+    fi
+
     ruff "$SRCDIR"/tools/*.py "$SRCDIR"/tools/splitconfig
 
     if test -n "$venv"
     then
-	deactivate
-	rm -r "$venv"
+        deactivate
+        rm -r "$venv"
     fi
 }
 


### PR DESCRIPTION
Apparently Ubuntu has a "snap" for `ruff`, but it doesn't seem to be working in 23.10.  So, just `pip install` both ruff and pyflakes if they are not installed.