### PR TITLE
Reduce string copying in array parsing.

### DIFF
--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -595,7 +595,7 @@ private:
   template<pqxx::internal::encoding_group>
   std::string::size_type scan_unquoted_string() const;
   template<pqxx::internal::encoding_group>
-  std::string parse_unquoted_string(std::string::size_type end) const;
+  std::string_view parse_unquoted_string(std::string::size_type end) const;
 
   template<pqxx::internal::encoding_group>
   std::string::size_type scan_glyph(std::string::size_type pos) const;

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -143,10 +143,9 @@ scan_unquoted_string(char const input[], std::size_t size, std::size_t pos)
 }
 
 
-// XXX: Retire this.  Just construct a string_view directly now!
 /// Parse an unquoted array entry or cfield of a composite-type field.
 template<pqxx::internal::encoding_group ENC>
-inline std::string
+inline std::string_view
 parse_unquoted_string(char const input[], std::size_t end, std::size_t pos)
 {
   return {&input[pos], end - pos};

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -80,7 +80,7 @@ std::string::size_type array_parser::scan_unquoted_string() const
  * that happens to spell "NULL".
  */
 template<pqxx::internal::encoding_group ENC>
-std::string
+std::string_view
 array_parser::parse_unquoted_string(std::string::size_type end) const
 {
   return pqxx::internal::parse_unquoted_string<ENC>(


### PR DESCRIPTION
This should reduce the copying of strings in array parsing a bit. Parsing an unquoted string is really just a matter of referring to the input data, so we can use a `std::string_view` there instead of a `std::string`.

Upon reflection I don't think this breaks the ABI, since it's purely an internal call.  _Yes_ there's an externally visible symbol involved but nobody has any business calling it.