### PR TITLE
Parameterised versions of `query()` etc.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 7.9.0
+ - Support parameterised versions of `query()` etc. (#644)
  - Put all feature tests back in config header. (#732)
  - Automate integration of feature tests into both CMake & autoconf. (#747)
  - Fix broken `to_buf()` on `zview`. (#728)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 7.9.0
- - Support parameterised versions of `query()` etc. (#644)
+ - Support parameterised versions of `query()` etc. (#646)
  - Put all feature tests back in config header. (#732)
  - Automate integration of feature tests into both CMake & autoconf. (#747)
  - Fix broken `to_buf()` on `zview`. (#728)

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -36,19 +36,6 @@ class PQXX_LIBEXPORT field
 public:
   using size_type = field_size_type;
 
-  /// Constructor.  Do not call this yourself; libpqxx will do it for you.
-  /** Create field as reference to a field in a result set.
-   * @param r Row that this field is part of.
-   * @param c Column number of this field.
-   */
-  [[deprecated(
-    "Do not construct fields yourself.  Get them from the row.")]] field(row const &r, row_size_type c) noexcept;
-
-  /// Constructor.  Do not call this yourself; libpqxx will do it for you.
-  [[deprecated(
-    "Do not construct fields yourself.  Get them from the "
-    "row.")]] field() noexcept = default;
-
   /**
    * @name Comparison
    */
@@ -266,6 +253,19 @@ public:
     return array_parser{c_str(), m_home.m_encoding};
   }
   //@}
+
+  /// Constructor.  Do not call this yourself; libpqxx will do it for you.
+  /** Create field as reference to a field in a result set.
+   * @param r Row that this field is part of.
+   * @param c Column number of this field.
+   */
+  [[deprecated(
+    "Do not construct fields yourself.  Get them from the row.")]] field(row const &r, row_size_type c) noexcept;
+
+  /// Constructor.  Do not call this yourself; libpqxx will do it for you.
+  [[deprecated(
+    "Do not construct fields yourself.  Get them from the "
+    "row.")]] field() noexcept = default;
 
 
 protected:

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -1,6 +1,6 @@
 /* Helpers for prepared statements and parameterised statements.
  *
- * See the connection class for more about such statements.
+ * See @ref connection and @transcation_base for more about such statements.
  *
  * Copyright (c) 2000-2023, Jeroen T. Vermeulen.
  *
@@ -22,199 +22,25 @@
 #include "pqxx/types.hxx"
 
 
-/// @deprecated The new @ref params class replaces all of this.
-namespace pqxx::prepare
-{
-/// Pass a number of statement parameters only known at runtime.
-/** @deprecated Use @ref params instead.
- *
- * When you call any of the `exec_params` functions, the number of arguments
- * is normally known at compile time.  This helper function supports the case
- * where it is not.
- *
- * Use this function to pass a variable number of parameters, based on a
- * sequence ranging from `begin` to `end` exclusively.
- *
- * The technique combines with the regular static parameters.  You can use it
- * to insert dynamic parameter lists in any place, or places, among the call's
- * parameters.  You can even insert multiple dynamic sequences.
- *
- * @param begin A pointer or iterator for iterating parameters.
- * @param end A pointer or iterator for iterating parameters.
- * @return An object representing the parameters.
- */
-template<typename IT>
-[[deprecated("Use the params class instead.")]] constexpr inline auto
-make_dynamic_params(IT begin, IT end)
-{
-  return pqxx::internal::dynamic_params(begin, end);
-}
-
-
-/// Pass a number of statement parameters only known at runtime.
-/** @deprecated Use @ref params instead.
- *
- * When you call any of the `exec_params` functions, the number of arguments
- * is normally known at compile time.  This helper function supports the case
- * where it is not.
- *
- * Use this function to pass a variable number of parameters, based on a
- * container of parameter values.
- *
- * The technique combines with the regular static parameters.  You can use it
- * to insert dynamic parameter lists in any place, or places, among the call's
- * parameters.  You can even insert multiple dynamic containers.
- *
- * @param container A container of parameter values.
- * @return An object representing the parameters.
- */
-template<typename C>
-[[deprecated("Use the params class instead.")]] constexpr inline auto
-make_dynamic_params(C const &container)
-{
-  using IT = typename C::const_iterator;
-#include "pqxx/internal/ignore-deprecated-pre.hxx"
-  return pqxx::internal::dynamic_params<IT>{container};
-#include "pqxx/internal/ignore-deprecated-post.hxx"
-}
-
-
-/// Pass a number of statement parameters only known at runtime.
-/** @deprecated Use @ref params instead.
- *
- * When you call any of the `exec_params` functions, the number of arguments
- * is normally known at compile time.  This helper function supports the case
- * where it is not.
- *
- * Use this function to pass a variable number of parameters, based on a
- * container of parameter values.
- *
- * The technique combines with the regular static parameters.  You can use it
- * to insert dynamic parameter lists in any place, or places, among the call's
- * parameters.  You can even insert multiple dynamic containers.
- *
- * @param container A container of parameter values.
- * @param accessor For each parameter `p`, pass `accessor(p)`.
- * @return An object representing the parameters.
- */
-template<typename C, typename ACCESSOR>
-[[deprecated("Use the params class instead.")]] constexpr inline auto
-make_dynamic_params(C &container, ACCESSOR accessor)
-{
-  using IT = decltype(std::begin(container));
-#include "pqxx/internal/ignore-deprecated-pre.hxx"
-  return pqxx::internal::dynamic_params<IT, ACCESSOR>{container, accessor};
-#include "pqxx/internal/ignore-deprecated-post.hxx"
-}
-} // namespace pqxx::prepare
-
-
 namespace pqxx
 {
-/// Generate parameter placeholders for use in an SQL statement.
-/** When you want to pass parameters to a prepared statement or a parameterised
- * statement, you insert placeholders into the SQL.  During invocation, the
- * database replaces those with the respective parameter values you passed.
- *
- * The placeholders look like `$1` (for the first parameter value), `$2` (for
- * the second), and so on.  You can just write those directly in your
- * statement.  But for those rare cases where it becomes difficult to track
- * which number a placeholder should have, you can use a `placeholders` object
- * to count and generate them in order.
- */
-template<typename COUNTER = unsigned int> class placeholders
-{
-public:
-  /// Maximum number of parameters we support.
-  static inline constexpr unsigned int max_params{
-    (std::numeric_limits<COUNTER>::max)()};
-
-  placeholders()
-  {
-    static constexpr auto initial{"$1\0"sv};
-    initial.copy(std::data(m_buf), std::size(initial));
-  }
-
-  /// Read an ephemeral version of the current placeholder text.
-  /** @warning Changing the current placeholder number will overwrite this.
-   * Use the view immediately, or lose it.
-   */
-  constexpr zview view() const & noexcept
-  {
-    return zview{std::data(m_buf), m_len};
-  }
-
-  /// Read the current placeholder text, as a `std::string`.
-  /** This will be slightly slower than converting to a `zview`.  With most
-   * C++ implementations however, until you get into ridiculous numbers of
-   * parameters, the string will benefit from the Short String Optimization, or
-   * SSO.
-   */
-  std::string get() const { return std::string(std::data(m_buf), m_len); }
-
-  /// Move on to the next parameter.
-  void next() &
-  {
-    if (m_current >= max_params)
-      throw range_error{pqxx::internal::concat(
-        "Too many parameters in one statement: limit is ", max_params, ".")};
-    ++m_current;
-    if (m_current % 10 == 0)
-    {
-      // Carry the 1.  Don't get too clever for this relatively rare
-      // case, just rewrite the entire number.  Leave the $ in place
-      // though.
-      char *const data{std::data(m_buf)};
-      char *const end{string_traits<COUNTER>::into_buf(
-        data + 1, data + std::size(m_buf), m_current)};
-      // (Subtract because we don't include the trailing zero.)
-      m_len = check_cast<COUNTER>(end - data, "placeholders counter") - 1;
-    }
-    else
-    {
-      PQXX_LIKELY
-      // Shortcut for the common case: just increment that last digit.
-      ++m_buf[m_len - 1];
-    }
-  }
-
-  /// Return the current placeholder number.  The initial placeholder is 1.
-  COUNTER count() const noexcept { return m_current; }
-
-private:
-  /// Current placeholder number.  Starts at 1.
-  COUNTER m_current = 1;
-
-  /// Length of the current placeholder string, not including trailing zero.
-  COUNTER m_len = 2;
-
-  /// Text buffer where we render the placeholders, with a trailing zero.
-  /** We keep reusing this for every subsequent placeholder, just because we
-   * don't like string allocations.
-   *
-   * Maximum length is the maximum base-10 digits that COUNTER can fully
-   * represent, plus 1 more for the extra digit that it can only partially
-   * fill up, plus room for the dollar sign and the trailing zero.
-   */
-  std::array<char, std::numeric_limits<COUNTER>::digits10 + 3> m_buf;
-};
-
-
 /// Build a parameter list for a parameterised or prepared statement.
-/** When calling a parameterised statement or a prepared statement, you can
- * pass parameters into the statement directly in the invocation, as
- * additional arguments to `exec_prepared` or `exec_params`.  But in
- * complex cases, sometimes that's just not convenient.
+/** When calling a parameterised statement or a prepared statement, in some
+ * cases you can pass parameters into the statement directly in the invocation,
+ * as additional arguments to e.g. `exec_prepared` or `exec_params`.  But not
+ * all functions accept that, plus, sometimes you want to build the lists at
+ * run time.
  *
  * In those situations, you can create a `params` and append your parameters
- * into that, one by one.  Then you pass the `params` to `exec_prepared` or
- * `exec_params`.
+ * into that, one by one.  Then you pass the `params` to  the function that
+ * executes your SQL statement.
  *
  * Combinations also work: if you have a `params` containing a string
  * parameter, and you call `exec_params` with an `int` argument followed by
  * your `params`, you'll be passing the `int` as the first parameter and
  * the string as the second.  You can even insert a `params` in a `params`,
- * or pass two `params` objects to a statement.
+ * or pass two `params` objects to a statement.  In the end all the embedded
+ * parameters show up in their natural order.
  */
 class PQXX_LIBEXPORT params
 {
@@ -379,5 +205,181 @@ private:
   static constexpr std::string_view s_overflow{
     "Statement parameter length overflow."sv};
 };
+
+
+/// Generate parameter placeholders for use in an SQL statement.
+/** When you want to pass parameters to a prepared statement or a parameterised
+ * statement, you insert placeholders into the SQL.  During invocation, the
+ * database replaces those with the respective parameter values you passed.
+ *
+ * The placeholders look like `$1` (for the first parameter value), `$2` (for
+ * the second), and so on.  You can just write those directly in your
+ * statement.  But for those rare cases where it becomes difficult to track
+ * which number a placeholder should have, you can use a `placeholders` object
+ * to count and generate them in order.
+ */
+template<typename COUNTER = unsigned int> class placeholders
+{
+public:
+  /// Maximum number of parameters we support.
+  static inline constexpr unsigned int max_params{
+    (std::numeric_limits<COUNTER>::max)()};
+
+  placeholders()
+  {
+    static constexpr auto initial{"$1\0"sv};
+    initial.copy(std::data(m_buf), std::size(initial));
+  }
+
+  /// Read an ephemeral version of the current placeholder text.
+  /** @warning Changing the current placeholder number will overwrite this.
+   * Use the view immediately, or lose it.
+   */
+  constexpr zview view() const & noexcept
+  {
+    return zview{std::data(m_buf), m_len};
+  }
+
+  /// Read the current placeholder text, as a `std::string`.
+  /** This will be slightly slower than converting to a `zview`.  With most
+   * C++ implementations however, until you get into ridiculous numbers of
+   * parameters, the string will benefit from the Short String Optimization, or
+   * SSO.
+   */
+  std::string get() const { return std::string(std::data(m_buf), m_len); }
+
+  /// Move on to the next parameter.
+  void next() &
+  {
+    if (m_current >= max_params)
+      throw range_error{pqxx::internal::concat(
+        "Too many parameters in one statement: limit is ", max_params, ".")};
+    ++m_current;
+    if (m_current % 10 == 0)
+    {
+      // Carry the 1.  Don't get too clever for this relatively rare
+      // case, just rewrite the entire number.  Leave the $ in place
+      // though.
+      char *const data{std::data(m_buf)};
+      char *const end{string_traits<COUNTER>::into_buf(
+        data + 1, data + std::size(m_buf), m_current)};
+      // (Subtract because we don't include the trailing zero.)
+      m_len = check_cast<COUNTER>(end - data, "placeholders counter") - 1;
+    }
+    else
+    {
+      PQXX_LIKELY
+      // Shortcut for the common case: just increment that last digit.
+      ++m_buf[m_len - 1];
+    }
+  }
+
+  /// Return the current placeholder number.  The initial placeholder is 1.
+  COUNTER count() const noexcept { return m_current; }
+
+private:
+  /// Current placeholder number.  Starts at 1.
+  COUNTER m_current = 1;
+
+  /// Length of the current placeholder string, not including trailing zero.
+  COUNTER m_len = 2;
+
+  /// Text buffer where we render the placeholders, with a trailing zero.
+  /** We keep reusing this for every subsequent placeholder, just because we
+   * don't like string allocations.
+   *
+   * Maximum length is the maximum base-10 digits that COUNTER can fully
+   * represent, plus 1 more for the extra digit that it can only partially
+   * fill up, plus room for the dollar sign and the trailing zero.
+   */
+  std::array<char, std::numeric_limits<COUNTER>::digits10 + 3> m_buf;
+};
 } // namespace pqxx
+
+
+/// @deprecated The new @ref params class replaces all of this.
+namespace pqxx::prepare
+{
+/// Pass a number of statement parameters only known at runtime.
+/** @deprecated Use @ref params instead.
+ *
+ * When you call any of the `exec_params` functions, the number of arguments
+ * is normally known at compile time.  This helper function supports the case
+ * where it is not.
+ *
+ * Use this function to pass a variable number of parameters, based on a
+ * sequence ranging from `begin` to `end` exclusively.
+ *
+ * The technique combines with the regular static parameters.  You can use it
+ * to insert dynamic parameter lists in any place, or places, among the call's
+ * parameters.  You can even insert multiple dynamic sequences.
+ *
+ * @param begin A pointer or iterator for iterating parameters.
+ * @param end A pointer or iterator for iterating parameters.
+ * @return An object representing the parameters.
+ */
+template<typename IT>
+[[deprecated("Use the params class instead.")]] constexpr inline auto
+make_dynamic_params(IT begin, IT end)
+{
+  return pqxx::internal::dynamic_params(begin, end);
+}
+
+
+/// Pass a number of statement parameters only known at runtime.
+/** @deprecated Use @ref params instead.
+ *
+ * When you call any of the `exec_params` functions, the number of arguments
+ * is normally known at compile time.  This helper function supports the case
+ * where it is not.
+ *
+ * Use this function to pass a variable number of parameters, based on a
+ * container of parameter values.
+ *
+ * The technique combines with the regular static parameters.  You can use it
+ * to insert dynamic parameter lists in any place, or places, among the call's
+ * parameters.  You can even insert multiple dynamic containers.
+ *
+ * @param container A container of parameter values.
+ * @return An object representing the parameters.
+ */
+template<typename C>
+[[deprecated("Use the params class instead.")]] constexpr inline auto
+make_dynamic_params(C const &container)
+{
+  using IT = typename C::const_iterator;
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
+  return pqxx::internal::dynamic_params<IT>{container};
+#include "pqxx/internal/ignore-deprecated-post.hxx"
+}
+
+
+/// Pass a number of statement parameters only known at runtime.
+/** @deprecated Use @ref params instead.
+ *
+ * When you call any of the `exec_params` functions, the number of arguments
+ * is normally known at compile time.  This helper function supports the case
+ * where it is not.
+ *
+ * Use this function to pass a variable number of parameters, based on a
+ * container of parameter values.
+ *
+ * The technique combines with the regular static parameters.  You can use it
+ * to insert dynamic parameter lists in any place, or places, among the call's
+ * parameters.  You can even insert multiple dynamic containers.
+ *
+ * @param container A container of parameter values.
+ * @param accessor For each parameter `p`, pass `accessor(p)`.
+ * @return An object representing the parameters.
+ */
+template<typename C, typename ACCESSOR>
+[[deprecated("Use the params class instead.")]] constexpr inline auto
+make_dynamic_params(C &container, ACCESSOR accessor)
+{
+  using IT = decltype(std::begin(container));
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
+  return pqxx::internal::dynamic_params<IT, ACCESSOR>{container, accessor};
+#include "pqxx/internal/ignore-deprecated-post.hxx"
+}
+} // namespace pqxx::prepare
 #endif

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -1,6 +1,6 @@
 /* Helpers for prepared statements and parameterised statements.
  *
- * See @ref connection and @transcation_base for more about such statements.
+ * See @ref connection and @ref transaction_base for more.
  *
  * Copyright (c) 2000-2023, Jeroen T. Vermeulen.
  *

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -106,8 +106,6 @@ public:
     return m_end - m_begin;
   }
 
-  [[deprecated("Swap iterators, not rows.")]] void swap(row &) noexcept;
-
   /// Row number, assuming this is a real row and not end()/rend().
   [[nodiscard]] constexpr result::size_type rownumber() const noexcept
   {
@@ -161,24 +159,6 @@ public:
     return rownumber();
   }
 
-  /** Produce a slice of this row, containing the given range of columns.
-   *
-   * @deprecated I haven't heard of anyone caring about row slicing at all in
-   * at least the last 15 years.  Yet it adds complexity, so unless anyone
-   * files a bug explaining why they really need this feature, I'm going to
-   * remove it.  Even if they do, the feature may need an update.
-   *
-   * The slice runs from the range's starting column to the range's end
-   * column, exclusive.  It looks just like a normal result row, except
-   * slices can be empty.
-   */
-  [[deprecated("Row slicing is going away.  File a bug if you need it.")]] row
-  slice(size_type sbegin, size_type send) const;
-
-  /// Is this a row without fields?  Can only happen to a slice.
-  [[nodiscard, deprecated("Row slicing is going away.")]] PQXX_PURE bool
-  empty() const noexcept;
-
   /// Extract entire row's values into a tuple.
   /** Converts to the types of the tuple's respective fields.
    *
@@ -209,6 +189,26 @@ public:
     using seq = std::make_index_sequence<sizeof...(TYPE)>;
     return get_tuple<std::tuple<TYPE...>>(seq{});
   }
+
+  [[deprecated("Swap iterators, not rows.")]] void swap(row &) noexcept;
+
+  /** Produce a slice of this row, containing the given range of columns.
+   *
+   * @deprecated I haven't heard of anyone caring about row slicing at all in
+   * at least the last 15 years.  Yet it adds complexity, so unless anyone
+   * files a bug explaining why they really need this feature, I'm going to
+   * remove it.  Even if they do, the feature may need an update.
+   *
+   * The slice runs from the range's starting column to the range's end
+   * column, exclusive.  It looks just like a normal result row, except
+   * slices can be empty.
+   */
+  [[deprecated("Row slicing is going away.  File a bug if you need it.")]] row
+  slice(size_type sbegin, size_type send) const;
+
+  /// Is this a row without fields?  Can only happen to a slice.
+  [[nodiscard, deprecated("Row slicing is going away.")]] PQXX_PURE bool
+  empty() const noexcept;
 
 protected:
   friend class const_row_iterator;

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -159,36 +159,6 @@ public:
   }
 #endif // PQXX_HAVE_CONCEPTS
 
-  /// Create a stream, without specifying columns.
-  /** @deprecated Use @ref table or @ref raw_table as a factory.
-   *
-   * Fields will be inserted in whatever order the columns have in the
-   * database.
-   *
-   * You'll probably want to specify the columns, so that the mapping between
-   * your data fields and the table is explicit in your code, and not hidden
-   * in an "implicit contract" between your code and your schema.
-   */
-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
-    transaction_base &tx, std::string_view table_name) :
-          stream_to{tx, table_name, ""sv}
-  {}
-
-  /// Create a stream, specifying column names as a container of strings.
-  /** @deprecated Use @ref table or @ref raw_table as a factory.
-   */
-  template<typename Columns>
-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
-    transaction_base &, std::string_view table_name, Columns const &columns);
-
-  /// Create a stream, specifying column names as a sequence of strings.
-  /** @deprecated Use @ref table or @ref raw_table as a factory.
-   */
-  template<typename Iter>
-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
-    transaction_base &, std::string_view table_name, Iter columns_begin,
-    Iter columns_end);
-
   explicit stream_to(stream_to &&other) :
           // (This first step only moves the transaction_focus base-class
           // object.)
@@ -267,6 +237,36 @@ public:
     fill_buffer(fields...);
     write_buffer();
   }
+
+  /// Create a stream, without specifying columns.
+  /** @deprecated Use @ref table or @ref raw_table as a factory.
+   *
+   * Fields will be inserted in whatever order the columns have in the
+   * database.
+   *
+   * You'll probably want to specify the columns, so that the mapping between
+   * your data fields and the table is explicit in your code, and not hidden
+   * in an "implicit contract" between your code and your schema.
+   */
+  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
+    transaction_base &tx, std::string_view table_name) :
+          stream_to{tx, table_name, ""sv}
+  {}
+
+  /// Create a stream, specifying column names as a container of strings.
+  /** @deprecated Use @ref table or @ref raw_table as a factory.
+   */
+  template<typename Columns>
+  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
+    transaction_base &, std::string_view table_name, Columns const &columns);
+
+  /// Create a stream, specifying column names as a sequence of strings.
+  /** @deprecated Use @ref table or @ref raw_table as a factory.
+   */
+  template<typename Iter>
+  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
+    transaction_base &, std::string_view table_name, Iter columns_begin,
+    Iter columns_end);
 
 private:
   /// Stream a pre-quoted table name and columns list.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -656,10 +656,13 @@ public:
    * zero.
    */
   //@{
