### PR TITLE
remove a use added for a purpose which is gone in the meantime.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -8,15 +8,6 @@ function(detect_code_compiled code macro msg)
     endif()
 endfunction(detect_code_compiled)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
-    include(CMakeDetermineCompilerSupport)
-    cmake_determine_compiler_support(CXX)
-else()
-    # This function changed names in CMake 3.30.  :-(
-    include(CMakeDetermineCompileFeatures)
-    cmake_determine_compile_features(CXX)
-endif()
-
 include(CheckIncludeFileCXX)
 include(CheckFunctionExists)
 include(CheckSymbolExists)


### PR DESCRIPTION
    The following comments explains why it was added, and that indeed it is no longer needed, as such.
    https://github.com/jtv/libpqxx/issues/851#issuecomment-2213649992

    Note that neither of these 2 cmake modules are for public use, they are internal cmake stuff.
    Nothing on the outside should use it. This was feedback given by kitware developers.