### PR TITLE
Fix memory leak when connection fails.

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -114,7 +114,11 @@ pqxx::connection::connection(
   if (m_conn == nullptr)
     throw std::bad_alloc{};
   if (status() == CONNECTION_BAD)
+  {
+    PQfinish(m_conn);
+    m_conn = nullptr;
     throw pqxx::broken_connection{PQerrorMessage(m_conn)};
+  }
 }
 
 


### PR DESCRIPTION
This was one path where a failed connection attempt left some memory allocated.