### PR TITLE
Trying to get readthedocs index back

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,8 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  builder: html
+  # builder: html
+  builder: dirhtml
   configuration: doc/conf.py
   fail_on_warning: true
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,8 +17,7 @@ build:
 sphinx:
   builder: html
   configuration: doc/conf.py
-  # Disabling this experimentally.
-  # fail_on_warning: true
+  fail_on_warning: true
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,11 @@ build:
   apt_packages:
     - doxygen
     - graphviz
+    - python3-graphviz
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  #builder: html
+  builder: html
   configuration: doc/conf.py
   fail_on_warning: true
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,3 +26,5 @@ sphinx:
 #   install:
 #   - requirements: docs/requirements.txt
 
+sphinx:
+  configuration: doc/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,8 @@ build:
 sphinx:
   builder: html
   configuration: doc/conf.py
-  fail_on_warning: true
+  # Disabling this experimentally.
+  # fail_on_warning: true
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html


### PR DESCRIPTION
See #802.  The readthedocs site made some changes recently, and it broke the docs build..  So I fixed that, but now the main indexes are missing!

I have no idea how to fix this.  Just going over things that might help.