### PR TITLE
Fix compile error in `field` enum support.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
  - Fix bad conversion of array of empty strings to string. (#816)
  - Move `[[likely]]` feature check back to compile time, to speed up configure.
  - Support `[[assume(...)]]`.
+ - Fix `throw_null_conversion` compile error when converting enums. (#807)
 7.9.0
  - Support standard libraries without `std::basic_string<std::byte>` etc.
  - `std::basic_string<std::byte` becomes `pqxx::bytes`. (#726)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -58,6 +58,11 @@ inline std::string state_buffer_overrun(HAVE have_bytes, NEED need_bytes)
 throw_null_conversion(std::string const &type);
 
 
+/// Throw exception for attempt to convert null to given type.
+[[noreturn]] PQXX_LIBEXPORT PQXX_COLD void
+throw_null_conversion(std::string_view type);
+
+
 /// Deliberately nonfunctional conversion traits for `char` types.
 /** There are no string conversions for `char` and its signed and unsigned
  * variants.  Such a conversion would be dangerously ambiguous: should we treat

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -53,12 +53,12 @@ inline std::string state_buffer_overrun(HAVE have_bytes, NEED need_bytes)
 }
 
 
-/// Throw exception for attempt to convert null to given type.
+/// Throw exception for attempt to convert SQL NULL to given type.
 [[noreturn]] PQXX_LIBEXPORT PQXX_COLD void
 throw_null_conversion(std::string const &type);
 
 
-/// Throw exception for attempt to convert null to given type.
+/// Throw exception for attempt to convert SQL NULL to given type.
 [[noreturn]] PQXX_LIBEXPORT PQXX_COLD void
 throw_null_conversion(std::string_view type);
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -25,6 +25,7 @@
 #include "pqxx/internal/header-pre.hxx"
 
 #include "pqxx/except.hxx"
+#include "pqxx/internal/concat.hxx"
 #include "pqxx/strconv.hxx"
 
 #include "pqxx/internal/header-post.hxx"
@@ -250,9 +251,17 @@ std::string demangle_type_name(char const raw[])
   return std::string{demangled ? demangled.get() : raw};
 }
 
+
+// TODO: Equivalents for converting a null in the other direction.
 void PQXX_COLD throw_null_conversion(std::string const &type)
 {
-  throw conversion_error{"Attempt to convert null to " + type + "."};
+  throw conversion_error{concat("Attempt to convert null to ", type, ".")};
+}
+
+
+void PQXX_COLD throw_null_conversion(std::string_view type)
+{
+  throw conversion_error{concat("Attempt to convert null to ", type, ".")};
 }
 
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -255,13 +255,13 @@ std::string demangle_type_name(char const raw[])
 // TODO: Equivalents for converting a null in the other direction.
 void PQXX_COLD throw_null_conversion(std::string const &type)
 {
-  throw conversion_error{concat("Attempt to convert null to ", type, ".")};
+  throw conversion_error{concat("Attempt to convert SQL null to ", type, ".")};
 }
 
 
 void PQXX_COLD throw_null_conversion(std::string_view type)
 {
-  throw conversion_error{concat("Attempt to convert null to ", type, ".")};
+  throw conversion_error{concat("Attempt to convert SQL null to ", type, ".")};
 }
 
 

--- a/test/unit/test_strconv.cxx
+++ b/test/unit/test_strconv.cxx
@@ -1,6 +1,8 @@
 #include <memory>
 #include <optional>
 
+#include <pqxx/transaction>
+
 #include "../test_helpers.hxx"
 
 namespace
@@ -94,6 +96,11 @@ void test_strconv_class_enum()
     pqxx::to_string(many::top),
     pqxx::to_string(std::numeric_limits<unsigned long long>::max()),
     "Large wide enum did not convert right.");
+
+  pqxx::connection conn;
+  pqxx::work tx{conn};
+  std::tuple<weather> out;
+  tx.exec1("SELECT 0").to(out);
 }
 
 


### PR DESCRIPTION
Fixes #807.

Type names for user-defined enums are stored as `std::string_view`, not as `std::string` like the others.  (Both are `inline` though.)

The problem did not affect the conversion as such, and that is why a pure unit test was not enough to catch it.  But it did show up when converting a `pqxx::field` value.