### PR TITLE
Avoid double `PQfinish()`, just in case.

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -747,6 +747,8 @@ pqxx::result pqxx::connection::exec_prepared(
 
 void pqxx::connection::close()
 {
+  // Just in case PQfinish() doesn't handle nullptr nicely.
+  if (m_conn == nullptr) return;
   try
   {
     if (m_trans)


### PR DESCRIPTION
I _think_ `PQfinish()` simply does nothing if you pass it a `nullptr`. But I don't actually see that documented anywhere, so...