+
   /// Execute an SQL statement with parameters.
+  /** This is like calling `exec()` with a @ref pqxx::params object
+   */
   template<typename... Args> result exec_params(zview query, Args &&...args)
   {
-    params pp(args...);
+    params pp{args...};
     return internal_exec_params(query, pp.make_c_params());
   }
 
@@ -688,6 +691,79 @@ public:
     auto const r{exec_params(query, std::forward<Args>(args)...)};
     check_rowcount_params(rows, std::size(r));
     return r;
+  }
+
+  /// Execute parameterised query, read full results, iterate rows of data.
+  /** Like @ref query, but the query can contain parameters.
+   *
+   * Converts each row of the result to a `std::tuple` of the types you pass
+   * as template arguments.  (The number of template arguments must match the
+   * number of columns in the query's result.)
+   *
+   * Example:
+   *
+   * ```cxx
+   *     for (
+   *         auto [name, salary] :
+   *             tx.query<std::string_view, int>(
+   *                 "SELECT name, salary FROM employee"
+                 )
+   *     )
+   *         std::cout << name << " earns " << salary << ".\n";
+   * ```
+   *
+   * You can't normally convert a field value to `std::string_view`, but this
+   * is one of the places where you can.  The underlying string to which the
+   * `string_view` points exists only for the duration of the one iteration.
+   * After that, the buffer that holds the actual string may have disappeared,
+   * or it may contain a new string value.
+   *
+   * If you expect a lot of rows from your query, it's probably faster to use
+   * transaction_base::stream() instead.  Or if you need to access metadata of
+   * the result, such as the number of rows in the result, or the number of
+   * rows that your query updates, then you'll need to use
+   * transaction_base::exec() instead.
+   *
+   * @return Something you can iterate using "range `for`" syntax.  The actual
+   * type details may change.
+   */
+  template<typename... TYPE> auto query(zview query, params const &parms)
+  {
+    return exec_params(query, parms).iter<TYPE...>();
+  }
+
+  /// Perform query parameterised, expect given number of rows, iterate results.
+  /** Works like @ref query, but checks that the result has exactly the
+   * expected number of rows.
+   *
+   * @throw unexpected_rows If the query returned the wrong number of rows.
+   *
+   * @return Something you can iterate using "range `for`" syntax.  The actual
+   * type details may change.
+   */
+  template<typename... TYPE> auto query_n(
+    result::size_type rows, zview query, params const &parms)
+  {
+    return exec_params_n(rows, query, parms).iter<TYPE...>();
+  }
+
+  // C++20: Concept like std::invocable, but without specifying param types.
+  /// Execute a query, load the full result, and perform `func` for each row.
+  /** The query may use parameters.  So for example, the query may contain `$1`
+   * to denote the first parameter value in `parms`, and so on.
+   *
+   * Converts each row to data types matching `func`'s parameter types.  The
+   * number of columns in the result set must match the number of parameters.
+   *
+   * This is a lot like for_stream().  The differences are:
+   * 1. It can execute some unusual queries that for_stream() can't.
+   * 2. The `exec` functions are faster for small results, but slower for large
+   *    results.
+   */
+  template<typename CALLABLE> void for_query(
+    zview query, CALLABLE &&func, params const &parms)
+  {
+    exec_params(query, parms).for_each(std::forward<CALLABLE>(func));
   }
   //@}
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -691,7 +691,19 @@ public:
   result exec_params_n(std::size_t rows, zview query, Args &&...args)
   {
     auto const r{exec_params(query, std::forward<Args>(args)...)};
-    check_rowcount_params(rows, std::size(r));
+    check_rowcount_params(rows, static_cast<std::size_t>(std::size(r)));
+    return r;
+  }
+
+  // Execute parameterised statement, expect exactly a given number of rows.
+  /** @throw unexpected_rows if the result contains the wrong number of rows.
+   */
+  template<typename... Args>
+  result exec_params_n(result::size_type rows, zview query, Args &&...args)
+  {
+    auto const r{exec_params(query, std::forward<Args>(args)...)};
+    check_rowcount_params(
+      static_cast<std::size_t>(rows), static_cast<std::size_t>(std::size(r)));
     return r;
   }
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -691,7 +691,9 @@ public:
   result exec_params_n(std::size_t rows, zview query, Args &&...args)
   {
     auto const r{exec_params(query, std::forward<Args>(args)...)};
-    check_rowcount_params(rows, static_cast<std::size_t>(std::size(r)));
+    // The cast isn't to get the type of the right width.  Automatic promotion
+    // will take care of that.  But we do need it unsigned first.
+    check_rowcount_params(rows, static_cast<unsigned>(std::size(r)));
     return r;
   }
 
