### PR TITLE
Clean up naming of `conn` & `trans` variables.

### DIFF
--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -56,7 +56,7 @@ class array final
 {
 public:
   /// Parse an SQL array, read as text from a pqxx::result or stream.
-  /** Uses `conn` only during construction, to find out the text encoding in
+  /** Uses `cx` only during construction, to find out the text encoding in
    * which it should interpret `data`.
    *
    * Once the `array` constructor completes, destroying or moving the
@@ -65,8 +65,8 @@ public:
    * @throws pqxx::unexpected_null if the array contains a null value, and the
    * `ELEMENT` type does not support null values.
    */
-  array(std::string_view data, connection const &conn) :
-          array{data, pqxx::internal::enc_group(conn.encoding_id())}
+  array(std::string_view data, connection const &cx) :
+          array{data, pqxx::internal::enc_group(cx.encoding_id())}
   {}
 
   /// How many dimensions does this array have?

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -323,8 +323,8 @@ public:
   void close();
 
 private:
-  PQXX_PRIVATE blob(connection &conn, int fd) noexcept :
-          m_conn{&conn}, m_fd{fd}
+  PQXX_PRIVATE blob(connection &cx, int fd) noexcept :
+          m_conn{&cx}, m_fd{fd}
   {}
   static PQXX_PRIVATE blob open_internal(dbtransaction &, oid, int);
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -323,9 +323,7 @@ public:
   void close();
 
 private:
-  PQXX_PRIVATE blob(connection &cx, int fd) noexcept :
-          m_conn{&cx}, m_fd{fd}
-  {}
+  PQXX_PRIVATE blob(connection &cx, int fd) noexcept : m_conn{&cx}, m_fd{fd} {}
   static PQXX_PRIVATE blob open_internal(dbtransaction &, oid, int);
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
   raw_conn(pqxx::connection *) noexcept;

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -1188,9 +1188,9 @@ using connection_base = connection;
  *         cg.process();
  *     }
  *
- *     pqxx::connection conn = std::move(cg).produce();
+ *     pqxx::connection cx = std::move(cg).produce();
  *
