### PR TITLE
[CMAKE] Adding allias for pqxx target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ endmacro()
 file(GLOB CXX_SOURCES *.cxx)
 
 add_library(pqxx ${CXX_SOURCES})
+add_library(libpqxx::pqxx ALIAS pqxx)
 
 get_target_property(pqxx_target_type pqxx TYPE)
 if(pqxx_target_type STREQUAL "SHARED_LIBRARY")


### PR DESCRIPTION
## Why?
This will improve consistency between different ways of adding libpqxx to the project (specifically between `find_package(libpqxx)` and `add_subdirectory(/subproject/path)`)

## Example code that will be perfectly clean after this change

There is a minimalistic batch manager for cmake that is a thin wrapper over FetchContent, with some improvements - [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake.git). It has the ability to check for an installed version via find_package() before loading a package and the lack of consistency between find_package() and add_subriddectory() breaks the beauty of the code.

```cmake
CPMAddPackage(
  NAME libpqxx
  GIT_TAG 7.8.1
  GITHUB_REPOSITORY jtv/libpqxx
)

target_link_libraries(${PROJECT_NAME} PRIVATE libpqxx::pqxx) # fail with add_subdirectory(), success with find_package()
target_link_libraries(${PROJECT_NAME} PRIVATE pqxx) # fail with find_package(), success with add_subdirectory()

# Note - in the second case the error will not be at configuration time, but at linking time.
```

If we add an alias to `pqxx` - the problem is solved. We will be able to use `libpqxx::pqxx` in both cases.