@@ -702,8 +704,10 @@ public:
   result exec_params_n(result::size_type rows, zview query, Args &&...args)
   {
     auto const r{exec_params(query, std::forward<Args>(args)...)};
+    // The casts aren't to get the type of the right width.  Automatic
+    // promotion will take care of that.  But we do need these unsigned first.
     check_rowcount_params(
-      static_cast<std::size_t>(rows), static_cast<std::size_t>(std::size(r)));
+      static_cast<unsigned>(rows), static_cast<unsigned>(std::size(r)));
     return r;
   }
 

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -61,19 +61,6 @@ class row;
 class stream_from;
 class transaction_base;
 
-/// Marker for @ref stream_from constructors: "stream from table."
-/** @deprecated Use @ref stream_from::table() instead.
- */
-struct from_table_t
-{};
-
-/// Marker for @ref stream_from constructors: "stream from query."
-/** @deprecated Use @ref stream_from::query() instead.
- */
-struct from_query_t
-{};
-
-
 /// Format code: is data text or binary?
 /** Binary-compatible with libpq's format codes.
  */
@@ -168,5 +155,18 @@ concept potential_binary =
 #  define PQXX_CHAR_STRINGS_ARG typename
 
 #endif // PQXX_HAVE_CONCEPTS
+
+/// Marker for @ref stream_from constructors: "stream from table."
+/** @deprecated Use @ref stream_from::table() instead.
+ */
+struct from_table_t
+{};
+
+/// Marker for @ref stream_from constructors: "stream from query."
+/** @deprecated Use @ref stream_from::query() instead.
+ */
+struct from_query_t
+{};
+
 } // namespace pqxx
 #endif

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -33,15 +33,15 @@ void test_exec1(pqxx::transaction_base &trans)
 
 void test_exec_n(pqxx::transaction_base &trans)
 {
-  pqxx::result R{trans.exec_n(3, "SELECT * FROM generate_series(1, 3)")};
+  pqxx::result R{trans.exec_n(3u, "SELECT * FROM generate_series(1, 3)")};
   PQXX_CHECK_EQUAL(std::size(R), 3, "Wrong result size from exec_n.");
 
   PQXX_CHECK_THROWS(
-    trans.exec_n(2, "SELECT * FROM generate_series(1, 3)"),
+    trans.exec_n(2u, "SELECT * FROM generate_series(1, 3)"),
     pqxx::unexpected_rows,
     "exec_n did not throw unexpected_rows for an undersized result.");
   PQXX_CHECK_THROWS(
-    trans.exec_n(4, "SELECT * FROM generate_series(1, 3)"),
+    trans.exec_n(4u, "SELECT * FROM generate_series(1, 3)"),
     pqxx::unexpected_rows,
     "exec_n did not throw unexpected_rows for an oversized result.");
 }