- *     // At this point, conn is a working connection.  You can no longer use
+ *     // At this point, cx is a working connection.  You can no longer use
  *     // cg at all.
  * ```
  */

--- a/include/pqxx/errorhandler.hxx
+++ b/include/pqxx/errorhandler.hxx
@@ -81,7 +81,7 @@ class quiet_errorhandler : public errorhandler
 {
 public:
   /// Suppress error notices.
-  quiet_errorhandler(connection &conn) : errorhandler{conn} {}
+  quiet_errorhandler(connection &cx) : errorhandler{cx} {}
 
   /// Revert to previous handling of error notices.
   virtual bool operator()(char const[]) noexcept override { return false; }

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -265,8 +265,7 @@ public:
    */
   [[deprecated(
     "Avoid pqxx::array_parser.  "
-    "Instead, use as_sql_array() to convert to pqxx::array."
-  )]]
+    "Instead, use as_sql_array() to convert to pqxx::array.")]]
   array_parser as_array() const & noexcept
   {
     return array_parser{c_str(), m_home.m_encoding};

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -121,8 +121,8 @@ public:
     transaction_base &tx, table_path path,
     std::initializer_list<std::string_view> columns = {})
   {
-    auto const &conn{tx.conn()};
-    return raw_table(tx, conn.quote_table(path), conn.quote_columns(columns));
+    auto const &cx{tx.conn()};
+    return raw_table(tx, cx.quote_table(path), cx.quote_columns(columns));
   }
 
 #if defined(PQXX_HAVE_CONCEPTS)
@@ -138,9 +138,9 @@ public:
   static stream_to
   table(transaction_base &tx, table_path path, COLUMNS const &columns)
   {
-    auto const &conn{tx.conn()};
+    auto const &cx{tx.conn()};
     return stream_to::raw_table(
-      tx, conn.quote_table(path), tx.conn().quote_columns(columns));
+      tx, cx.quote_table(path), tx.conn().quote_columns(columns));
   }
 
   /// Create a `stream_to` writing to a named table and columns.

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -23,9 +23,9 @@ constexpr int INV_WRITE{0x00020000}, INV_READ{0x00040000};
 
 
 pqxx::internal::pq::PGconn *
-pqxx::blob::raw_conn(pqxx::connection *conn) noexcept
+pqxx::blob::raw_conn(pqxx::connection *cx) noexcept
 {
-  pqxx::internal::gate::connection_largeobject const gate{*conn};
+  pqxx::internal::gate::connection_largeobject const gate{*cx};
   return gate.raw_connection();
 }
 
@@ -37,21 +37,21 @@ pqxx::blob::raw_conn(pqxx::dbtransaction const &tx) noexcept
 }
 
 
-std::string pqxx::blob::errmsg(connection const *conn)
+std::string pqxx::blob::errmsg(connection const *cx)
 {
-  pqxx::internal::gate::const_connection_largeobject const gate{*conn};
+  pqxx::internal::gate::const_connection_largeobject const gate{*cx};
   return gate.error_message();
 }
 
 
 pqxx::blob pqxx::blob::open_internal(dbtransaction &tx, oid id, int mode)
 {
-  auto &conn{tx.conn()};
-  int const fd{lo_open(raw_conn(&conn), id, mode)};
+  auto &cx{tx.conn()};
+  int const fd{lo_open(raw_conn(&cx), id, mode)};
   if (fd == -1)
     throw pqxx::failure{internal::concat(
-      "Could not open binary large object ", id, ": ", errmsg(&conn))};
-  return {conn, fd};
+      "Could not open binary large object ", id, ": ", errmsg(&cx))};
+  return {cx, fd};
 }
 
 

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -22,8 +22,7 @@ constexpr int INV_WRITE{0x00020000}, INV_READ{0x00040000};
 } // namespace
 
 
-pqxx::internal::pq::PGconn *
-pqxx::blob::raw_conn(pqxx::connection *cx) noexcept
+pqxx::internal::pq::PGconn *pqxx::blob::raw_conn(pqxx::connection *cx) noexcept
 {
   pqxx::internal::gate::connection_largeobject const gate{*cx};
   return gate.raw_connection();

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -66,9 +66,9 @@ extern "C"
 {
   // The PQnoticeProcessor that receives an error or warning from libpq and
   // sends it to the appropriate connection for processing.
-  void pqxx_notice_processor(void *conn, char const *msg) noexcept
+  void pqxx_notice_processor(void *cx, char const *msg) noexcept
   {
-    reinterpret_cast<pqxx::connection *>(conn)->process_notice(msg);
+    reinterpret_cast<pqxx::connection *>(cx)->process_notice(msg);
   }
 
 
@@ -553,9 +553,9 @@ using notify_ptr = std::unique_ptr<PGnotify, void (*)(void const *)>;
 
 
 /// Get one notification from a connection, or null.
-notify_ptr get_notif(pqxx::internal::pq::PGconn *conn)
+notify_ptr get_notif(pqxx::internal::pq::PGconn *cx)
 {
-  return {PQnotifies(conn), pqxx::internal::pq::pqfreemem};
+  return {PQnotifies(cx), pqxx::internal::pq::pqfreemem};
 }
 } // namespace
 

--- a/src/errorhandler.cxx
+++ b/src/errorhandler.cxx
@@ -19,7 +19,7 @@
 #include "pqxx/internal/header-post.hxx"
 
 
-pqxx::errorhandler::errorhandler(connection &conn) : m_home{&conn}
+pqxx::errorhandler::errorhandler(connection &cx) : m_home{&cx}
 {
   pqxx::internal::gate::connection_errorhandler{*m_home}.register_errorhandler(
     this);

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -88,9 +88,9 @@ pqxx::stream_from pqxx::stream_from::table(
   transaction_base &tx, table_path path,
   std::initializer_list<std::string_view> columns)
 {
-  auto const &conn{tx.conn()};
+  auto const &cx{tx.conn()};
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
-  return raw_table(tx, conn.quote_table(path), conn.quote_columns(columns));
+  return raw_table(tx, cx.quote_table(path), cx.quote_columns(columns));
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 

--- a/test/test01.cxx
+++ b/test/test01.cxx
@@ -13,11 +13,11 @@ namespace
 // a transaction, and perform a query inside it.
 void test_001()
 {
-  connection conn;
+  connection cx;
 
   // Begin a transaction acting on our current connection.  Give it a human-
   // readable name so the library can include it in error messages.
-  work tx{conn, "test1"};
+  work tx{cx, "test1"};
 
   // Perform a query on the database, storing result rows in R.
   result r(tx.exec("SELECT * FROM pg_tables"));

--- a/test/test02.cxx
+++ b/test/test02.cxx
@@ -12,7 +12,7 @@ namespace
 {
 void bad_connect()
 {
-  connection conn{"totally#invalid@connect$string!?"};
+  connection cx{"totally#invalid@connect$string!?"};
 }
 
 void test_002()

--- a/test/test04.cxx
+++ b/test/test04.cxx
@@ -30,8 +30,8 @@ class TestListener final : public notification_receiver
   bool m_done;
 
 public:
-  explicit TestListener(connection &conn) :
-          notification_receiver(conn, "listen"), m_done(false)
+  explicit TestListener(connection &cx) :
+          notification_receiver(cx, "listen"), m_done(false)
   {}
 
   virtual void operator()(std::string const &, int be_pid) override
@@ -47,14 +47,14 @@ public:
 
 void test_004()
 {
-  connection conn;
+  connection cx;
 
-  TestListener L{conn};
+  TestListener L{cx};
   // Trigger our notification receiver.
-  perform([&conn, &L] {
-    work tx(conn);
-    tx.exec0("NOTIFY " + conn.quote_name(L.channel()));
-    Backend_PID = conn.backendpid();
+  perform([&cx, &L] {
+    work tx(cx);
+    tx.exec0("NOTIFY " + cx.quote_name(L.channel()));
+    Backend_PID = cx.backendpid();
     tx.commit();
   });
 
@@ -65,7 +65,7 @@ void test_004()
     // Sleep for one second.  I'm not proud of this, but how does one inject
     // a change to the built-in clock in a static language?
     pqxx::internal::wait_for(1000u);
-    notifs = conn.get_notifs();
+    notifs = cx.get_notifs();
   }
 
   PQXX_CHECK_NOT_EQUAL(L.done(), false, "No notification received.");

--- a/test/test07.cxx
+++ b/test/test07.cxx
@@ -38,11 +38,11 @@ int To4Digits(int Y)
 
 void test_007()
 {
-  connection conn;
-  conn.set_client_encoding("SQL_ASCII");
+  connection cx;
+  cx.set_client_encoding("SQL_ASCII");
 
   {
-    work tx{conn};
+    work tx{cx};
     test::create_pqxxevents(tx);
     tx.commit();
   }
@@ -50,8 +50,8 @@ void test_007()
   // Perform (an instantiation of) the UpdateYears transactor we've defined
   // in the code above.  This is where the work gets done.
   std::map<int, int> conversions;
-  perform([&conversions, &conn] {
-    work tx{conn};
+  perform([&conversions, &cx] {
+    work tx{cx};
     // First select all different years occurring in the table.
     result R(tx.exec("SELECT year FROM pqxxevents"));
 

--- a/test/test10.cxx
+++ b/test/test10.cxx
@@ -92,8 +92,8 @@ void Test(connection &C, bool ExplicitAbort)
 
 void test_abort()
 {
-  connection conn;
-  nontransaction t{conn};
+  connection cx;
+  nontransaction t{cx};
   test::create_pqxxevents(t);
   connection &c(t.conn());
   t.commit();

--- a/test/test11.cxx
+++ b/test/test11.cxx
@@ -14,8 +14,8 @@ namespace
 {
 void test_011()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
   std::string const Table{"pg_tables"};
 
   result R(tx.exec("SELECT * FROM " + Table));

--- a/test/test13.cxx
+++ b/test/test13.cxx
@@ -21,9 +21,9 @@ constexpr unsigned int BoringYear = 1977;
 
 // Count events and specifically events occurring in Boring Year, leaving the
 // former count in the result pair's first member, and the latter in second.
-std::pair<int, int> count_events(connection &conn, std::string const &table)
+std::pair<int, int> count_events(connection &cx, std::string const &table)
 {
-  work tx{conn};
+  work tx{cx};
   std::string const count_query{"SELECT count(*) FROM " + table};
   return std::make_pair(
     tx.query_value<int>(count_query),
@@ -50,9 +50,9 @@ void failed_insert(connection &C, std::string const &table)
 
 void test_013()
 {
-  connection conn;
+  connection cx;
   {
-    work tx{conn};
+    work tx{cx};
     test::create_pqxxevents(tx);
     tx.commit();
   }
@@ -60,18 +60,18 @@ void test_013()
   std::string const Table{"pqxxevents"};
 
   auto const Before{
-    perform([&conn, &Table] { return count_events(conn, Table); })};
+    perform([&cx, &Table] { return count_events(cx, Table); })};
   PQXX_CHECK_EQUAL(
     Before.second, 0,
     "Already have event for " + to_string(BoringYear) + "--can't test.");
 
-  quiet_errorhandler d(conn);
+  quiet_errorhandler d(cx);
   PQXX_CHECK_THROWS(
-    perform([&conn, &Table] { failed_insert(conn, Table); }), deliberate_error,
+    perform([&cx, &Table] { failed_insert(cx, Table); }), deliberate_error,
     "Failing transactor failed to throw correct exception.");
 
   auto const After{
-    perform([&conn, &Table] { return count_events(conn, Table); })};
+    perform([&cx, &Table] { return count_events(cx, Table); })};
 
   PQXX_CHECK_EQUAL(
     After.first, Before.first, "abort() didn't reset event count.");

--- a/test/test13.cxx
+++ b/test/test13.cxx
@@ -70,8 +70,7 @@ void test_013()
     perform([&cx, &Table] { failed_insert(cx, Table); }), deliberate_error,
     "Failing transactor failed to throw correct exception.");
 
-  auto const After{
-    perform([&cx, &Table] { return count_events(cx, Table); })};
+  auto const After{perform([&cx, &Table] { return count_events(cx, Table); })};
 
   PQXX_CHECK_EQUAL(
     After.first, Before.first, "abort() didn't reset event count.");

--- a/test/test14.cxx
+++ b/test/test14.cxx
@@ -13,12 +13,12 @@ namespace
 {
 void test_014()
 {
-  connection conn;
+  connection cx;
 
   // Begin a "non-transaction" acting on our current connection.  This is
   // really all the transactional integrity we need since we're only
   // performing one query which does not modify the database.
-  nontransaction tx{conn, "test14"};
+  nontransaction tx{cx, "test14"};
 
   // The transaction class family also has process_notice() functions.
   // These simply pass the notice through to their connection, but this may

--- a/test/test16.cxx
+++ b/test/test16.cxx
@@ -13,8 +13,8 @@ namespace
 {
 void test_016()
 {
-  connection conn;
-  robusttransaction<> tx{conn};
+  connection cx;
+  robusttransaction<> tx{cx};
   result R{tx.exec("SELECT * FROM pg_tables")};
 
   result::const_iterator c;

--- a/test/test17.cxx
+++ b/test/test17.cxx
@@ -15,9 +15,9 @@ namespace
 {
 void test_017()
 {
-  connection conn;
-  perform([&conn] {
-    nontransaction tx{conn};
+  connection cx;
+  perform([&cx] {
+    nontransaction tx{cx};
     auto const r{tx.exec("SELECT * FROM generate_series(1, 4)")};
     PQXX_CHECK_EQUAL(std::size(r), 4, "Weird query result.");
     tx.commit();

--- a/test/test18.cxx
+++ b/test/test18.cxx
@@ -66,8 +66,7 @@ void test_018()
       "Not getting expected exception from failing transactor.");
   }
 
-  auto const After{
-    perform([&cx, &Table] { return count_events(cx, Table); })};
+  auto const After{perform([&cx, &Table] { return count_events(cx, Table); })};
 
   PQXX_CHECK_EQUAL(After.first, Before.first, "Event count changed.");
   PQXX_CHECK_EQUAL(

--- a/test/test18.cxx
+++ b/test/test18.cxx
@@ -20,9 +20,9 @@ constexpr long BoringYear{1977};
 
 // Count events and specifically events occurring in Boring Year, leaving the
 // former count in the result pair's first member, and the latter in second.
-std::pair<int, int> count_events(connection &conn, std::string const &table)
+std::pair<int, int> count_events(connection &cx, std::string const &table)
 {
-  nontransaction tx{conn};
+  nontransaction tx{cx};
   std::string const count_query{"SELECT count(*) FROM " + table};
   return std::make_pair(
     tx.query_value<int>(count_query),
@@ -36,9 +36,9 @@ struct deliberate_error : std::exception
 
 void test_018()
 {
-  connection conn;
+  connection cx;
   {
-    work tx{conn};
+    work tx{cx};
     test::create_pqxxevents(tx);
     tx.commit();
   }
@@ -46,16 +46,16 @@ void test_018()
   std::string const Table{"pqxxevents"};
 
   auto const Before{
-    perform([&conn, &Table] { return count_events(conn, Table); })};
+    perform([&cx, &Table] { return count_events(cx, Table); })};
   PQXX_CHECK_EQUAL(
     Before.second, 0,
     "Already have event for " + to_string(BoringYear) + ", cannot run.");
 
   {
-    quiet_errorhandler d{conn};
+    quiet_errorhandler d{cx};
     PQXX_CHECK_THROWS(
-      perform([&conn, Table] {
-        robusttransaction<serializable> tx{conn};
+      perform([&cx, Table] {
+        robusttransaction<serializable> tx{cx};
         tx.exec0(
           "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
           ", '" + tx.esc("yawn") + "')");
@@ -67,7 +67,7 @@ void test_018()
   }
 
   auto const After{
-    perform([&conn, &Table] { return count_events(conn, Table); })};
+    perform([&cx, &Table] { return count_events(cx, Table); })};
 
   PQXX_CHECK_EQUAL(After.first, Before.first, "Event count changed.");
   PQXX_CHECK_EQUAL(

--- a/test/test20.cxx
+++ b/test/test20.cxx
@@ -16,8 +16,8 @@ constexpr unsigned long BoringYear{1977};
 
 void test_020()
 {
-  connection conn;
-  nontransaction t1{conn};
+  connection cx;
+  nontransaction t1{cx};
   test::create_pqxxevents(t1);
 
   std::string const Table{"pqxxevents"};
@@ -53,7 +53,7 @@ void test_020()
   t1.abort();
 
   // Verify that our record was added, despite the Abort()
-  nontransaction t2{conn, "t2"};
+  nontransaction t2{cx, "t2"};
   R = t2.exec(("SELECT * FROM " + Table +
                " "
                "WHERE year=" +
@@ -79,7 +79,7 @@ void test_020()
   t2.commit();
 
   // And again, verify results
-  nontransaction t3{conn, "t3"};
+  nontransaction t3{cx, "t3"};
 
   R = t3.exec(("SELECT * FROM " + Table +
                " "

--- a/test/test21.cxx
+++ b/test/test21.cxx
@@ -14,48 +14,48 @@ namespace
 {
 void test_021()
 {
-  connection conn;
+  connection cx;
 
   std::string const HostName{
-    ((conn.hostname() == nullptr) ? "<local>" : conn.hostname())};
-  conn.process_notice(
-    std::string{} + "database=" + conn.dbname() +
+    ((cx.hostname() == nullptr) ? "<local>" : cx.hostname())};
+  cx.process_notice(
+    std::string{} + "database=" + cx.dbname() +
     ", "
     "username=" +
-    conn.username() +
+    cx.username() +
     ", "
     "hostname=" +
     HostName +
     ", "
     "port=" +
-    to_string(conn.port()) +
+    to_string(cx.port()) +
     ", "
     "backendpid=" +
-    to_string(conn.backendpid()) + "\n");
+    to_string(cx.backendpid()) + "\n");
 
-  work tx{conn, "test_021"};
+  work tx{cx, "test_021"};
 
   // By now our connection should really have been created
-  conn.process_notice("Printing details on actual connection\n");
-  conn.process_notice(
-    std::string{} + "database=" + conn.dbname() +
+  cx.process_notice("Printing details on actual connection\n");
+  cx.process_notice(
+    std::string{} + "database=" + cx.dbname() +
     ", "
     "username=" +
-    conn.username() +
+    cx.username() +
     ", "
     "hostname=" +
     HostName +
     ", "
     "port=" +
-    to_string(conn.port()) +
+    to_string(cx.port()) +
     ", "
     "backendpid=" +
-    to_string(conn.backendpid()) + "\n");
+    to_string(cx.backendpid()) + "\n");
 
   std::string P;
-  from_string(conn.port(), P);
+  from_string(cx.port(), P);
   PQXX_CHECK_EQUAL(
-    P, to_string(conn.port()), "Port string conversion is broken.");
+    P, to_string(cx.port()), "Port string conversion is broken.");
   PQXX_CHECK_EQUAL(to_string(P), P, "Port string conversion is broken.");
 
   result R(tx.exec("SELECT * FROM pg_tables"));

--- a/test/test26.cxx
+++ b/test/test26.cxx
@@ -67,16 +67,16 @@ std::map<int, int> update_years(connection &C)
 
 void test_026()
 {
-  connection conn;
+  connection cx;
   {
-    nontransaction tx{conn};
+    nontransaction tx{cx};
     test::create_pqxxevents(tx);
     tx.commit();
   }
 
   // Perform (an instantiation of) the UpdateYears transactor we've defined
   // in the code above.  This is where the work gets done.
-  auto const conversions{perform([&conn] { return update_years(conn); })};
+  auto const conversions{perform([&cx] { return update_years(cx); })};
 
   PQXX_CHECK(not std::empty(conversions), "No conversions done!");
 }

--- a/test/test29.cxx
+++ b/test/test29.cxx
@@ -37,7 +37,7 @@ std::pair<int, int> CountEvents(transaction_base &tx)
 
 // Try adding a record, then aborting it, and check whether the abort was
 // performed correctly.
-void Test(connection &conn, bool ExplicitAbort)
+void Test(connection &cx, bool ExplicitAbort)
 {
   std::vector<std::string> BoringRow{to_string(BoringYear), "yawn"};
 
@@ -48,7 +48,7 @@ void Test(connection &conn, bool ExplicitAbort)
   {
     // Begin a transaction acting on our current connection; we'll abort it
     // later though.
-    work Doomed(conn, "Doomed");
+    work Doomed(cx, "Doomed");
 
     // Verify that our Boring Year was not yet in the events table
     EventCounts = CountEvents(Doomed);
@@ -80,7 +80,7 @@ void Test(connection &conn, bool ExplicitAbort)
   // Now check that we're back in the original state.  Note that this may go
   // wrong if somebody managed to change the table between our two
   // transactions.
-  work Checkup(conn, "Checkup");
+  work Checkup(cx, "Checkup");
 
   auto NewEvents{CountEvents(Checkup)};
   PQXX_CHECK_EQUAL(
@@ -92,15 +92,15 @@ void Test(connection &conn, bool ExplicitAbort)
 
 void test_029()
 {
-  connection conn;
+  connection cx;
   {
-    nontransaction tx{conn};
+    nontransaction tx{cx};
     test::create_pqxxevents(tx);
   }
 
   // Test abort semantics, both with explicit and implicit abort
-  Test(conn, true);
-  Test(conn, false);
+  Test(cx, true);
+  Test(cx, false);
 }
 
 

--- a/test/test30.cxx
+++ b/test/test30.cxx
@@ -16,8 +16,8 @@ void test_030()
 {
   std::string const Table{"pg_tables"};
 
-  connection conn;
-  work tx{conn, "test30"};
+  connection cx;
+  work tx{cx, "test30"};
 
   result R(tx.exec(("SELECT * FROM " + Table).c_str()));
   PQXX_CHECK(not std::empty(R), "Table " + Table + " is empty, cannot test.");

--- a/test/test37.cxx
+++ b/test/test37.cxx
@@ -64,8 +64,7 @@ void test_037()
       "Did not get expected exception from failing transactor.");
   }
 
-  auto const After{
-    perform([&cx, &Table] { return count_events(cx, Table); })};
+  auto const After{perform([&cx, &Table] { return count_events(cx, Table); })};
 
   PQXX_CHECK_EQUAL(After.first, Before.first, "Number of events changed.");
   PQXX_CHECK_EQUAL(

--- a/test/test37.cxx
+++ b/test/test37.cxx
@@ -18,10 +18,10 @@ constexpr int BoringYear{1977};
 
 // Count events and specifically events occurring in Boring Year, leaving the
 // former count in the result pair's first member, and the latter in second.
-std::pair<int, int> count_events(connection &conn, std::string const &table)
+std::pair<int, int> count_events(connection &cx, std::string const &table)
 {
   std::string const count_query{"SELECT count(*) FROM " + table};
-  nontransaction tx{conn};
+  nontransaction tx{cx};
   return std::make_pair(
     tx.query_value<int>(count_query),
     tx.query_value<int>(count_query + " WHERE year=" + to_string(BoringYear)));
@@ -34,25 +34,25 @@ struct deliberate_error : std::exception
 
 void test_037()
 {
-  connection conn;
+  connection cx;
   {
-    nontransaction tx{conn};
+    nontransaction tx{cx};
     test::create_pqxxevents(tx);
   }
 
   std::string const Table{"pqxxevents"};
 
   auto const Before{
-    perform([&conn, &Table] { return count_events(conn, Table); })};
+    perform([&cx, &Table] { return count_events(cx, Table); })};
   PQXX_CHECK_EQUAL(
     Before.second, 0,
     "Already have event for " + to_string(BoringYear) + ", cannot test.");
 
   {
-    quiet_errorhandler d(conn);
+    quiet_errorhandler d(cx);
     PQXX_CHECK_THROWS(
-      perform([&conn, &Table] {
-        robusttransaction<> tx{conn};
+      perform([&cx, &Table] {
+        robusttransaction<> tx{cx};
         tx.exec0(
           "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
           ", "
@@ -65,7 +65,7 @@ void test_037()
   }
 
   auto const After{
-    perform([&conn, &Table] { return count_events(conn, Table); })};
+    perform([&cx, &Table] { return count_events(cx, Table); })};
 
   PQXX_CHECK_EQUAL(After.first, Before.first, "Number of events changed.");
   PQXX_CHECK_EQUAL(

--- a/test/test39.cxx
+++ b/test/test39.cxx
@@ -13,8 +13,8 @@ int BoringYear{1977};
 
 void test_039()
 {
-  connection conn;
-  nontransaction tx1{conn};
+  connection cx;
+  nontransaction tx1{cx};
   test::create_pqxxevents(tx1);
   std::string const Table{"pqxxevents"};
 
@@ -50,7 +50,7 @@ void test_039()
   tx1.abort();
 
   // Verify that our record was added, despite the Abort()
-  nontransaction tx2(conn, "tx2");
+  nontransaction tx2(cx, "tx2");
   R = tx2.exec(
     "SELECT * FROM " + Table +
     " "
@@ -73,7 +73,7 @@ void test_039()
   tx2.commit();
 
   // And again, verify results
-  nontransaction tx3(conn, "tx3");
+  nontransaction tx3(cx, "tx3");
 
   R = tx3.exec(
     "SELECT * FROM " + Table +

--- a/test/test46.cxx
+++ b/test/test46.cxx
@@ -15,8 +15,8 @@ namespace
 {
 void test_046()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
 
   row R{tx.exec1("SELECT count(*) FROM pg_tables")};
 

--- a/test/test56.cxx
+++ b/test/test56.cxx
@@ -10,9 +10,9 @@ namespace
 {
 void test_056()
 {
-  connection conn;
-  work tx{conn};
-  quiet_errorhandler d(conn);
+  connection cx;
+  work tx{cx};
+  quiet_errorhandler d(cx);
 
   PQXX_CHECK_THROWS(
     tx.exec("DELIBERATELY INVALID TEST QUERY..."), sql_error,

--- a/test/test60.cxx
+++ b/test/test60.cxx
@@ -39,8 +39,7 @@ void CheckDatestyle(connection &cx, std::string expected)
 void RedoDatestyle(
   connection &cx, std::string const &style, std::string const &expected)
 {
-  PQXX_CHECK_EQUAL(
-    SetDatestyle(cx, style), expected, "Set wrong datestyle.");
+  PQXX_CHECK_EQUAL(SetDatestyle(cx, style), expected, "Set wrong datestyle.");
 }
 
 

--- a/test/test60.cxx
+++ b/test/test60.cxx
@@ -12,16 +12,16 @@ using namespace pqxx;
 // Example program for libpqxx.  Test session variable functionality.
 namespace
 {
-std::string GetDatestyle(connection &conn)
+std::string GetDatestyle(connection &cx)
 {
-  return conn.get_var("DATESTYLE");
+  return cx.get_var("DATESTYLE");
 }
 
 
-std::string SetDatestyle(connection &conn, std::string style)
+std::string SetDatestyle(connection &cx, std::string style)
 {
-  conn.set_session_var("DATESTYLE", style);
-  std::string const fullname{GetDatestyle(conn)};
+  cx.set_session_var("DATESTYLE", style);
+  std::string const fullname{GetDatestyle(cx)};
   PQXX_CHECK(
     not std::empty(fullname),
     "Setting datestyle to " + style + " makes it an empty string.");
@@ -30,53 +30,53 @@ std::string SetDatestyle(connection &conn, std::string style)
 }
 
 
-void CheckDatestyle(connection &conn, std::string expected)
+void CheckDatestyle(connection &cx, std::string expected)
 {
-  PQXX_CHECK_EQUAL(GetDatestyle(conn), expected, "Got wrong datestyle.");
+  PQXX_CHECK_EQUAL(GetDatestyle(cx), expected, "Got wrong datestyle.");
 }
 
 
 void RedoDatestyle(
-  connection &conn, std::string const &style, std::string const &expected)
+  connection &cx, std::string const &style, std::string const &expected)
 {
   PQXX_CHECK_EQUAL(
-    SetDatestyle(conn, style), expected, "Set wrong datestyle.");
+    SetDatestyle(cx, style), expected, "Set wrong datestyle.");
 }
 
 
 void ActivationTest(
-  connection &conn, std::string const &style, std::string const &expected)
+  connection &cx, std::string const &style, std::string const &expected)
 {
-  RedoDatestyle(conn, style, expected);
-  CheckDatestyle(conn, expected);
+  RedoDatestyle(cx, style, expected);
+  CheckDatestyle(cx, expected);
 }
 
 
 void test_060()
 {
-  connection conn;
+  connection cx;
 
-  PQXX_CHECK(not std::empty(GetDatestyle(conn)), "Initial datestyle not set.");
+  PQXX_CHECK(not std::empty(GetDatestyle(cx)), "Initial datestyle not set.");
 
-  std::string const ISOname{SetDatestyle(conn, "ISO")};
-  std::string const SQLname{SetDatestyle(conn, "SQL")};
+  std::string const ISOname{SetDatestyle(cx, "ISO")};
+  std::string const SQLname{SetDatestyle(cx, "SQL")};
 
   PQXX_CHECK_NOT_EQUAL(ISOname, SQLname, "Same datestyle in SQL and ISO.");
 
-  RedoDatestyle(conn, "SQL", SQLname);
+  RedoDatestyle(cx, "SQL", SQLname);
 
-  ActivationTest(conn, "ISO", ISOname);
-  ActivationTest(conn, "SQL", SQLname);
+  ActivationTest(cx, "ISO", ISOname);
+  ActivationTest(cx, "SQL", SQLname);
 
   PQXX_CHECK_THROWS(
-    conn.set_session_var("bonjour_name", std::optional<std::string>{}),
+    cx.set_session_var("bonjour_name", std::optional<std::string>{}),
     pqxx::variable_set_to_null,
     "Setting a variable to null did not report the error correctly.");
 
   // Prove that setting an unknown variable causes an error, as expected
-  quiet_errorhandler d{conn};
+  quiet_errorhandler d{cx};
   PQXX_CHECK_THROWS(
-    conn.set_session_var("NONEXISTENT_VARIABLE_I_HOPE", 1), sql_error,
+    cx.set_session_var("NONEXISTENT_VARIABLE_I_HOPE", 1), sql_error,
     "Setting unknown variable failed to fail.");
 }
 

--- a/test/test61.cxx
+++ b/test/test61.cxx
@@ -37,8 +37,8 @@ void RedoDatestyle(
 
 void test_061()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
 
   PQXX_CHECK(not std::empty(GetDatestyle(tx)), "Initial datestyle not set.");
 
@@ -52,7 +52,7 @@ void test_061()
   // Prove that setting an unknown variable causes an error, as expected
   quiet_errorhandler d(tx.conn());
   PQXX_CHECK_THROWS(
-    conn.set_session_var("NONEXISTENT_VARIABLE_I_HOPE", 1), sql_error,
+    cx.set_session_var("NONEXISTENT_VARIABLE_I_HOPE", 1), sql_error,
     "Setting unknown variable failed to fail.");
 }
 

--- a/test/test62.cxx
+++ b/test/test62.cxx
@@ -14,8 +14,8 @@ namespace
 {
 void test_062()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
 
   std::string const TestStr{
     "Nasty\n\030Test\n\t String with \200\277 weird bytes "

--- a/test/test69.cxx
+++ b/test/test69.cxx
@@ -43,8 +43,8 @@ void TestPipeline(pipeline &P, int numqueries)
 
 void test_069()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
   pipeline P(tx);
   PQXX_CHECK(std::empty(P), "Pipeline is not empty initially.");
   for (int i{0}; i < 5; ++i) TestPipeline(P, i);

--- a/test/test70.cxx
+++ b/test/test70.cxx
@@ -55,8 +55,8 @@ void TestPipeline(pipeline &P, int numqueries)
 // compare results.  Use retain() and resume() for performance.
 void test_070()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
   pipeline P(tx);
 
   PQXX_CHECK(std::empty(P), "Pipeline is not empty initially.");
@@ -91,7 +91,7 @@ void test_070()
   for (int i{0}; i < 5; ++i) TestPipeline(P, i);
 
   // See if retrieve() fails on an empty pipeline, as it should
-  quiet_errorhandler d(conn);
+  quiet_errorhandler d(cx);
   PQXX_CHECK_THROWS_EXCEPTION(
     P.retrieve(), "Empty pipeline allows retrieve().");
 }

--- a/test/test71.cxx
+++ b/test/test71.cxx
@@ -25,8 +25,8 @@ template<typename PAIR> void checkresult(pipeline &P, PAIR c)
 
 void test_071()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
   pipeline P(tx);
 
   // Keep expected result for every query we issue

--- a/test/test72.cxx
+++ b/test/test72.cxx
@@ -13,8 +13,8 @@ namespace
 {
 void test_072()
 {
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
   pipeline P{tx};
 
   // Ensure all queries are issued at once to make the test more interesting
@@ -34,7 +34,7 @@ void test_072()
 
   // We should *not* get a result for the query behind the error
   {
-    quiet_errorhandler d{conn};
+    quiet_errorhandler d{cx};
     PQXX_CHECK_THROWS(
       P.retrieve(id_2).at(0).at(0).as<int>(), std::runtime_error,
       "Pipeline wrongly resumed after SQL error.");
@@ -42,7 +42,7 @@ void test_072()
 
   // Now see that we get an exception when we touch the failed result
   {
-    quiet_errorhandler d{conn};
+    quiet_errorhandler d{cx};
     PQXX_CHECK_THROWS(
       P.retrieve(id_f), sql_error, "Pipeline failed to register SQL error.");
   }

--- a/test/test74.cxx
+++ b/test/test74.cxx
@@ -13,8 +13,8 @@ namespace
 void test_074()
 {
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
-  connection conn;
-  work tx{conn};
+  connection cx;
+  work tx{cx};
 
   result R{tx.exec("SELECT * FROM pg_tables")};
   std::string const sval{R.at(0).at(1).c_str()};

--- a/test/test75.cxx
+++ b/test/test75.cxx
@@ -12,8 +12,8 @@ namespace
 {
 void test_075()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   pqxx::test::create_pqxxevents(tx);
   auto const R(tx.exec("SELECT year FROM pqxxevents"));

--- a/test/test76.cxx
+++ b/test/test76.cxx
@@ -7,8 +7,8 @@ namespace
 {
 void test_076()
 {
-  pqxx::connection conn;
-  pqxx::nontransaction tx{conn};
+  pqxx::connection cx;
+  pqxx::nontransaction tx{cx};
 
   auto RFalse{tx.exec1("SELECT 1=0")}, RTrue{tx.exec1("SELECT 1=1")};
   auto False{pqxx::from_string<bool>(RFalse[0])},

--- a/test/test77.cxx
+++ b/test/test77.cxx
@@ -8,8 +8,8 @@ namespace
 {
 void test_077()
 {
-  pqxx::connection conn;
-  pqxx::nontransaction tx{conn};
+  pqxx::connection cx;
+  pqxx::nontransaction tx{cx};
 
   auto RFalse{tx.exec("SELECT 1=0")}, RTrue{tx.exec("SELECT 1=1")};
   auto f{pqxx::from_string<bool>(RFalse[0][0])};

--- a/test/test78.cxx
+++ b/test/test78.cxx
@@ -19,8 +19,8 @@ class TestListener : public pqxx::notification_receiver
   bool m_done;
 
 public:
-  explicit TestListener(pqxx::connection &conn, std::string const &Name) :
-          pqxx::notification_receiver(conn, Name), m_done(false)
+  explicit TestListener(pqxx::connection &cx, std::string const &Name) :
+          pqxx::notification_receiver(cx, Name), m_done(false)
   {}
 
   void operator()(std::string const &, int be_pid) override
@@ -40,13 +40,13 @@ public:
 
 void test_078()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
   std::string const NotifName{"my listener"};
-  TestListener L{conn, NotifName};
+  TestListener L{cx, NotifName};
 
-  pqxx::perform([&conn, &L] {
-    pqxx::work tx{conn};
+  pqxx::perform([&cx, &L] {
+    pqxx::work tx{cx};
     tx.exec0("NOTIFY " + tx.quote_name(L.channel()));
     tx.commit();
   });
@@ -56,7 +56,7 @@ void test_078()
   {
     PQXX_CHECK_EQUAL(notifs, 0, "Got unexpected notifications.");
     std::cout << ".";
-    notifs = conn.await_notification();
+    notifs = cx.await_notification();
   }
   std::cout << std::endl;
 

--- a/test/test82.cxx
+++ b/test/test82.cxx
@@ -10,8 +10,8 @@ namespace
 {
 void test_082()
 {
-  pqxx::connection conn;
-  pqxx::nontransaction tx{conn};
+  pqxx::connection cx;
+  pqxx::nontransaction tx{cx};
 
   pqxx::test::create_pqxxevents(tx);
   std::string const Table{"pqxxevents"};

--- a/test/test84.cxx
+++ b/test/test84.cxx
@@ -18,8 +18,8 @@ namespace
 {
 void test_084()
 {
-  pqxx::connection conn;
-  pqxx::transaction<pqxx::serializable> tx{conn};
+  pqxx::connection cx;
+  pqxx::transaction<pqxx::serializable> tx{cx};
 
   std::string const Table{"pg_tables"}, Key{"tablename"};
 

--- a/test/test87.cxx
+++ b/test/test87.cxx
@@ -30,8 +30,8 @@ class TestListener final : public pqxx::notification_receiver
   bool m_done;
 
 public:
-  explicit TestListener(pqxx::connection &conn, std::string Name) :
-          pqxx::notification_receiver(conn, Name), m_done(false)
+  explicit TestListener(pqxx::connection &cx, std::string Name) :
+          pqxx::notification_receiver(cx, Name), m_done(false)
   {}
 
   void operator()(std::string const &, int be_pid) override
@@ -51,13 +51,13 @@ public:
 
 void test_087()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
   std::string const NotifName{"my notification"};
-  TestListener L{conn, NotifName};
+  TestListener L{cx, NotifName};
 
-  pqxx::perform([&conn, &L] {
-    pqxx::work tx{conn};
+  pqxx::perform([&cx, &L] {
+    pqxx::work tx{cx};
     tx.exec0("NOTIFY " + tx.quote_name(L.channel()));
     tx.commit();
   });
@@ -69,8 +69,8 @@ void test_087()
 
     std::cout << ".";
 
-    pqxx::internal::wait_fd(conn.sock(), true, false);
-    notifs = conn.get_notifs();
+    pqxx::internal::wait_fd(cx.sock(), true, false);
+    notifs = cx.get_notifs();
   }
   std::cout << std::endl;
 

--- a/test/test88.cxx
+++ b/test/test88.cxx
@@ -11,9 +11,9 @@ namespace
 {
 void test_088()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
-  pqxx::work tx0{conn};
+  pqxx::work tx0{cx};
   pqxx::test::create_pqxxevents(tx0);
 
   // Trivial test: create subtransactions, and commit/abort
@@ -28,7 +28,7 @@ void test_088()
   tx0.commit();
 
   // Basic functionality: perform query in subtransaction; abort, continue
-  pqxx::work tx1{conn, "tx1"};
+  pqxx::work tx1{cx, "tx1"};
   std::cout << tx1.exec1("SELECT 'tx1 starts'")[0].c_str() << std::endl;
   pqxx::subtransaction tx1a{tx1, "tx1a"};
   std::cout << tx1a.exec1("SELECT '  a'")[0].c_str() << std::endl;
@@ -43,7 +43,7 @@ void test_088()
   tx1.commit();
 
   // Commit/rollback functionality
-  pqxx::work tx2{conn, "tx2"};
+  pqxx::work tx2{cx, "tx2"};
   std::string const Table{"test088"};
   tx2.exec0("CREATE TEMP TABLE " + Table + "(no INTEGER, text VARCHAR)");
 
@@ -72,7 +72,7 @@ void test_088()
   tx2.abort();
 
   // Auto-abort should only roll back the subtransaction.
-  pqxx::work tx3{conn, "tx3"};
+  pqxx::work tx3{cx, "tx3"};
   pqxx::subtransaction tx3a(tx3, "tx3a");
   PQXX_CHECK_THROWS(
     tx3a.exec("SELECT * FROM nonexistent_table WHERE nonattribute=0"),

--- a/test/test90.cxx
+++ b/test/test90.cxx
@@ -8,13 +8,13 @@ namespace
 {
 void test_090()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
   // Test connection's adorn_name() function for uniqueness
   std::string const nametest{"basename"};
 
   PQXX_CHECK_NOT_EQUAL(
-    conn.adorn_name(nametest), conn.adorn_name(nametest),
+    cx.adorn_name(nametest), cx.adorn_name(nametest),
     "\"Unique\" names are not unique.");
 }
 } // namespace

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -19,8 +19,8 @@ make_binarystring(pqxx::transaction_base &T, std::string content)
 
 void test_binarystring()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto b{make_binarystring(tx, "")};
   PQXX_CHECK(std::empty(b), "Empty binarystring is not empty.");
   PQXX_CHECK_EQUAL(b.str(), "", "Empty binarystring doesn't work.");
@@ -142,8 +142,8 @@ void test_binarystring_stream()
   pqxx::binarystring bin{data};
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 
-  pqxx::connection conn;
-  pqxx::transaction tx{conn};
+  pqxx::connection cx;
+  pqxx::transaction tx{cx};
   tx.exec0("CREATE TEMP TABLE pqxxbinstream(id integer, bin bytea)");
 
   auto to{pqxx::stream_to::table(tx, {"pqxxbinstream"})};
@@ -163,8 +163,8 @@ void test_binarystring_stream()
 
 void test_binarystring_array_stream()
 {
-  pqxx::connection conn;
-  pqxx::transaction tx{conn};
+  pqxx::connection cx;
+  pqxx::transaction tx{cx};
   tx.exec0("CREATE TEMP TABLE pqxxbinstream(id integer, vec bytea[])");
 
   constexpr char bytes1[]{"a\tb\0c"}, bytes2[]{"1\0.2"};

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -24,8 +24,8 @@ void test_blob_is_useless_by_default()
 
 void test_blob_create_makes_empty_blob()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::create(tx)};
   auto b{pqxx::blob::open_r(tx, id)};
   b.seek_end(0);
@@ -35,8 +35,8 @@ void test_blob_create_makes_empty_blob()
 
 void test_blob_create_with_oid_requires_oid_be_free()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::create(tx)};
 
   PQXX_CHECK_THROWS(
@@ -47,8 +47,8 @@ void test_blob_create_with_oid_requires_oid_be_free()
 
 void test_blob_create_with_oid_obeys_oid()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::create(tx)};
   pqxx::blob::remove(tx, id);
 
@@ -59,11 +59,11 @@ void test_blob_create_with_oid_obeys_oid()
 
 void test_blobs_are_transactional()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::create(tx)};
   tx.abort();
-  pqxx::work tx2{conn};
+  pqxx::work tx2{cx};
   PQXX_CHECK_THROWS(
     pqxx::ignore_unused(pqxx::blob::open_r(tx2, id)), pqxx::failure,
     "Blob from aborted transaction still exists.");
@@ -72,8 +72,8 @@ void test_blobs_are_transactional()
 
 void test_blob_remove_removes_blob()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::create(tx)};
   pqxx::blob::remove(tx, id);
   PQXX_CHECK_THROWS(
@@ -84,8 +84,8 @@ void test_blob_remove_removes_blob()
 
 void test_blob_remove_is_not_idempotent()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::create(tx)};
   pqxx::blob::remove(tx, id);
   PQXX_CHECK_THROWS(
@@ -96,8 +96,8 @@ void test_blob_remove_is_not_idempotent()
 
 void test_blob_checks_open_mode()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::create(tx)};
   pqxx::blob b_r{pqxx::blob::open_r(tx, id)};
   pqxx::blob b_w{pqxx::blob::open_w(tx, id)};
@@ -126,8 +126,8 @@ void test_blob_supports_move()
   pqxx::bytes buf;
   buf.push_back(std::byte{'x'});
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::create(tx)};
   pqxx::blob b1{pqxx::blob::open_rw(tx, id)};
   b1.write(buf);
@@ -153,8 +153,8 @@ void test_blob_read_reads_data()
 {
   pqxx::bytes const data{std::byte{'a'}, std::byte{'b'}, std::byte{'c'}};
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::from_buf(tx, data)};
 
   pqxx::bytes buf;
@@ -187,8 +187,8 @@ void test_blob_read_span()
   pqxx::bytes const data{std::byte{'u'}, std::byte{'v'}, std::byte{'w'},
                          std::byte{'x'}, std::byte{'y'}, std::byte{'z'}};
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::oid id{pqxx::blob::from_buf(tx, data)};
 
   auto b{pqxx::blob::open_r(tx, id)};
@@ -237,8 +237,8 @@ void test_blob_read_span()
 void test_blob_reads_vector()
 {
   char const content[]{"abcd"};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(
     tx, pqxx::bytes_view{
           reinterpret_cast<std::byte const *>(content), std::size(content)})};
@@ -255,8 +255,8 @@ void test_blob_reads_vector()
 
 void test_blob_write_appends_at_insertion_point()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::create(tx)};
 
   auto b{pqxx::blob::open_rw(tx, id)};
@@ -287,8 +287,8 @@ void test_blob_write_appends_at_insertion_point()
 void test_blob_writes_span()
 {
 #if defined(PQXX_HAVE_SPAN)
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   constexpr char content[]{"gfbltk"};
   pqxx::bytes data{
     reinterpret_cast<std::byte const *>(content), std::size(content)};
@@ -316,8 +316,8 @@ void test_blob_resize_shortens_to_desired_length()
   pqxx::bytes const data{
     std::byte{'w'}, std::byte{'o'}, std::byte{'r'}, std::byte{'k'}};
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(tx, data)};
 
   pqxx::blob::open_w(tx, id).resize(2);
@@ -331,8 +331,8 @@ void test_blob_resize_shortens_to_desired_length()
 
 void test_blob_resize_extends_to_desired_length()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(tx, pqxx::bytes{std::byte{100}})};
   pqxx::blob::open_w(tx, id).resize(3);
   pqxx::bytes buf;
@@ -345,8 +345,8 @@ void test_blob_resize_extends_to_desired_length()
 
 void test_blob_tell_tracks_position()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::create(tx)};
   auto b{pqxx::blob::open_rw(tx, id)};
 
@@ -365,8 +365,8 @@ void test_blob_seek_sets_positions()
   pqxx::bytes data{std::byte{0}, std::byte{1}, std::byte{2}, std::byte{3},
                    std::byte{4}, std::byte{5}, std::byte{6}, std::byte{7},
                    std::byte{8}, std::byte{9}};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(tx, data)};
   auto b{pqxx::blob::open_r(tx, id)};
 
@@ -395,8 +395,8 @@ void test_blob_from_buf_interoperates_with_to_buf()
 {
   pqxx::bytes const data{std::byte{'h'}, std::byte{'i'}};
   pqxx::bytes buf;
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::blob::to_buf(tx, pqxx::blob::from_buf(tx, data), buf, 10);
   PQXX_CHECK_EQUAL(buf, data, "from_buf()/to_buf() roundtrip did not work.");
 }
@@ -405,8 +405,8 @@ void test_blob_from_buf_interoperates_with_to_buf()
 void test_blob_append_from_buf_appends()
 {
   pqxx::bytes const data{std::byte{'h'}, std::byte{'o'}};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::create(tx)};
   pqxx::blob::append_from_buf(tx, data, id);
   pqxx::blob::append_from_buf(tx, data, id);
@@ -490,8 +490,8 @@ void test_blob_from_file_creates_blob_from_file_contents()
   char const temp_file[] = "blob-test-from_file.tmp";
   pqxx::bytes const data{std::byte{'4'}, std::byte{'2'}};
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::bytes buf;
 
   pqxx::oid id;
@@ -510,8 +510,8 @@ void test_blob_from_file_with_oid_writes_blob()
   char const temp_file[] = "blob-test-from_file-oid.tmp";
   pqxx::bytes buf;
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   // Guarantee (more or less) that id is not in use.
   auto id{pqxx::blob::create(tx)};
@@ -531,8 +531,8 @@ void test_blob_append_to_buf_appends()
   pqxx::bytes const data{
     std::byte{'b'}, std::byte{'l'}, std::byte{'u'}, std::byte{'b'}};
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(tx, data)};
 
   pqxx::bytes buf;
@@ -555,8 +555,8 @@ void test_blob_to_file_writes_file()
   pqxx::bytes const data{std::byte{'C'}, std::byte{'+'}, std::byte{'+'}};
 
   char const temp_file[] = "blob-test-to_file.tmp";
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(tx, data)};
   pqxx::bytes buf;
 
@@ -577,8 +577,8 @@ void test_blob_to_file_writes_file()
 
 void test_blob_close_leaves_blob_unusable()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto id{pqxx::blob::from_buf(tx, pqxx::bytes{std::byte{1}})};
   auto b{pqxx::blob::open_rw(tx, id)};
   b.close();
@@ -598,8 +598,8 @@ void test_blob_accepts_std_filesystem_path()
   char const temp_file[] = "blob-test-filesystem-path.tmp";
   pqxx::bytes const data{std::byte{'4'}, std::byte{'2'}};
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::bytes buf;
 
   TempFile f{temp_file, data};

--- a/test/unit/test_cancel_query.cxx
+++ b/test/unit/test_cancel_query.cxx
@@ -7,17 +7,17 @@ namespace
 {
 void test_cancel_query()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   // Calling cancel_query() while none is in progress has no effect.
-  conn.cancel_query();
+  cx.cancel_query();
 
   // Nothing much is guaranteed about cancel_query, except that it doesn't make
   // the process die in flames.
   pqxx::pipeline p{tx, "test_cancel_query"};
   p.retain(0);
   p.insert("SELECT pg_sleep(1)");
-  conn.cancel_query();
+  cx.cancel_query();
 }
 
 

--- a/test/unit/test_column.cxx
+++ b/test/unit/test_column.cxx
@@ -6,8 +6,8 @@ namespace
 {
 void test_table_column()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0("CREATE TEMP TABLE pqxxfoo (x varchar, y integer, z integer)");
   tx.exec0("INSERT INTO pqxxfoo VALUES ('xx', 1, 2)");

--- a/test/unit/test_composite.cxx
+++ b/test/unit/test_composite.cxx
@@ -7,8 +7,8 @@ namespace
 {
 void test_composite()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TYPE pqxxfoo AS (a integer, b text)");
   auto const r{tx.exec1("SELECT '(5,hello)'::pqxxfoo")};
 
@@ -23,8 +23,8 @@ void test_composite()
 
 void test_composite_escapes()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::row r;
   tx.exec0("CREATE TYPE pqxxsingle AS (x text)");
   std::string s;
@@ -42,8 +42,8 @@ void test_composite_escapes()
 
 void test_composite_handles_nulls()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::row r;
 
   tx.exec0("CREATE TYPE pqxxnull AS (a integer)");
@@ -68,8 +68,8 @@ void test_composite_handles_nulls()
 
 void test_composite_renders_to_string()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   char buf[1000];
 
   pqxx::composite_into_buf(

--- a/test/unit/test_connection.cxx
+++ b/test/unit/test_connection.cxx
@@ -204,12 +204,12 @@ void test_raw_connection()
 
 void test_closed_connection()
 {
-  pqxx::connection conn;
-  conn.close();
-  PQXX_CHECK(not conn.dbname(), "Closed connection had a dbname.");
-  PQXX_CHECK(not conn.username(), "Closed connection had a username.");
-  PQXX_CHECK(not conn.hostname(), "Closed connection had a hostname.");
-  PQXX_CHECK(not conn.port(), "Closed connection had a port.");
+  pqxx::connection cx;
+  cx.close();
+  PQXX_CHECK(not cx.dbname(), "Closed connection had a dbname.");
+  PQXX_CHECK(not cx.username(), "Closed connection had a username.");
+  PQXX_CHECK(not cx.hostname(), "Closed connection had a hostname.");
+  PQXX_CHECK(not cx.port(), "Closed connection had a port.");
 }
 
 

--- a/test/unit/test_cursor.cxx
+++ b/test/unit/test_cursor.cxx
@@ -5,9 +5,9 @@
 
 namespace
 {
-void test_stateless_cursor_provides_random_access(pqxx::connection &conn)
+void test_stateless_cursor_provides_random_access(pqxx::connection &cx)
 {
-  pqxx::work tx{conn};
+  pqxx::work tx{cx};
   pqxx::stateless_cursor<
     pqxx::cursor_base::read_only, pqxx::cursor_base::owned>
     c{tx, "SELECT * FROM generate_series(0, 3)", "count", false};
@@ -26,9 +26,9 @@ void test_stateless_cursor_provides_random_access(pqxx::connection &conn)
 }
 
 
-void test_stateless_cursor_ignores_trailing_semicolon(pqxx::connection &conn)
+void test_stateless_cursor_ignores_trailing_semicolon(pqxx::connection &cx)
 {
-  pqxx::work tx{conn};
+  pqxx::work tx{cx};
   pqxx::stateless_cursor<
     pqxx::cursor_base::read_only, pqxx::cursor_base::owned>
     c{tx, "SELECT * FROM generate_series(0, 3)  ;; ; \n \t  ", "count", false};
@@ -40,9 +40,9 @@ void test_stateless_cursor_ignores_trailing_semicolon(pqxx::connection &conn)
 
 void test_cursor()
 {
-  pqxx::connection conn;
-  test_stateless_cursor_provides_random_access(conn);
-  test_stateless_cursor_ignores_trailing_semicolon(conn);
+  pqxx::connection cx;
+  test_stateless_cursor_provides_random_access(cx);
+  test_stateless_cursor_ignores_trailing_semicolon(cx);
 }
 
 

--- a/test/unit/test_error_verbosity.cxx
+++ b/test/unit/test_error_verbosity.cxx
@@ -24,11 +24,11 @@ void test_error_verbosity()
     static_cast<int>(PQERRORS_VERBOSE),
     "error_verbosity enum should match PGVerbosity.");
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
-  conn.set_verbosity(pqxx::error_verbosity::terse);
+  pqxx::connection cx;
+  pqxx::work tx{cx};
+  cx.set_verbosity(pqxx::error_verbosity::terse);
   tx.exec1("SELECT 1");
-  conn.set_verbosity(pqxx::error_verbosity::verbose);
+  cx.set_verbosity(pqxx::error_verbosity::verbose);
   tx.exec1("SELECT 2");
 }
 

--- a/test/unit/test_errorhandler.cxx
+++ b/test/unit/test_errorhandler.cxx
@@ -209,13 +209,13 @@ void test_get_errorhandlers(pqxx::connection &c)
 
 void test_errorhandler()
 {
-  pqxx::connection conn;
-  test_process_notice_calls_errorhandler(conn);
-  test_error_handlers_get_called_newest_to_oldest(conn);
-  test_returning_false_stops_error_handling(conn);
-  test_destroyed_error_handlers_are_not_called(conn);
+  pqxx::connection cx;
+  test_process_notice_calls_errorhandler(cx);
+  test_error_handlers_get_called_newest_to_oldest(cx);
+  test_returning_false_stops_error_handling(cx);
+  test_destroyed_error_handlers_are_not_called(cx);
   test_destroying_connection_unregisters_handlers();
-  test_get_errorhandlers(conn);
+  test_get_errorhandlers(cx);
 }
 
 

--- a/test/unit/test_escape.cxx
+++ b/test/unit/test_escape.cxx
@@ -145,10 +145,10 @@ void test_esc_like(pqxx::transaction_base &tx)
 
 void test_escaping()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
-  test_esc(conn, tx);
-  test_quote(conn, tx);
+  pqxx::connection cx;
+  pqxx::work tx{cx};
+  test_esc(cx, tx);
+  test_quote(cx, tx);
   test_quote_name(tx);
   test_esc_raw_unesc_raw(tx);
   test_esc_like(tx);
@@ -158,8 +158,8 @@ void test_escaping()
 void test_esc_escapes_into_buffer()
 {
 #if defined(PQXX_HAVE_CONCEPTS)
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::string buffer;
   buffer.resize(20);
@@ -178,8 +178,8 @@ void test_esc_escapes_into_buffer()
 void test_esc_accepts_various_types()
 {
 #if defined(PQXX_HAVE_CONCEPTS) && defined(PQXX_HAVE_SPAN)
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::string buffer;
   buffer.resize(20);
@@ -198,8 +198,8 @@ void test_esc_accepts_various_types()
 void test_binary_esc_checks_buffer_length()
 {
 #if defined(PQXX_HAVE_CONCEPTS) && defined(PQXX_HAVE_SPAN)
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::string buf;
   pqxx::bytes bin{std::byte{'b'}, std::byte{'o'}, std::byte{'o'}};

--- a/test/unit/test_exceptions.cxx
+++ b/test/unit/test_exceptions.cxx
@@ -26,8 +26,8 @@ void test_exceptions()
       "Getting query from pqxx exception is broken.");
   }
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   try
   {
     tx.exec("INVALID QUERY HERE");

--- a/test/unit/test_float.cxx
+++ b/test/unit/test_float.cxx
@@ -36,9 +36,9 @@ void test_infinities()
 /// Reproduce bug #262: repeated float conversions break without charconv.
 template<typename T> void bug_262()
 {
-  pqxx::connection conn;
-  conn.prepare("stmt", "select cast($1 as float)");
-  pqxx::work tr{conn};
+  pqxx::connection cx;
+  cx.prepare("stmt", "select cast($1 as float)");
+  pqxx::work tr{cx};
 
   // We must use the same float type both for passing the value to the
   // statement and for retrieving result of the statement execution.  This is

--- a/test/unit/test_largeobject.cxx
+++ b/test/unit/test_largeobject.cxx
@@ -10,7 +10,7 @@ namespace
 {
 void test_stream_large_object()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
   // Construct a really nasty string.  (Don't just construct a std::string from
   // a char[] constant, because it'll terminate at the embedded zero.)
@@ -22,7 +22,7 @@ void test_stream_large_object()
   constexpr char bytes[]{"\xff\0end"};
   std::string const contents{bytes, std::size(bytes)};
 
-  pqxx::work tx{conn};
+  pqxx::work tx{cx};
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
   pqxx::largeobject new_obj{tx};
 

--- a/test/unit/test_nonblocking_connect.cxx
+++ b/test/unit/test_nonblocking_connect.cxx
@@ -17,8 +17,8 @@ void test_nonblocking_connect()
     nbc.process();
   }
 
-  pqxx::connection conn{std::move(nbc).produce()};
-  pqxx::work tx{conn};
+  pqxx::connection cx{std::move(nbc).produce()};
+  pqxx::work tx{cx};
   PQXX_CHECK_EQUAL(tx.query_value<int>("SELECT 10"), 10, "Bad value!?");
 }
 

--- a/test/unit/test_pipeline.cxx
+++ b/test/unit/test_pipeline.cxx
@@ -9,8 +9,8 @@ namespace
 {
 void test_pipeline()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   // A pipeline grabs transaction focus, blocking regular queries and such.
   pqxx::pipeline pipe(tx, "test_pipeline_detach");

--- a/test/unit/test_read_transaction.cxx
+++ b/test/unit/test_read_transaction.cxx
@@ -6,8 +6,8 @@ namespace
 {
 void test_read_transaction()
 {
-  pqxx::connection conn;
-  pqxx::read_transaction tx{conn};
+  pqxx::connection cx;
+  pqxx::read_transaction tx{cx};
   PQXX_CHECK_EQUAL(
     tx.exec("SELECT 1")[0][0].as<int>(), 1,
     "Bad result from read transaction.");

--- a/test/unit/test_result_iteration.cxx
+++ b/test/unit/test_result_iteration.cxx
@@ -7,8 +7,8 @@ namespace
 {
 void test_result_iteration()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::result r{tx.exec("SELECT generate_series(1, 3)")};
 
   PQXX_CHECK(std::end(r) != std::begin(r), "Broken begin/end.");
@@ -26,8 +26,8 @@ void test_result_iteration()
 
 void test_result_iter()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::result r{tx.exec("SELECT generate_series(1, 3)")};
 
   int total{0};
@@ -38,8 +38,8 @@ void test_result_iter()
 
 void test_result_iterator_swap()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::result r{tx.exec("SELECT generate_series(1, 3)")};
 
   auto head{std::begin(r)}, next{head + 1};
@@ -56,8 +56,8 @@ void test_result_iterator_swap()
 
 void test_result_iterator_assignment()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::result r{tx.exec("SELECT generate_series(1, 3)")};
 
   pqxx::result::const_iterator fwd;
@@ -85,8 +85,8 @@ void check_employee(std::string name, int salary)
 
 void test_result_for_each()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE employee(name varchar, salary int)");
   auto fill{pqxx::stream_to::table(tx, {"employee"}, {"name", "salary"})};
   fill.write_values("x", 1000);

--- a/test/unit/test_result_slicing.cxx
+++ b/test/unit/test_result_slicing.cxx
@@ -65,8 +65,8 @@ namespace
 {
 void test_result_slicing()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto r{tx.exec("SELECT 1")};
 
   PQXX_CHECK(not std::empty(r[0]), "A plain row shows up as empty.");

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -6,8 +6,8 @@ namespace
 {
 void test_row()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::result rows{tx.exec("SELECT 1, 2, 3")};
   pqxx::row r{rows[0]};
   PQXX_CHECK_EQUAL(std::size(r), 3, "Unexpected row size.");
@@ -26,8 +26,8 @@ void test_row()
 
 void test_row_iterator()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::result rows{tx.exec("SELECT 1, 2, 3")};
 
   auto i{std::begin(rows[0])};
@@ -58,8 +58,8 @@ void test_row_as()
 {
   using pqxx::operator"" _zv;
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   pqxx::row const r{tx.exec1("SELECT 1, 2, 3")};
   auto [one, two, three]{r.as<int, float, pqxx::zview>()};
@@ -81,8 +81,8 @@ void test_row_as()
 // In a random access iterator i, i[n] == *(i + n).
 void test_row_iterator_array_index_offsets_iterator()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto const row{tx.exec1("SELECT 5, 4, 3, 2")};
   PQXX_CHECK_EQUAL(
     row.begin()[1].as<std::string>(), "4",

--- a/test/unit/test_simultaneous_transactions.cxx
+++ b/test/unit/test_simultaneous_transactions.cxx
@@ -7,11 +7,11 @@ namespace
 {
 void test_simultaneous_transactions()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
-  pqxx::nontransaction n1{conn};
+  pqxx::nontransaction n1{cx};
   PQXX_CHECK_THROWS(
-    pqxx::nontransaction n2{conn}, std::logic_error,
+    pqxx::nontransaction n2{cx}, std::logic_error,
     "Allowed to open simultaneous nontransactions.");
 }
 

--- a/test/unit/test_sql_cursor.cxx
+++ b/test/unit/test_sql_cursor.cxx
@@ -7,8 +7,8 @@ namespace
 {
 void test_forward_sql_cursor()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   // Plain owned, scoped, forward-only read-only cursor.
   pqxx::internal::sql_cursor forward(
@@ -107,8 +107,8 @@ void test_forward_sql_cursor()
 
 void test_scroll_sql_cursor()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   pqxx::internal::sql_cursor scroll(
     tx, "SELECT generate_series(1, 10)", "scroll",
     pqxx::cursor_base::random_access, pqxx::cursor_base::read_only,
@@ -170,8 +170,8 @@ void test_scroll_sql_cursor()
 
 void test_adopted_sql_cursor()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0(
     "DECLARE adopted SCROLL CURSOR FOR "
@@ -231,8 +231,8 @@ void test_adopted_sql_cursor()
 
 void test_hold_cursor()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   // "With hold" cursor is kept after commit.
   pqxx::internal::sql_cursor with_hold(
@@ -240,7 +240,7 @@ void test_hold_cursor()
     pqxx::cursor_base::forward_only, pqxx::cursor_base::read_only,
     pqxx::cursor_base::owned, true);
   tx.commit();
-  pqxx::work tx2(conn, "tx2");
+  pqxx::work tx2(cx, "tx2");
   auto rows{with_hold.fetch(1)};
   PQXX_CHECK_EQUAL(
     std::size(rows), 1, "Did not get 1 row from with-hold cursor");
@@ -251,7 +251,7 @@ void test_hold_cursor()
     pqxx::cursor_base::forward_only, pqxx::cursor_base::read_only,
     pqxx::cursor_base::owned, false);
   tx2.commit();
-  pqxx::work tx3(conn, "tx3");
+  pqxx::work tx3(cx, "tx3");
   PQXX_CHECK_THROWS(
     no_hold.fetch(1), pqxx::sql_error, "Cursor not closed on commit");
 }

--- a/test/unit/test_stateless_cursor.cxx
+++ b/test/unit/test_stateless_cursor.cxx
@@ -7,8 +7,8 @@ namespace
 {
 void test_stateless_cursor()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   pqxx::stateless_cursor<
     pqxx::cursor_base::read_only, pqxx::cursor_base::owned>

--- a/test/unit/test_strconv.cxx
+++ b/test/unit/test_strconv.cxx
@@ -97,8 +97,8 @@ void test_strconv_class_enum()
     pqxx::to_string(std::numeric_limits<unsigned long long>::max()),
     "Large wide enum did not convert right.");
 
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   std::tuple<weather> out;
   tx.exec1("SELECT 0").to(out);
 }

--- a/test/unit/test_stream_from.cxx
+++ b/test/unit/test_stream_from.cxx
@@ -106,9 +106,9 @@ void test_nonoptionals(pqxx::connection &connection)
 }
 
 
-void test_bad_tuples(pqxx::connection &conn)
+void test_bad_tuples(pqxx::connection &cx)
 {
-  pqxx::work tx{conn};
+  pqxx::work tx{cx};
   auto extractor{pqxx::stream_from::table(tx, {"stream_from_test"})};
   PQXX_CHECK(extractor, "stream_from failed to initialize");
 
@@ -205,8 +205,8 @@ void test_optional(pqxx::connection &connection)
 
 void test_stream_from()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0(
     "CREATE TEMP TABLE stream_from_test ("
     "number0 INT NOT NULL,"
@@ -228,20 +228,20 @@ void test_stream_from()
     bytea{'f', 'o', 'o', ' ', 'b', 'a', 'r', '\0'});
   tx.commit();
 
-  test_nonoptionals(conn);
-  test_bad_tuples(conn);
+  test_nonoptionals(cx);
+  test_bad_tuples(cx);
   std::cout << "testing `std::unique_ptr` as optional...\n";
-  test_optional<std::unique_ptr>(conn);
+  test_optional<std::unique_ptr>(cx);
   std::cout << "testing `std::optional` as optional...\n";
-  test_optional<std::optional>(conn);
+  test_optional<std::optional>(cx);
 }
 
 
 void test_stream_from_does_escaping()
 {
   std::string const input{"a\t\n\n\n \\b\nc"};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE badstr (str text)");
   tx.exec0("INSERT INTO badstr (str) VALUES (" + tx.quote(input) + ")");
   auto reader{pqxx::stream_from::table(tx, {"badstr"})};
@@ -254,8 +254,8 @@ void test_stream_from_does_escaping()
 
 void test_stream_from_does_iteration()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE str (s text)");
   tx.exec0("INSERT INTO str (s) VALUES ('foo')");
   auto reader{pqxx::stream_from::table(tx, {"str"})};
@@ -289,8 +289,8 @@ void test_stream_from_does_iteration()
 
 void test_stream_from_read_row()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE sample (id integer, name varchar, opt integer)");
   tx.exec0("INSERT INTO sample (id, name) VALUES (321, 'something')");
 
@@ -310,15 +310,15 @@ void test_stream_from_read_row()
 
 void test_stream_from_parses_awkward_strings()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
   // This is a particularly awkward encoding that we should test.  Its
   // multibyte characters can include byte values that *look* like ASCII
   // characters, such as quotes and backslashes.  It is crucial that we parse
   // those properly.  A byte-for-byte scan could find special ASCII characters
   // that aren't really there.
-  conn.set_client_encoding("SJIS");
-  pqxx::work tx{conn};
+  cx.set_client_encoding("SJIS");
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE nasty(id integer, value varchar)");
   tx.exec0(
     "INSERT INTO nasty(id, value) VALUES "

--- a/test/unit/test_stream_query.cxx
+++ b/test/unit/test_stream_query.cxx
@@ -17,8 +17,8 @@ namespace
 {
 void test_stream_handles_empty()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   for (auto [out] : tx.stream<int>("SELECT generate_series(1, 0)"))
     PQXX_CHECK(false, "Unexpectedly got a value: " + pqxx::to_string(out));
   PQXX_CHECK_EQUAL(
@@ -30,8 +30,8 @@ void test_stream_handles_empty()
 void test_stream_does_escaping()
 {
   std::string const input{"a\t\n\n\n \\b\nc"};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   int counter{0};
   for (auto [out] : tx.stream<std::string_view>("SELECT " + tx.quote(input)))
   {
@@ -44,8 +44,8 @@ void test_stream_does_escaping()
 
 void test_stream_iterates()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::vector<int> ids;
   std::vector<std::string> values;
@@ -72,8 +72,8 @@ void test_stream_iterates()
 
 void test_stream_reads_simple_values()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   int counter{0};
   for (auto [id, name] :
        tx.stream<std::size_t, std::string>("SELECT 213, 'Hi'"))
@@ -90,8 +90,8 @@ void test_stream_reads_simple_values()
 
 void test_stream_reads_string_view()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   std::vector<std::string> out;
   for (auto [v] : tx.stream<std::string_view>(
          "SELECT 'x' || generate_series FROM generate_series(1, 2)"))
@@ -107,8 +107,8 @@ void test_stream_reads_string_view()
 
 void test_stream_reads_nulls_as_optionals()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   for (auto [null] : tx.stream<std::optional<std::string>>("SELECT NULL"))
     PQXX_CHECK(not null.has_value(), "NULL translated to nonempty optional.");
@@ -124,15 +124,15 @@ void test_stream_reads_nulls_as_optionals()
 
 void test_stream_parses_awkward_strings()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
 
   // This is a particularly awkward encoding that we should test.  Its
   // multibyte characters can include byte values that *look* like ASCII
   // characters, such as quotes and backslashes.  It is crucial that we parse
   // those properly.  A byte-for-byte scan could find special ASCII characters
   // that aren't really there.
-  conn.set_client_encoding("SJIS");
-  pqxx::work tx{conn};
+  cx.set_client_encoding("SJIS");
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE nasty(id integer, value varchar)");
   tx.exec0(
     "INSERT INTO nasty(id, value) VALUES "
@@ -175,8 +175,8 @@ void test_stream_parses_awkward_strings()
 
 void test_stream_handles_nulls_in_all_places()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   for (auto [a, b, c, d, e] :
        tx.stream<
          std::optional<std::string>, std::optional<int>, int,
@@ -194,8 +194,8 @@ void test_stream_handles_nulls_in_all_places()
 
 void test_stream_handles_empty_string()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::string out{"<uninitialised>"};
   for (auto [empty] : tx.stream<std::string_view>("SELECT ''")) out = empty;

--- a/test/unit/test_stream_to.cxx
+++ b/test/unit/test_stream_to.cxx
@@ -233,8 +233,8 @@ void test_too_many_fields_fold(pqxx::connection &connection)
 
 void test_stream_to_does_nonnull_optional()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE foo(x integer, y text)");
   auto inserter{pqxx::stream_to::table(tx, {"foo"})};
   inserter.write_values(
@@ -285,8 +285,8 @@ void test_optional_fold(pqxx::connection &connection)
 // As an alternative to a tuple, you can also insert a container.
 void test_container_stream_to()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   tx.exec0("CREATE TEMP TABLE test_container(a integer, b integer)");
 
   auto inserter{pqxx::stream_to::table(tx, {"test_container"})};
@@ -322,9 +322,9 @@ void test_variant_fold(pqxx::connection_base &connection)
   tx.commit();
 }
 
-void clear_table(pqxx::connection &conn)
+void clear_table(pqxx::connection &cx)
 {
-  pqxx::work tx{conn};
+  pqxx::work tx{cx};
   tx.exec0("DELETE FROM stream_to_test");
   tx.commit();
 }
@@ -332,8 +332,8 @@ void clear_table(pqxx::connection &conn)
 
 void test_stream_to()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0(
     "CREATE TEMP TABLE stream_to_test ("
@@ -346,38 +346,38 @@ void test_stream_to()
     ")");
   tx.commit();
 
-  test_nonoptionals(conn);
-  clear_table(conn);
-  test_nonoptionals_fold(conn);
-  clear_table(conn);
-  test_bad_null(conn);
-  clear_table(conn);
-  test_bad_null_fold(conn);
-  clear_table(conn);
-  test_too_few_fields(conn);
-  clear_table(conn);
-  test_too_few_fields_fold(conn);
-  clear_table(conn);
-  test_too_many_fields(conn);
-  clear_table(conn);
-  test_too_many_fields_fold(conn);
-  clear_table(conn);
-  test_optional<std::unique_ptr>(conn);
-  clear_table(conn);
-  test_optional_fold<std::unique_ptr>(conn);
-  clear_table(conn);
-  test_optional<std::optional>(conn);
-  clear_table(conn);
-  test_optional_fold<std::optional>(conn);
-  clear_table(conn);
-  test_variant_fold(conn);
+  test_nonoptionals(cx);
+  clear_table(cx);
+  test_nonoptionals_fold(cx);
+  clear_table(cx);
+  test_bad_null(cx);
+  clear_table(cx);
+  test_bad_null_fold(cx);
+  clear_table(cx);
+  test_too_few_fields(cx);
+  clear_table(cx);
+  test_too_few_fields_fold(cx);
+  clear_table(cx);
+  test_too_many_fields(cx);
+  clear_table(cx);
+  test_too_many_fields_fold(cx);
+  clear_table(cx);
+  test_optional<std::unique_ptr>(cx);
+  clear_table(cx);
+  test_optional_fold<std::unique_ptr>(cx);
+  clear_table(cx);
+  test_optional<std::optional>(cx);
+  clear_table(cx);
+  test_optional_fold<std::optional>(cx);
+  clear_table(cx);
+  test_variant_fold(cx);
 }
 
 
 void test_stream_to_factory_with_static_columns()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0("CREATE TEMP TABLE pqxx_stream_to(a integer, b varchar)");
 
@@ -395,8 +395,8 @@ void test_stream_to_factory_with_static_columns()
 
 void test_stream_to_factory_with_dynamic_columns()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0("CREATE TEMP TABLE pqxx_stream_to(a integer, b varchar)");
 
@@ -405,7 +405,7 @@ void test_stream_to_factory_with_dynamic_columns()
   auto stream{pqxx::stream_to::table(tx, {"pqxx_stream_to"}, columns)};
 #else
   auto stream{pqxx::stream_to::raw_table(
-    tx, conn.quote_table({"pqxx_stream_to"}), conn.quote_columns(columns))};
+    tx, cx.quote_table({"pqxx_stream_to"}), cx.quote_columns(columns))};
 #endif
   stream.write_values(4, "four");
   stream.complete();
@@ -421,8 +421,8 @@ void test_stream_to_factory_with_dynamic_columns()
 
 void test_stream_to_quotes_arguments()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::string const table{R"--(pqxx_Stream"'x)--"}, column{R"--(a'"b)--"};
 
@@ -442,8 +442,8 @@ void test_stream_to_quotes_arguments()
 
 void test_stream_to_optionals()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0("CREATE TEMP TABLE pqxx_strings(key integer, value varchar)");
 
@@ -491,8 +491,8 @@ void test_stream_to_optionals()
 
 void test_stream_to_escaping()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   tx.exec0("CREATE TEMP TABLE foo (i integer, t varchar)");
 

--- a/test/unit/test_string_conversion.cxx
+++ b/test/unit/test_string_conversion.cxx
@@ -161,8 +161,8 @@ void test_integer_conversion()
 
 void test_convert_null()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   PQXX_CHECK_EQUAL(
     tx.quote(nullptr), "NULL", "Null pointer did not come out as SQL 'null'.");
   PQXX_CHECK_EQUAL(

--- a/test/unit/test_subtransaction.cxx
+++ b/test/unit/test_subtransaction.cxx
@@ -23,9 +23,9 @@ int count_rows(pqxx::transaction_base &trans)
 }
 
 
-void test_subtransaction_commits_if_commit_called(pqxx::connection &conn)
+void test_subtransaction_commits_if_commit_called(pqxx::connection &cx)
 {
-  pqxx::work trans(conn);
+  pqxx::work trans(cx);
   make_table(trans);
   {
     pqxx::subtransaction sub(trans);
@@ -37,9 +37,9 @@ void test_subtransaction_commits_if_commit_called(pqxx::connection &conn)
 }
 
 
-void test_subtransaction_aborts_if_abort_called(pqxx::connection &conn)
+void test_subtransaction_aborts_if_abort_called(pqxx::connection &cx)
 {
-  pqxx::work trans(conn);
+  pqxx::work trans(cx);
   make_table(trans);
   {
     pqxx::subtransaction sub(trans);
@@ -51,9 +51,9 @@ void test_subtransaction_aborts_if_abort_called(pqxx::connection &conn)
 }
 
 
-void test_subtransaction_aborts_implicitly(pqxx::connection &conn)
+void test_subtransaction_aborts_implicitly(pqxx::connection &cx)
 {
-  pqxx::work trans(conn);
+  pqxx::work trans(cx);
   make_table(trans);
   {
     pqxx::subtransaction sub(trans);
@@ -67,10 +67,10 @@ void test_subtransaction_aborts_implicitly(pqxx::connection &conn)
 
 void test_subtransaction()
 {
-  pqxx::connection conn;
-  test_subtransaction_commits_if_commit_called(conn);
-  test_subtransaction_aborts_if_abort_called(conn);
-  test_subtransaction_aborts_implicitly(conn);
+  pqxx::connection cx;
+  test_subtransaction_commits_if_commit_called(cx);
+  test_subtransaction_aborts_if_abort_called(cx);
+  test_subtransaction_aborts_implicitly(cx);
 }
 
 

--- a/test/unit/test_subtransaction.cxx
+++ b/test/unit/test_subtransaction.cxx
@@ -5,62 +5,62 @@
 
 namespace
 {
-void make_table(pqxx::transaction_base &trans)
+void make_table(pqxx::transaction_base &tx)
 {
-  trans.exec0("CREATE TEMP TABLE foo (x INTEGER)");
+  tx.exec0("CREATE TEMP TABLE foo (x INTEGER)");
 }
 
 
-void insert_row(pqxx::transaction_base &trans)
+void insert_row(pqxx::transaction_base &tx)
 {
-  trans.exec0("INSERT INTO foo(x) VALUES (1)");
+  tx.exec0("INSERT INTO foo(x) VALUES (1)");
 }
 
 
-int count_rows(pqxx::transaction_base &trans)
+int count_rows(pqxx::transaction_base &tx)
 {
-  return trans.query_value<int>("SELECT count(*) FROM foo");
+  return tx.query_value<int>("SELECT count(*) FROM foo");
 }
 
 
 void test_subtransaction_commits_if_commit_called(pqxx::connection &cx)
 {
-  pqxx::work trans(cx);
-  make_table(trans);
+  pqxx::work tx(cx);
+  make_table(tx);
   {
-    pqxx::subtransaction sub(trans);
+    pqxx::subtransaction sub(tx);
     insert_row(sub);
     sub.commit();
   }
   PQXX_CHECK_EQUAL(
-    count_rows(trans), 1, "Work done in committed subtransaction was lost.");
+    count_rows(tx), 1, "Work done in committed subtransaction was lost.");
 }
 
 
 void test_subtransaction_aborts_if_abort_called(pqxx::connection &cx)
 {
-  pqxx::work trans(cx);
-  make_table(trans);
+  pqxx::work tx(cx);
+  make_table(tx);
   {
-    pqxx::subtransaction sub(trans);
+    pqxx::subtransaction sub(tx);
     insert_row(sub);
     sub.abort();
   }
   PQXX_CHECK_EQUAL(
-    count_rows(trans), 0, "Aborted subtransaction was not rolled back.");
+    count_rows(tx), 0, "Aborted subtransaction was not rolled back.");
 }
 
 
 void test_subtransaction_aborts_implicitly(pqxx::connection &cx)
 {
-  pqxx::work trans(cx);
-  make_table(trans);
+  pqxx::work tx(cx);
+  make_table(tx);
   {
-    pqxx::subtransaction sub(trans);
+    pqxx::subtransaction sub(tx);
     insert_row(sub);
   }
   PQXX_CHECK_EQUAL(
-    count_rows(trans), 0,
+    count_rows(tx), 0,
     "Uncommitted subtransaction was not rolled back uring destruction.");
 }
 

--- a/test/unit/test_time.cxx
+++ b/test/unit/test_time.cxx
@@ -11,8 +11,8 @@ using namespace std::literals;
 
 void test_date_string_conversion()
 {
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   std::tuple<int, unsigned, unsigned, std::string_view> const conversions[]{
     {-542, 1, 1, "0543-01-01 BC"sv},
     {-1, 2, 3, "0002-02-03 BC"sv},

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -47,9 +47,9 @@ void test_exec_n(pqxx::transaction_base &trans)
 }
 
 
-void test_query_value(pqxx::connection &conn)
+void test_query_value(pqxx::connection &cx)
 {
-  pqxx::work tx{conn};
+  pqxx::work tx{cx};
 
   PQXX_CHECK_EQUAL(
     tx.query_value<int>("SELECT 84 / 2"), 42,
@@ -76,14 +76,14 @@ void test_query_value(pqxx::connection &conn)
 
 void test_transaction_base()
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
   {
-    pqxx::work tx{conn};
+    pqxx::work tx{cx};
     test_exec_n(tx);
     test_exec0(tx);
     test_exec1(tx);
   }
-  test_query_value(conn);
+  test_query_value(cx);
 }
 
 
@@ -181,8 +181,8 @@ void test_transaction_for_query()
     "SELECT i, concat('x', (2*i)::text) "
     "FROM generate_series(1, 3) AS i "
     "ORDER BY i"};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   std::string ints;
   std::string strings;
   tx.for_query(query, [&ints, &strings](int i, std::string const &s) {
@@ -214,8 +214,8 @@ void test_transaction_for_stream()
     "SELECT i, concat('x', (2*i)::text) "
     "FROM generate_series(1, 3) AS i "
     "ORDER BY i"};
-  pqxx::connection conn;
-  pqxx::work tx{conn};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   std::string ints;
   std::string strings;
   tx.for_stream(query, [&ints, &strings](int i, std::string const &s) {

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -5,43 +5,43 @@
 
 namespace
 {
-void test_exec0(pqxx::transaction_base &trans)
+void test_exec0(pqxx::transaction_base &tx)
 {
-  pqxx::result E{trans.exec0("SELECT * FROM pg_tables WHERE 0 = 1")};
+  pqxx::result E{tx.exec0("SELECT * FROM pg_tables WHERE 0 = 1")};
   PQXX_CHECK(std::empty(E), "Nonempty result from exec0.");
 
   PQXX_CHECK_THROWS(
-    trans.exec0("SELECT 99"), pqxx::unexpected_rows,
+    tx.exec0("SELECT 99"), pqxx::unexpected_rows,
     "Nonempty exec0 result did not throw unexpected_rows.");
 }
 
 
-void test_exec1(pqxx::transaction_base &trans)
+void test_exec1(pqxx::transaction_base &tx)
 {
-  pqxx::row R{trans.exec1("SELECT 99")};
+  pqxx::row R{tx.exec1("SELECT 99")};
   PQXX_CHECK_EQUAL(std::size(R), 1, "Wrong size result from exec1.");
   PQXX_CHECK_EQUAL(R.front().as<int>(), 99, "Wrong result from exec1.");
 
   PQXX_CHECK_THROWS(
-    trans.exec1("SELECT * FROM pg_tables WHERE 0 = 1"), pqxx::unexpected_rows,
+    tx.exec1("SELECT * FROM pg_tables WHERE 0 = 1"), pqxx::unexpected_rows,
     "Empty exec1 result did not throw unexpected_rows.");
   PQXX_CHECK_THROWS(
-    trans.exec1("SELECT * FROM generate_series(1, 2)"), pqxx::unexpected_rows,
+    tx.exec1("SELECT * FROM generate_series(1, 2)"), pqxx::unexpected_rows,
     "Two-row exec1 result did not throw unexpected_rows.");
 }
 
 
-void test_exec_n(pqxx::transaction_base &trans)
+void test_exec_n(pqxx::transaction_base &tx)
 {
-  pqxx::result R{trans.exec_n(3u, "SELECT * FROM generate_series(1, 3)")};
+  pqxx::result R{tx.exec_n(3u, "SELECT * FROM generate_series(1, 3)")};
   PQXX_CHECK_EQUAL(std::size(R), 3, "Wrong result size from exec_n.");
 
   PQXX_CHECK_THROWS(
-    trans.exec_n(2u, "SELECT * FROM generate_series(1, 3)"),
+    tx.exec_n(2u, "SELECT * FROM generate_series(1, 3)"),
     pqxx::unexpected_rows,
     "exec_n did not throw unexpected_rows for an undersized result.");
   PQXX_CHECK_THROWS(
-    trans.exec_n(4u, "SELECT * FROM generate_series(1, 3)"),
+    tx.exec_n(4u, "SELECT * FROM generate_series(1, 3)"),
     pqxx::unexpected_rows,
     "exec_n did not throw unexpected_rows for an oversized result.");
 }

--- a/test/unit/test_transaction_focus.cxx
+++ b/test/unit/test_transaction_focus.cxx
@@ -15,8 +15,8 @@ auto make_focus(pqxx::dbtransaction &tx)
 
 void test_cannot_run_statement_during_focus()
 {
-  pqxx::connection conn;
-  pqxx::transaction tx{conn};
+  pqxx::connection cx;
+  pqxx::transaction tx{cx};
   tx.exec("SELECT 1");
   auto focus{make_focus(tx)};
   PQXX_CHECK_THROWS(
@@ -27,9 +27,9 @@ void test_cannot_run_statement_during_focus()
 
 void test_cannot_run_prepared_statement_during_focus()
 {
-  pqxx::connection conn;
-  conn.prepare("foo", "SELECT 1");
-  pqxx::transaction tx{conn};
+  pqxx::connection cx;
+  cx.prepare("foo", "SELECT 1");
+  pqxx::transaction tx{cx};
   tx.exec_prepared("foo");
   auto focus{make_focus(tx)};
   PQXX_CHECK_THROWS(
@@ -39,8 +39,8 @@ void test_cannot_run_prepared_statement_during_focus()
 
 void test_cannot_run_params_statement_during_focus()
 {
-  pqxx::connection conn;
-  pqxx::transaction tx{conn};
+  pqxx::connection cx;
+  pqxx::transaction tx{cx};
   tx.exec_params("select $1", 10);
   auto focus{make_focus(tx)};
   PQXX_CHECK_THROWS(

--- a/test/unit/test_transactor.cxx
+++ b/test/unit/test_transactor.cxx
@@ -7,9 +7,9 @@ namespace
 {
 void test_transactor_newstyle_executes_simple_query()
 {
-  pqxx::connection conn;
-  auto const r{pqxx::perform([&conn] {
-    return pqxx::work{conn}.exec("SELECT generate_series(1, 4)");
+  pqxx::connection cx;
+  auto const r{pqxx::perform([&cx] {
+    return pqxx::work{cx}.exec("SELECT generate_series(1, 4)");
   })};
 
   PQXX_CHECK_EQUAL(std::size(r), 4, "Unexpected result size.");

--- a/test/unit/test_transactor.cxx
+++ b/test/unit/test_transactor.cxx
@@ -8,9 +8,8 @@ namespace
 void test_transactor_newstyle_executes_simple_query()
 {
   pqxx::connection cx;
-  auto const r{pqxx::perform([&cx] {
-    return pqxx::work{cx}.exec("SELECT generate_series(1, 4)");
-  })};
+  auto const r{pqxx::perform(
+    [&cx] { return pqxx::work{cx}.exec("SELECT generate_series(1, 4)"); })};
 
   PQXX_CHECK_EQUAL(std::size(r), 4, "Unexpected result size.");
   PQXX_CHECK_EQUAL(r.columns(), 1, "Unexpected number of columns.");

--- a/tools/rmlo.cxx
+++ b/tools/rmlo.cxx
@@ -6,7 +6,7 @@
 
 int main(int, char *argv[])
 {
-  pqxx::connection conn;
+  pqxx::connection cx;
   bool failures = false;
 
   try
@@ -16,8 +16,8 @@ int main(int, char *argv[])
       auto o{pqxx::from_string<pqxx::oid>(argv[i])};
       try
       {
-        pqxx::perform([o, &conn] {
-          pqxx::work tx{conn};
+        pqxx::perform([o, &cx] {
+          pqxx::work tx{cx};
           pqxx::blob::remove(tx, o);
           tx.commit();
         });


### PR DESCRIPTION
For years now I've been using `tx` as the standard name for a variable (or parameter) that denotes a transaction.  (There were a few places where they were still called `trans`, but this PR cleans those up.)

So why not use `cx` for a connection?  That way we have `tx{cx}` instead of `tx{conn}` or `trans{conn}`.  Simple, short, regular, and (I think) just as clear.