### PR TITLE
Disable clang-based parsing in Doxygen.

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -178,7 +178,8 @@ SKIP_FUNCTION_MACROS   = NO
 # generated with the -Duse_libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = YES
+# TODO: Re-enable this once clang parser gets better.
+CLANG_ASSISTED_PARSING = NO
 
 # If the CLANG_ASSISTED_PARSING tag is set to YES and the CLANG_ADD_INC_PATHS
 # tag is set to YES then doxygen will add the directory of each input to the


### PR DESCRIPTION
The clang-assisted parsing in Doxygen is supposed to be slower but more accurate.

However I find that it just leads to tons of ridiculous errors, showing a complete and radical lack of comprehension of the code it's parsing. Seems to be failing to expand macros.