### PR TITLE
add binary option to stream / COPY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ win32/common
 **/runner.log
 **/runner.trs
 **/test-suite.log
+/x64
+/CMakeFiles
+/.vs
+/out
+/Testing/Temporary
+/unit_runner.dir

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -102,6 +102,24 @@ public:
 #include "pqxx/internal/ignore-deprecated-post.hxx"
   }
 
+  /// Factory: Execute query, and stream the results.
+  /** The query can be a SELECT query or a VALUES query; or it can be an
+   * UPDATE, INSERT, or DELETE with a RETURNING clause.
+   *
+   * The query is executed as part of a COPY statement, so there are additional
+   * restrictions on what kind of query you can use here.  See the PostgreSQL
+   * documentation for the COPY command:
+   *
+   *     https://www.postgresql.org/docs/current/sql-copy.html
+   */
+  static stream_from query_binary(transaction_base &tx, std::string_view q)
+  {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
+    return stream_from{tx, from_query, q, true};
+#include "pqxx/internal/ignore-deprecated-post.hxx"
+  }
+
+
   /**
    * @name Streaming data from tables
    *

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -38,13 +38,12 @@ constexpr std::string_view class_name{"stream_from"};
 
 
 pqxx::stream_from::stream_from(
-  transaction_base &tx, from_query_t, std::string_view query) :
+  transaction_base &tx, from_query_t, std::string_view query, bool binary /*= false*/) :
         transaction_focus{tx, class_name}, m_char_finder{get_finder(tx)}
 {
-  tx.exec0(internal::concat("COPY ("sv, query, ") TO STDOUT"sv));
+  tx.exec0(binary?internal::concat("COPY ("sv, query, ") TO STDOUT WITH BINARY"sv):internal::concat("COPY ("sv, query, ") TO STDOUT"sv));
   register_me();
 }
-
 
 pqxx::stream_from::stream_from(
   transaction_base &tx, from_table_t, std::string_view table) :


### PR DESCRIPTION
Add a binary option to stream_to and stream_from. 
This could increase performance for some use cases, but beware it requires to handle the raw encoding / decoding in your client code.