### PR TITLE
WIP: Factor out restrictions on number of result rows.

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -52,6 +52,7 @@ install(
     PATTERN types
     PATTERN util
     PATTERN version
+    PATTERN want
     PATTERN zview
     PATTERN internal/*.hxx
     PATTERN internal/gates/*.hxx

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -36,6 +36,7 @@ nobase_include_HEADERS= pqxx/pqxx \
 	pqxx/types pqxx/types.hxx \
 	pqxx/zview pqxx/zview.hxx \
 	pqxx/version pqxx/version.hxx \
+	pqxx/want pqxx/want.hxx \
 	pqxx/internal/array-composite.hxx \
 	pqxx/internal/callgate.hxx \
 	pqxx/internal/concat.hxx \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -384,6 +384,7 @@ nobase_include_HEADERS = pqxx/pqxx \
 	pqxx/types pqxx/types.hxx \
 	pqxx/zview pqxx/zview.hxx \
 	pqxx/version pqxx/version.hxx \
+	pqxx/want pqxx/want.hxx \
 	pqxx/internal/array-composite.hxx \
 	pqxx/internal/callgate.hxx \
 	pqxx/internal/concat.hxx \

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -37,6 +37,7 @@
 #include "pqxx/result.hxx"
 #include "pqxx/row.hxx"
 #include "pqxx/util.hxx"
+#include "pqxx/want.hxx"
 
 namespace pqxx::internal::gate
 {
@@ -504,15 +505,9 @@ public:
   [[nodiscard]] std::optional<std::tuple<TYPE...>> query01(zview query)
   {
     result res{exec(query)};
-    auto const rows{std::size(res)};
-    switch (rows)
-    {
-    case 0: return {};
-    case 1: return {res[0].as<TYPE...>()};
-    default:
-      throw unexpected_rows{internal::concat(
-        "Expected at most one row of data, got "sv, rows, "."sv)};
-    }
+    want<0, 2>(res);
+    if (std::size(res) == 0) return {};
+    else return {res[0].as<TYPE...>()};
   }
 
   /// Execute a query, in streaming fashion; loop over the results row by row.
@@ -870,15 +865,9 @@ public:
   query01(zview query, params const &parms)
   {
     result res{exec_params(query, parms)};
-    auto const rows{std::size(res)};
-    switch (rows)
-    {
-    case 0: return {};
-    case 1: return {res[0].as<TYPE...>()};
-    default:
-      throw unexpected_rows{internal::concat(
-        "Expected at most one row of data, got "sv, rows, "."sv)};
-    }
+    want<0, 2>(res);
+    if (std::size(res) == 0) return {};
+    else return {res[0].as<TYPE...>()};
   }
 
   // C++20: Concept like std::invocable, but without specifying param types.

--- a/include/pqxx/want
+++ b/include/pqxx/want
@@ -1,0 +1,6 @@
+/** Helpers for constraining expected query results.
+ */
+// Actual definitions in .hxx file so edtiors and such recognize file type.
+#include "pqxx/internal/header-pre.hxx"
+#include "pqxx/want.hxx"
+#include "pqxx/internal/header-post.hxx"

--- a/include/pqxx/want.hxx
+++ b/include/pqxx/want.hxx
@@ -1,0 +1,120 @@
+/* Helpers for constraining query results.
+ *
+ * DO NOT INCLUDE THIS FILE DIRECTLY; include pqxx/want instead.
+ *
+ * Copyright (c) 2000-2024, Jeroen T. Vermeulen.
+ *
+ * See COPYING for copyright license.  If you did not receive a flie called
+ * COPYING with this source code, please notify the distributor of this
+ * mistake, or contact the author.
+ */
+#ifndef PQXX_H_WANT
+#define PQXX_H_WANT
+
+#include <pqxx/except.hxx>
+#include <pqxx/internal/concat.hxx>
+#include <pqxx/result.hxx>
+
+
+namespace pqxx
+{
+// XXX: Support "at least n rows"?
+// XXX: Support dynamic limits.
+// XXX: std::source_location?
+
+/// Check that @ref result `r` contains exactly `expected` rows.
+/** @throw unexpected_rows if the result did not contain exactly the expected
+ * number of rows.
+ */
+template<result::size_type expected>
+inline void want(result const &r)
+{
+  static_assert(expected >= 0);
+  auto const sz{std::size(r)};
+  PQXX_ASSUME(sz >= 0);
+  if (sz != expected)
+  {
+    if constexpr (expected == 1)
+      throw unexpected_rows{pqxx::internal::concat("Expected 1 row, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat("Expected ", expected, " rows, got ", sz, ".")};
+  }
+}
+
+
+/// Check that @ref result `r` contains an acceptable number of rows.
+/** @throw unexpected_rows if `r` contains fewer than `minimum` rows,
+ * or if it contained  
+ */
+template<result::size_type minimum, result::size_type excess>
+inline void want(result const &r)
+{
+  static_assert(minimum >= 0);
+  static_assert(excess > minimum);
+  auto const sz{std::size(r)};
+  PQXX_ASSUME(sz >= 0);
+  if (sz < minimum)
+  {
+    if constexpr (minimum == 1)
+      throw unexpected_rows{pqxx::internal::concat("Expected at least 1 row, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat("Expected at least ", minimum, " rows, got ", sz, ".")};
+  }
+  if (sz >= excess)
+  {
+    if constexpr (excess == 1)
+      throw unexpected_rows{pqxx::internal::concat("Expected no rows, got ", sz, ".")};
+    else if constexpr (excess == 2)
+      throw unexpected_rows{pqxx::internal::concat("Expected at most one row, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat("Expected fewer than ", excess, " rows, got ", sz, ".")};
+  }
+}
+
+
+/// Check that @ref result `r` contains exactly `expected` rows.
+/** @throw unexpected_rows if the result did not contain exactly the expected
+ * number of rows.
+ */
+inline void want(result::size_type expected, result const &r)
+{
+  auto const sz{std::size(r)};
+  PQXX_ASSUME(sz >= 0);
+  if (sz != expected)
+  {
+    if (expected == 1)
+      throw unexpected_rows{pqxx::internal::concat("Expected 1 row, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat("Expected ", expected, " rows, got ", sz, ".")};
+  }
+}
+
+
+/// Check that @ref result `r` contains an acceptable number of rows.
+/** @throw unexpected_rows if `r` contains fewer than `minimum` rows,
+ * or if it contained  
+ */
+inline void want(result::size_type minimum, result::size_type excess, result const &r)
+{
+  auto const sz{std::size(r)};
+  PQXX_ASSUME(sz >= 0);
+  if (sz < minimum)
+  {
+    if (minimum == 1)
+      throw unexpected_rows{pqxx::internal::concat("Expected at least 1 row, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat("Expected at least ", minimum, " rows, got ", sz, ".")};
+  }
+  if (sz >= excess)
+  {
+    if (excess == 1)
+      throw unexpected_rows{pqxx::internal::concat("Expected no rows, got ", sz, ".")};
+    else if (excess == 2)
+      throw unexpected_rows{pqxx::internal::concat("Expected at most one row, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat("Expected fewer than ", excess, " rows, got ", sz, ".")};
+  }
+}
+} // namespace pqxx
+
+#endif


### PR DESCRIPTION
I'm looking into moving the distinctions between `exec0()`, `exec1()`, `exec_n()` etc. out into a separate function.

So far this is just an experiment.