### PR TITLE
Remove unneeded cmp0057 new

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -8,6 +8,15 @@ function(detect_code_compiled code macro msg)
     endif()
 endfunction(detect_code_compiled)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
+    include(CMakeDetermineCompilerSupport)
+    cmake_determine_compiler_support(CXX)
+else()
+    # This function changed names in CMake 3.30.  :-(
+    include(CMakeDetermineCompileFeatures)
+    cmake_determine_compile_features(CXX)
+endif()
+
 include(CheckIncludeFileCXX)
 include(CheckFunctionExists)
 include(CheckSymbolExists)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -38,8 +38,6 @@ check_function_exists("poll" PQXX_HAVE_POLL)
 
 set(CMAKE_REQUIRED_LIBRARIES pq)
 
-cmake_policy(SET CMP0057 NEW)
-
 # check_cxx_source_compiles requires CMAKE_REQUIRED_DEFINITIONS to specify
 # compiling arguments. Workaround: Push CMAKE_REQUIRED_DEFINITIONS
 if(CMAKE_REQUIRED_DEFINITIONS)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -8,15 +8,6 @@ function(detect_code_compiled code macro msg)
     endif()
 endfunction(detect_code_compiled)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
-    include(CMakeDetermineCompilerSupport)
-    cmake_determine_compiler_support(CXX)
-else()
-    # This function changed names in CMake 3.30.  :-(
-    include(CMakeDetermineCompileFeatures)
-    cmake_determine_compile_features(CXX)
-endif()
-
 include(CheckIncludeFileCXX)
 include(CheckFunctionExists)
 include(CheckSymbolExists)


### PR DESCRIPTION

setting the policy to new is not needed, because we demand cmake_minimum_required(VERSION 3.8) and this policy was introduced in cmake 3.3, see here : https://cmake.org/cmake/help/latest/policy/CMP0057.html

this means any newer cmake is using the new policy (unless somebody would set it to old explicitly)