@@ -126,7 +126,7 @@ void test_transaction_query_params()
   PQXX_CHECK_EQUAL(outcome, 64, "Parameterised query() produced wrong result.");
 
   outcome = -1;
-  for (auto [value] : tx.query_n<int>(1, "SELECT * FROM generate_series(1, $1)", {1}))
+  for (auto [value] : tx.query_n<int>(1u, "SELECT * FROM generate_series(1, $1)", {1}))
   {
     PQXX_CHECK_EQUAL(outcome, -1, "Queried one row, got multiple.");
     outcome = value;
@@ -134,7 +134,7 @@ void test_transaction_query_params()
   PQXX_CHECK_EQUAL(outcome, 1, "Bad value from query_n() with params.");
 
   PQXX_CHECK_THROWS(
-    tx.query_n<int>(2, "SELECT $1", {9}),
+    tx.query_n<int>(2u, "SELECT $1", {9}),
       pqxx::unexpected_rows,
         "query_n() with params failed to detect unexpected rows.");
 
@@ -283,14 +283,14 @@ void test_transaction_query_n()
   pqxx::work w{c};
 
   PQXX_CHECK_THROWS(
-    pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 3)")),
+    pqxx::ignore_unused(w.query_n<int>(5u, "SELECT generate_series(1, 3)")),
     pqxx::unexpected_rows, "No exception when query_n returns too few rows.");
   PQXX_CHECK_THROWS(
-    pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 10)")),
+    pqxx::ignore_unused(w.query_n<int>(5u, "SELECT generate_series(1, 10)")),
     pqxx::unexpected_rows, "No exception when query_n returns too many rows.");
 
   std::vector<int> v;
