### PR TITLE
Only copy headers to source tree if building docs.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -10,10 +10,6 @@ all-local: docs
 
 if BUILD_DOCS
 DOXYGEN = doxygen
-else
-DOXYGEN = echo -n "Not running doxygen "
-endif
-
 # Doxygen config needs the source files in its local tree.  That means the
 # build tree.  If that differs from the source tree, copy the files.
 docs:
@@ -23,6 +19,9 @@ docs:
 	    cp -r "$(srcdir)"/../test ../test/ ; \
 	fi
 	$(DOXYGEN) "$(srcdir)"/Doxyfile
+else
+docs:
+endif
 
 dist-hook:
 	if [ -d doxygen-html ]; then \

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -260,7 +260,6 @@ top_srcdir = @top_srcdir@
 with_postgres_lib = @with_postgres_lib@
 MAINTAINERCLEANFILES = Makefile.in
 EXTRA_DIST = Doxyfile
-@BUILD_DOCS_FALSE@DOXYGEN = echo -n "Not running doxygen "
 @BUILD_DOCS_TRUE@DOXYGEN = doxygen
 all: all-am
 
@@ -467,16 +466,16 @@ maintainer-clean-local:
 	$(MKDIR) doxygen-html
 
 all-local: docs
-
 # Doxygen config needs the source files in its local tree.  That means the
 # build tree.  If that differs from the source tree, copy the files.
-docs:
-	if ! [ "$(srcdir)/../src" -ef ../src ]; then \
-	    cp "$(srcdir)"/../src/*.[ch]xx ../src/ ; \
-	    cp -r "$(srcdir)"/../include/pqxx/* ../include/pqxx/ ; \
-	    cp -r "$(srcdir)"/../test ../test/ ; \
-	fi
-	$(DOXYGEN) "$(srcdir)"/Doxyfile
+@BUILD_DOCS_TRUE@docs:
+@BUILD_DOCS_TRUE@	if ! [ "$(srcdir)/../src" -ef ../src ]; then \
+@BUILD_DOCS_TRUE@	    cp "$(srcdir)"/../src/*.[ch]xx ../src/ ; \
+@BUILD_DOCS_TRUE@	    cp -r "$(srcdir)"/../include/pqxx/* ../include/pqxx/ ; \
+@BUILD_DOCS_TRUE@	    cp -r "$(srcdir)"/../test ../test/ ; \
+@BUILD_DOCS_TRUE@	fi
+@BUILD_DOCS_TRUE@	$(DOXYGEN) "$(srcdir)"/Doxyfile
+@BUILD_DOCS_FALSE@docs:
 
 dist-hook:
 	if [ -d doxygen-html ]; then \

--- a/include/pqxx/doc/mainpage.md
+++ b/include/pqxx/doc/mainpage.md
@@ -3,7 +3,7 @@ libpqxx                                      {#mainpage}
 
 @version 7.9.2
 @author Jeroen T. Vermeulen
-@see http://pqxx.org
+@see https://pqxx.org/libpqxx/
 @see https://github.com/jtv/libpqxx
 
 Welcome to libpqxx, the C++ API to the PostgreSQL database management system.


### PR DESCRIPTION
The `docs` target copies the header files into the build tree, so that doxygen can find them.  But that turns out to cause trouble for regular development: the `docs` target gets built even when not configured to build documentation, so you're always compiling using copies of the header files.  A real pain when editing those.

For now, just skip the copying when not configured to build the docs. In a later iteration we can do something more sensible such as copy the headers and the source files to a different location in the build tree.