### PR TITLE
doc: fix doxygen-html build output directory

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,6 +14,6 @@ add_custom_target(build-docs ALL
 )
 
 install(
-    DIRECTORY doxygen-html
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doxygen-html/
     DESTINATION ${CMAKE_INSTALL_DOCDIR}/html
 )


### PR DESCRIPTION
Relative directories for the CMake `install` `DIRECTORY` command are interpreted with respect to the current source directory [1], whereas the `doxygen-html` output is generated in the current binary directory. So use the `CMAKE_CURRENT_BINARY_DIR` variable to specify the correct `doxygen-html` build output directory for installation. Also add a trailing slash to avoid appending the `doxygen-html` directory to the destination directory.

 * `doc/CMakeLists.txt`: fix `doxygen-html` build output directory

[1] https://cmake.org/cmake/help/latest/command/install.html#directory