-  for (auto [n] : w.query_n<int>(3, "SELECT generate_series(7, 9)"))
+  for (auto [n] : w.query_n<int>(3u, "SELECT generate_series(7, 9)"))
     v.push_back(n);
   PQXX_CHECK_EQUAL(std::size(v), 3u, "Wrong number of rows.");
   PQXX_CHECK_EQUAL(v[0], 7, "Wrong result data.");

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -66,6 +66,11 @@ void test_query_value(pqxx::connection &conn)
   PQXX_CHECK_THROWS(
     tx.query_value<int>("SELECT 3.141"), pqxx::conversion_error,
     "Got int field from float string.");
+
+  // Now with parameters:
+  PQXX_CHECK_EQUAL(
+    tx.query_value<int>("SELECT $1 + 1", {5}), 6,
+    "Wrong value from query_value with params.");
 }
 
 
@@ -132,6 +137,40 @@ void test_transaction_query_params()
     tx.query_n<int>(2, "SELECT $1", {9}),
       pqxx::unexpected_rows,
         "query_n() with params failed to detect unexpected rows.");
+
+  std::tuple<int> res{tx.query1<int>("SELECT $1 / 3", {33})};
+  auto [res_int] = res;
+  PQXX_CHECK_EQUAL(res_int, 11, "Wrong value from query1() with params.");
+
+  PQXX_CHECK_THROWS(
+    pqxx::ignore_unused(
+      tx.query1<int>("SELECT * from generate_series(1, $1)", {4})),
+    pqxx::unexpected_rows,
+    "query1() with params failed to detect wrong number of rows.");
+
+  std::tuple<int, int> const res2{
+    tx.query1<int, int>("SELECT $1, $2", {3, 6})};
+  auto [res2_a, res2_b] = res2;
+  PQXX_CHECK_EQUAL(
+    res2_a, 3, "Multi-column query1() with params gave wrong result.");
+  PQXX_CHECK_EQUAL(
+    res2_b, 6, "Multi-column query1() with params gave wrong result.");
+
+  std::optional<std::tuple<int>> const opt1{
+    tx.query01<int>("SELECT 1 WHERE 1 = $1", {0})};
+  PQXX_CHECK(not opt1, "query01 got a result it shouldn't have.");
+  std::optional<std::tuple<int>> const opt2{
+    tx.query01<int>("SELECT $1 - 10", {12})};
+  PQXX_CHECK(
+    opt2.has_value(), "query01 did not get the result it should have.");
+  auto const [opt2_val] = *opt2;
+  PQXX_CHECK_EQUAL(opt2_val, 2, "query01 got wrong result.");
+  auto const [opt3_a, opt3_b] =
+    tx.query01<int, int>("SELECT $1, $2", {12, 99}).value();
+  PQXX_CHECK_EQUAL(
+    opt3_a, 12, "Multi-column query01() with params gave wrong result.");
+  PQXX_CHECK_EQUAL(
+    opt3_b, 99, "Multi-column query01() with params gave wrong result.");
 }
 
 
