### PR TITLE
853: Silly typo in obscure `stream_to` constructor.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  - Bump gcc/clang/postgres minimum version requirements.
  - Another fix to the readthedocs documentation build. (#845)
  - Work around CMake 3.30 renaming one of its functions. (#851)
+ - Fix obscure deprecated `stream_to` constructor. (#853)
 7.9.1
  - Fix bad conversion of array of empty strings to string. (#816)
  - Move `[[likely]]` feature check back to compile time, to speed up configure.

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@
  - Bump gcc/clang/postgres minimum version requirements.
  - Another fix to the readthedocs documentation build. (#845)
  - Work around CMake 3.30 renaming one of its functions. (#851)
- - Fix obscure deprecated `stream_to` constructor. (#853)
+ - Remove obscure deprecated `stream_to` constructor that never worked. (#853)
 7.9.1
  - Fix bad conversion of array of empty strings to string. (#816)
  - Move `[[likely]]` feature check back to compile time, to speed up configure.

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -260,14 +260,6 @@ public:
   [[deprecated("Use table() or raw_table() factory.")]] stream_to(
     transaction_base &, std::string_view table_name, Columns const &columns);
 
-  /// Create a stream, specifying column names as a sequence of strings.
-  /** @deprecated Use @ref table or @ref raw_table as a factory.
-   */
-  template<typename Iter>
-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
-    transaction_base &, std::string_view table_name, Iter columns_begin,
-    Iter columns_end);
-
 private:
   /// Stream a pre-quoted table name and columns list.
   stream_to(
@@ -472,19 +464,6 @@ template<typename Columns>
 inline stream_to::stream_to(
   transaction_base &tx, std::string_view table_name, Columns const &columns) :
         stream_to{tx, table_name, std::begin(columns), std::end(columns)}
-{}
-
-
-template<typename Iter>
-inline stream_to::stream_to(
-  transaction_base &tx, std::string_view table_name, Iter columns_begin,
-  Iter columns_end) :
-        stream_to{
-          tx,
-          tx.quote_name(table_name),
-          separated_list(",", columns_begin, columns_end, [&tx](auto col) {
-              return tx.quote_name(*col);
-            })}
 {}
 } // namespace pqxx
 #endif

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -481,11 +481,10 @@ inline stream_to::stream_to(
   Iter columns_end) :
         stream_to{
           tx,
-          tx.quote_name(
-            table_name,
-            separated_list(",", columns_begin, columns_end, [&tx](auto col) {
+          tx.quote_name(table_name),
+          separated_list(",", columns_begin, columns_end, [&tx](auto col) {
               return tx.quote_name(*col);
-            }))}
+            })}
 {}
 } // namespace pqxx
 #endif


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/853

This has been broken (at compile time!) for _years_ but someone finally noticed.  It's a deprecated constructor, so perhaps I ought to delete it rather than fix it.