### PR TITLE
Get rid of tabs in code.

### DIFF
--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -547,7 +547,7 @@ public:
    * void setpw(transaction_base &t, string const &user, string const &pw)
    * {
    *   t.exec0("ALTER USER " + user + " "
-   *   	"PASSWORD '" + t.conn().encrypt_password(user,pw) + "'");
+   *       "PASSWORD '" + t.conn().encrypt_password(user,pw) + "'");
    * }
    * ```
    *

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -54,9 +54,9 @@ namespace pqxx
  * also access a row by indexing a `result R` by the row's zero-based
  * number:
  *
- *
- *	for (result::size_type i=0; i < std::size(R); ++i) Process(R[i]);
- *
+ * ```cxx
+ *     for (result::size_type i=0; i < std::size(R); ++i) Process(R[i]);
+ * ```
  *
  * Result sets in libpqxx are lightweight, reference-counted wrapper objects
  * which are relatively small and cheap to copy.  Think of a result object as

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -37,7 +37,7 @@ namespace pqxx
  * values (see below):
  *
  * ```cxx
- *	cout << row["date"].c_str() << ": " << row["name"].c_str() << endl;
+ *    cout << row["date"].c_str() << ": " << row["name"].c_str() << endl;
  * ```
  *
  * The row itself acts like a (non-modifyable) container, complete with its

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -56,12 +56,12 @@ namespace pqxx
  * try
  * {
  *   T.exec0("UPDATE employees SET wage=wage*2");
- *   T.commit();	// NOTE: do this inside try block
+ *   T.commit();  // NOTE: do this inside try block
  * }
  * catch (exception const &e)
  * {
  *   cerr << e.what() << endl;
- *   T.abort();		// Usually not needed; same happens when T's life ends.
+ *   T.abort();  // Usually not needed; same happens when T's life ends.
  * }
  * ```
  */

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -94,7 +94,7 @@ namespace pqxx
  *
  * @param callback Transaction code that can be called with no arguments.
  * @param attempts Maximum number of times to attempt performing callback.
- *	Must be greater than zero.
+ *     Must be greater than zero.
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>

--- a/tools/extract_version
+++ b/tools/extract_version
@@ -9,7 +9,7 @@ srcdir=${srcdir:-.}
 
 # Print usage information.
 usage() {
-	cat <<EOF
+    cat <<EOF
 Print libpqxx version information based on the source tree's VERSION file.
 
 Usage: $0 [option]
@@ -28,11 +28,11 @@ EOF
 
 # Print "unknown argument" error.
 unknown_arg() {
-	cat <<EOF >&2
+    cat <<EOF >&2
 Unknown argument: $1.
 Try
 
-	$0 --help
+    $0 --help
 
 for usage information.
 EOF
@@ -41,33 +41,33 @@ EOF
 
 case "$ARG" in
 ''|-f|--full)
-	# Default: Print full version.
-	cat "$srcdir/VERSION"
-	;;
+    # Default: Print full version.
+    cat "$srcdir/VERSION"
+    ;;
 
 -h|--help)
-	# Print usage information, and exit.
-	usage
-	exit
-	;;
+    # Print usage information, and exit.
+    usage
+    exit
+    ;;
 
 -a|--abi)
-	# Print just the ABI version (major & minor).
-	sed -e 's/^\([^.]*\.[^.]*\)\..*/\1/' "$srcdir/VERSION"
-	;;
+    # Print just the ABI version (major & minor).
+    sed -e 's/^\([^.]*\.[^.]*\)\..*/\1/' "$srcdir/VERSION"
+    ;;
 
 -M|--major)
-	# Print the major version number.
-	sed -e 's/^\([^.]*\)\..*/\1/' "$srcdir/VERSION"
-	;;
+    # Print the major version number.
+    sed -e 's/^\([^.]*\)\..*/\1/' "$srcdir/VERSION"
+    ;;
 
 -m|--minor)
-	# Print the minor version number.
-	sed -e 's/^[^.]*\.\([^.]*\)\..*/\1/' "$srcdir/VERSION"
-	;;
+    # Print the minor version number.
+    sed -e 's/^[^.]*\.\([^.]*\)\..*/\1/' "$srcdir/VERSION"
+    ;;
 
 *)
-	unknown_arg "$ARG"
-	exit 1
-	;;
+    unknown_arg "$ARG"
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
There were still a few tabs here and there.  I guess clang-format doesn't clean those up.