@@ -152,6 +191,21 @@ void test_transaction_for_query()
   });
   PQXX_CHECK_EQUAL(ints, "1 2 3 ", "Unexpected int sequence.");
   PQXX_CHECK_EQUAL(strings, "x2 x4 x6 ", "Unexpected string sequence.");
+
+  // And now with parameters...
+  int x{0}, y{0};
+  tx.for_query(
+    "SELECT $1, $2",
+    [&x, &y](int xout, int yout)
+    {
+      PQXX_CHECK_EQUAL(x, 0, "for_query() called too many times.");
+      PQXX_CHECK_EQUAL(y, 0, "for_query() called too many times.");
+      x = xout;
+      y = yout;
+    },
+    {42, 67});
+  PQXX_CHECK_EQUAL(x, 42, "for_query() with parameters got wrong value.");
+  PQXX_CHECK_EQUAL(y, 67, "for_query() with parameters got wrong value.");
 }
 
 

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -126,7 +126,7 @@ void test_transaction_query_params()
   PQXX_CHECK_EQUAL(outcome, 64, "Parameterised query() produced wrong result.");
 
   outcome = -1;
-  for (auto [value] : tx.query_n<int>(1u, "SELECT * FROM generate_series(1, $1)", {1}))
+  for (auto [value] : tx.query_n<int>(1, "SELECT * FROM generate_series(1, $1)", {1}))
   {
     PQXX_CHECK_EQUAL(outcome, -1, "Queried one row, got multiple.");
     outcome = value;
@@ -134,7 +134,7 @@ void test_transaction_query_params()
   PQXX_CHECK_EQUAL(outcome, 1, "Bad value from query_n() with params.");
 
   PQXX_CHECK_THROWS(
-    tx.query_n<int>(2u, "SELECT $1", {9}),
+    tx.query_n<int>(2, "SELECT $1", {9}),
       pqxx::unexpected_rows,
         "query_n() with params failed to detect unexpected rows.");
 
@@ -283,14 +283,14 @@ void test_transaction_query_n()
   pqxx::work w{c};
 
   PQXX_CHECK_THROWS(
-    pqxx::ignore_unused(w.query_n<int>(5u, "SELECT generate_series(1, 3)")),
+    pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 3)")),
     pqxx::unexpected_rows, "No exception when query_n returns too few rows.");
   PQXX_CHECK_THROWS(
-    pqxx::ignore_unused(w.query_n<int>(5u, "SELECT generate_series(1, 10)")),
+    pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 10)")),
     pqxx::unexpected_rows, "No exception when query_n returns too many rows.");
 
   std::vector<int> v;
-  for (auto [n] : w.query_n<int>(3u, "SELECT generate_series(7, 9)"))
+  for (auto [n] : w.query_n<int>(3, "SELECT generate_series(7, 9)"))
     v.push_back(n);
   PQXX_CHECK_EQUAL(std::size(v), 3u, "Wrong number of rows.");
   PQXX_CHECK_EQUAL(v[0], 7, "Wrong result data.");


### PR DESCRIPTION
Fixes #646.

The new functions do not have "params" in their names.  I'm hoping to get to a future where parameterised calls and regular calls look alike, except that the parameterised calls take an extra `params` argument.

Perhaps in a later stage after that, we can pass parameter packs so the parameters don't have to be wrapped up in a `params`.  But that's for later; it complicates the situation with `std::source_location` parameters which I also want to add, in 8.0.