### PR TITLE
Don't copy headers when not building docs.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@
  - Another fix to the readthedocs documentation build. (#845)
  - Work around CMake 3.30 renaming one of its functions. (#851)
  - Support reading a field as an SQL array using `as_sql_array()`. (#841)
+ - Don't copy headers into build tree when not building docs.
 7.9.1
  - Fix bad conversion of array of empty strings to string. (#816)
  - Move `[[likely]]` feature check back to compile time, to speed up configure.

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  - Bump gcc/clang/postgres minimum version requirements.
  - Another fix to the readthedocs documentation build. (#845)
  - Work around CMake 3.30 renaming one of its functions. (#851)
+ - Support reading a field as an SQL array using `as_sql_array()`. (#841)
 7.9.1
  - Fix bad conversion of array of empty strings to string. (#816)
  - Move `[[likely]]` feature check back to compile time, to speed up configure.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -14,6 +14,7 @@ else
 DOXYGEN = echo -n "Not running doxygen "
 endif
 
+if BUILD_DOCS
 # Doxygen config needs the source files in its local tree.  That means the
 # build tree.  If that differs from the source tree, copy the files.
 docs:
@@ -23,6 +24,9 @@ docs:
 	    cp -r "$(srcdir)"/../test ../test/ ; \
 	fi
 	$(DOXYGEN) "$(srcdir)"/Doxyfile
+else
+docs:
+endif
 
 dist-hook:
 	if [ -d doxygen-html ]; then \

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -470,13 +470,14 @@ all-local: docs
 
 # Doxygen config needs the source files in its local tree.  That means the
 # build tree.  If that differs from the source tree, copy the files.
-docs:
-	if ! [ "$(srcdir)/../src" -ef ../src ]; then \
-	    cp "$(srcdir)"/../src/*.[ch]xx ../src/ ; \
-	    cp -r "$(srcdir)"/../include/pqxx/* ../include/pqxx/ ; \
-	    cp -r "$(srcdir)"/../test ../test/ ; \
-	fi
-	$(DOXYGEN) "$(srcdir)"/Doxyfile
+@BUILD_DOCS_TRUE@docs:
+@BUILD_DOCS_TRUE@	if ! [ "$(srcdir)/../src" -ef ../src ]; then \
+@BUILD_DOCS_TRUE@	    cp "$(srcdir)"/../src/*.[ch]xx ../src/ ; \
+@BUILD_DOCS_TRUE@	    cp -r "$(srcdir)"/../include/pqxx/* ../include/pqxx/ ; \
+@BUILD_DOCS_TRUE@	    cp -r "$(srcdir)"/../test ../test/ ; \
+@BUILD_DOCS_TRUE@	fi
+@BUILD_DOCS_TRUE@	$(DOXYGEN) "$(srcdir)"/Doxyfile
+@BUILD_DOCS_FALSE@docs:
 
 dist-hook:
 	if [ -d doxygen-html ]; then \

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -200,7 +200,11 @@ private:
           "Malformed array: does not end in the right number of '}'."};
   }
 
-  explicit array(std::string_view data, pqxx::internal::encoding_group enc)
+  // Allow fields to construct arrays passing the encoding group.
+  // Couldn't make this work through a call gate, thanks to the templating.
+  friend class ::pqxx::field;
+
+  array(std::string_view data, pqxx::internal::encoding_group enc)
   {
     using group = pqxx::internal::encoding_group;
     switch (enc)

--- a/include/pqxx/doc/mainpage.md
+++ b/include/pqxx/doc/mainpage.md
@@ -3,7 +3,7 @@ libpqxx                                      {#mainpage}
 
 @version 7.9.2
 @author Jeroen T. Vermeulen
-@see http://pqxx.org
+@see https://pqxx.org/libpqxx/
 @see https://github.com/jtv/libpqxx
 
 Welcome to libpqxx, the C++ API to the PostgreSQL database management system.

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -243,6 +243,19 @@ public:
     return as<O<T>>();
   }
 
+  /// Read SQL array contents as a @ref pqxx::array.
+  template<typename ELEMENT, auto... ARGS>
+  array<ELEMENT, ARGS...> as_sql_array() const
+  {
+    using array_type = array<ELEMENT, ARGS...>;
+
+    // There's no such thing as a null SQL array.
+    if (is_null())
+      internal::throw_null_conversion(type_name<array_type>);
+    else
+      return array_type{this->view(), this->m_home.m_encoding};
+  }
+
   /// Parse the field as an SQL array.
   /** Call the parser to retrieve values (and structure) from the array.
    *
@@ -250,6 +263,10 @@ public:
    * you keep the @ref row of `field` object alive, it will keep the @ref
    * result object alive as well.
    */
+  [[deprecated(
+    "Avoid pqxx::array_parser.  "
+    "Instead, use as_sql_array() to convert to pqxx::array."
+  )]]
   array_parser as_array() const & noexcept
   {
     return array_parser{c_str(), m_home.m_encoding};

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -693,6 +693,16 @@ void test_array_iterates_in_row_major_order()
 }
 
 
+void test_as_sql_array()
+{
+  pqxx::connection conn;
+  pqxx::work tx{conn};
+  auto const r{tx.exec1("SELECT ARRAY [5, 4, 3, 2]")};
+  auto const array{r[0].as_sql_array<int>()};
+  PQXX_CHECK_EQUAL(array[1], 4, "Got wrong value out of array.");
+}
+
+
 PQXX_REGISTER_TEST(test_empty_arrays);
 PQXX_REGISTER_TEST(test_array_null_value);
 PQXX_REGISTER_TEST(test_array_double_quoted_string);
@@ -714,4 +724,5 @@ PQXX_REGISTER_TEST(test_array_parses_multidim_arrays);
 PQXX_REGISTER_TEST(test_array_at_checks_bounds);
 PQXX_REGISTER_TEST(test_array_iterates_in_row_major_order);
 PQXX_REGISTER_TEST(test_array_generate_empty_strings);
+PQXX_REGISTER_TEST(test_as_sql_array);
 } // namespace


### PR DESCRIPTION
In order to help Doxygen find all the headers, I had the `docs` target
copy all of them into the build tree (if that differed from the source
tree).

But it turns out that that was happening even on non-documentation
builds.  Which makes development a little hard, because you're always
working with _copies_ of the headers, stuck in the build tree!

For now, just skip the copying when not configured to generate
documentation.  Later we can look into copying the headers somewhere
into the `docs` directory instead, so they don't get into the way of
the source build itself.