### PR TITLE
Fix example in data type docs

### DIFF
--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -224,9 +224,9 @@ the API — or how it uses the API internally.
     template<> struct string_traits<T>
     {
       // Do you support converting T to PostgreSQL string format?
-      static constexpr converts_to_string{true};
+      static constexpr bool converts_to_string{true};
       // Do you support converting PostgreSQL string format to T?
-      static constexpr converts_from_string{true};
+      static constexpr bool converts_from_string{true};
 
       // If converts_to_string is true:
 


### PR DESCRIPTION
Hi, thanks for this library! This is a small fix for the data type docs. Otherwise, the example fails with:

```text
error: a type specifier is required for all declarations
  static constexpr converts_to_string{true};
  ~~~~~~~~~~~~~~~~ ^
```