### PR TITLE
Make row iterator a proper `random_access_iterator`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@
  - Work around CMake 3.30 renaming one of its functions. (#851)
  - Remove obscure deprecated `stream_to` constructor that never worked. (#853)
  - Support reading a field as an SQL array using `as_sql_array()`. (#841)
+ - Make row iterator a _proper_ `random_access_iterator`. (#846)
+ - Downgrade result iterator to "bidirectional"; was never really RA. (#846)
 7.9.1
  - Fix bad conversion of array of empty strings to string. (#816)
  - Move `[[likely]]` feature check back to compile time, to speed up configure.

--- a/include/pqxx/internal/result_iterator.hxx
+++ b/include/pqxx/internal/result_iterator.hxx
@@ -32,6 +32,7 @@ namespace pqxx
 class PQXX_LIBEXPORT const_result_iterator : public row
 {
 public:
+  // TODO: Change operator[] so this becomes a proper random_access_iterator.
   using iterator_category = std::bidirectional_iterator_tag;
   using value_type = row const;
   using pointer = row const *;
@@ -80,6 +81,7 @@ public:
   //@{
   using row::back;
   using row::front;
+  // TODO: Replace with standard operator[]: i[n] == *(i + n).
   using row::operator[];
   using row::at;
   using row::rownumber;
@@ -239,6 +241,7 @@ public:
   //@{
   using const_result_iterator::back;
   using const_result_iterator::front;
+  // TODO: Replace with standard operator[]: i[n] == *(i + n).
   using const_result_iterator::operator[];
   using const_result_iterator::at;
   using const_result_iterator::rownumber;

--- a/include/pqxx/internal/result_iterator.hxx
+++ b/include/pqxx/internal/result_iterator.hxx
@@ -32,7 +32,7 @@ namespace pqxx
 class PQXX_LIBEXPORT const_result_iterator : public row
 {
 public:
-  using iterator_category = std::random_access_iterator_tag;
+  using iterator_category = std::bidirectional_iterator_tag;
   using value_type = row const;
   using pointer = row const *;
   using reference = row;

--- a/include/pqxx/internal/result_iterator.hxx
+++ b/include/pqxx/internal/result_iterator.hxx
@@ -55,9 +55,9 @@ public:
    * @name Dereferencing operators
    *
    * An iterator "points to" its own row, which is also itself.  This makes it
-   * easy to address a @ref result as a two-dimensional container, without
-   * going through the intermediate step of dereferencing the iterator.  It
-   * makes the interface similar to C pointer/array semantics.
+   * easy to address a @ref pqxx::result as a two-dimensional container,
+   * without going through the intermediate step of dereferencing the iterator.
+   * It makes the interface similar to C pointer/array semantics.
    *
    * IIRC Alex Stepanov, the inventor of the STL, once remarked that having
    * this as standard behaviour for pointers would be useful in some

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -397,6 +397,9 @@ public:
   operator-(difference_type) const noexcept;
   [[nodiscard]] inline difference_type
   operator-(const_row_iterator const &) const noexcept;
+
+  [[nodiscard]] inline field operator[](difference_type offset) const noexcept
+  { return *(*this + offset); }
   //@}
 };
 
@@ -487,6 +490,8 @@ public:
   {
     return rhs.const_row_iterator::operator-(*this);
   }
+  [[nodiscard]] inline field operator[](difference_type offset) const noexcept
+  { return *(*this + offset); }
   //@}
 
   /**

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -399,7 +399,9 @@ public:
   operator-(const_row_iterator const &) const noexcept;
 
   [[nodiscard]] inline field operator[](difference_type offset) const noexcept
-  { return *(*this + offset); }
+  {
+    return *(*this + offset);
+  }
   //@}
 };
 
@@ -491,7 +493,9 @@ public:
     return rhs.const_row_iterator::operator-(*this);
   }
   [[nodiscard]] inline field operator[](difference_type offset) const noexcept
-  { return *(*this + offset); }
+  {
+    return *(*this + offset);
+  }
   //@}
 
   /**

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -84,8 +84,12 @@ void test_row_iterator_array_index_offsets_iterator()
   pqxx::connection conn;
   pqxx::work tx{conn};
   auto const row{tx.exec1("SELECT 5, 4, 3, 2")};
-  PQXX_CHECK_EQUAL(row.begin()[1].as<std::string>(), "4", "Row iterator indexing went wrong.");
-  PQXX_CHECK_EQUAL(row.rbegin()[1].as<std::string>(), "3", "Reverse row iterator indexing went wrong.");
+  PQXX_CHECK_EQUAL(
+    row.begin()[1].as<std::string>(), "4",
+    "Row iterator indexing went wrong.");
+  PQXX_CHECK_EQUAL(
+    row.rbegin()[1].as<std::string>(), "3",
+    "Reverse row iterator indexing went wrong.");
 }
 
 

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -78,7 +78,19 @@ void test_row_as()
 }
 
 
+// In a random access iterator i, i[n] == *(i + n).
+void test_row_iterator_array_index_offsets_iterator()
+{
+  pqxx::connection conn;
+  pqxx::work tx{conn};
+  auto const row{tx.exec1("SELECT 5, 4, 3, 2")};
+  PQXX_CHECK_EQUAL(row.begin()[1].as<std::string>(), "4", "Row iterator indexing went wrong.");
+  PQXX_CHECK_EQUAL(row.rbegin()[1].as<std::string>(), "3", "Reverse row iterator indexing went wrong.");
+}
+
+
 PQXX_REGISTER_TEST(test_row);
 PQXX_REGISTER_TEST(test_row_iterator);
 PQXX_REGISTER_TEST(test_row_as);
+PQXX_REGISTER_TEST(test_row_iterator_array_index_offsets_iterator);
 } // namespace


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/846

This involves defining `operator[]` on the iterator, which indexes at an offset: `i[n] == *(i + n)`.

Unfortunately I can't do the same for the _result_ iterator.  Way back when, unaware of this requirement, I defined array indexing on a result iterator as `i[n] == (*i)[n]`.  It made some code a lot more convenient and seemed very logical.