### PR TITLE
Distinguish prepared statements by overload.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  - Fixed error message on clashing transaction focuses. (#879)
  - Don't call`/bin/true`; macOS doesn't have it.  Just call `true`. (#885)
  - Deprecate `exec_prepared()`; just use `exec()` with a `pqxx::prepped`.
+ - Deprecate `exec1()` etc.  Use `result::expect_rows()` etc.
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
  - Bump minimum CMake version to 3.28. (#874)
  - Fixed error message on clashing transaction focuses. (#879)
  - Don't call`/bin/true`; macOS doesn't have it.  Just call `true`. (#885)
- - Deprecate `exec_prepared()`; call `exec()` with a `pqxx::prepped` object.
+ - Deprecate `exec_prepared()`; just use `exec()` with a `pqxx::prepped`.
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
  - Bump minimum CMake version to 3.28. (#874)
  - Fixed error message on clashing transaction focuses. (#879)
  - Don't call`/bin/true`; macOS doesn't have it.  Just call `true`. (#885)
+ - Deprecate `exec_prepared()`; call `exec()` with a `pqxx::prepped` object.
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/include/pqxx/internal/gates/connection-transaction.hxx
+++ b/include/pqxx/internal/gates/connection-transaction.hxx
@@ -31,12 +31,13 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
   void write_copy_line(std::string_view line) { home().write_copy_line(line); }
   void end_copy_write() { home().end_copy_write(); }
 
-  result exec_prepared(zview statement, internal::c_params const &args)
+  result exec_prepared(
+    std::string_view statement, internal::c_params const &args)
   {
     return home().exec_prepared(statement, args);
   }
 
-  result exec_params(zview query, internal::c_params const &args)
+  result exec_params(std::string_view query, internal::c_params const &args)
   {
     return home().exec_params(query, args);
   }

--- a/include/pqxx/internal/gates/connection-transaction.hxx
+++ b/include/pqxx/internal/gates/connection-transaction.hxx
@@ -31,8 +31,8 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
   void write_copy_line(std::string_view line) { home().write_copy_line(line); }
   void end_copy_write() { home().end_copy_write(); }
 
-  result exec_prepared(
-    std::string_view statement, internal::c_params const &args)
+  result
+  exec_prepared(std::string_view statement, internal::c_params const &args)
   {
     return home().exec_prepared(statement, args);
   }

--- a/include/pqxx/internal/header-pre.hxx
+++ b/include/pqxx/internal/header-pre.hxx
@@ -182,7 +182,6 @@
 
 // C++23: Assume support.
 // C++20: Assume __has_cpp_attribute is defined.
-// XXX: Find places to apply [[assume(...)]].
 #if !defined(__has_cpp_attribute)
 #  define PQXX_ASSUME(condition) while (false)
 #elif !__has_cpp_attribute(assume)

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -74,12 +74,16 @@ public:
   using iterator = result_iter<TYPE...>;
 
   explicit result_iteration(result const &home) : m_home{home}
-  { m_home.expect_columns(sizeof...(TYPE)); }
+  {
+    m_home.expect_columns(sizeof...(TYPE));
+  }
 
   iterator begin() const
   {
-    if (std::size(m_home) == 0) return end();
-    else return iterator{m_home};
+    if (std::size(m_home) == 0)
+      return end();
+    else
+      return iterator{m_home};
   }
   iterator end() const { return {}; }
 

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -72,21 +72,14 @@ template<typename... TYPE> class result_iteration
 {
 public:
   using iterator = result_iter<TYPE...>;
+
   explicit result_iteration(result const &home) : m_home{home}
-  {
-    constexpr auto tup_size{sizeof...(TYPE)};
-    if (home.columns() != tup_size)
-      throw usage_error{internal::concat(
-        "Tried to extract ", to_string(tup_size),
-        " field(s) from a result with ", to_string(home.columns()),
-        " column(s).")};
-  }
+  { m_home.expect_columns(sizeof...(TYPE)); }
+
   iterator begin() const
   {
-    if (std::size(m_home) == 0)
-      return end();
-    else
-      return iterator{m_home};
+    if (std::size(m_home) == 0) return end();
+    else return iterator{m_home};
   }
   iterator end() const { return {}; }
 

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -83,6 +83,9 @@ public:
 
   /// Execute `query` on `tx`, stream results.
   inline stream_query(transaction_base &tx, std::string_view query);
+  /// Execute `query` on `tx`, stream results.
+  inline stream_query(
+    transaction_base &tx, std::string_view query, params const &);
 
   stream_query(stream_query &&) = delete;
   stream_query &operator=(stream_query &&) = delete;

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -25,8 +25,8 @@ inline stream_query<TYPE...>::stream_query(
   transaction_base &tx, std::string_view query, params const &parms) :
         transaction_focus{tx, "stream_query"}, m_char_finder{get_finder(tx)}
 {
-  auto const r{
-    tx.exec(internal::concat("COPY (", query, ") TO STDOUT"), parms).no_rows()};
+  auto const r{tx.exec(internal::concat("COPY (", query, ") TO STDOUT"), parms)
+                 .no_rows()};
   if (r.columns() != sizeof...(TYPE))
     throw usage_error{concat(
       "Parsing query stream with wrong number of columns: "

--- a/include/pqxx/prepared_statement
+++ b/include/pqxx/prepared_statement
@@ -1,9 +1,10 @@
 /// Marker type to indicate that a string is the name of a prepared statement.
 
+#include "pqxx/internal/header-pre.hxx"
+
 // This include is deprecated.  It will go away.
 // Include <params> if you need it.
 #include "params.hxx"
 
-#include "pqxx/internal/header-pre.hxx"
 #include "pqxx/prepared_statement.hxx"
 #include "pqxx/internal/header-post.hxx"

--- a/include/pqxx/prepared_statement
+++ b/include/pqxx/prepared_statement
@@ -1,3 +1,9 @@
-/// @deprecated Include @c <pqxx/params> instead.
+/// Marker type to indicate that a string is the name of a prepared statement.
 
+// This include is deprecated.  It will go away.
+// Include <params> if you need it.
 #include "params.hxx"
+
+#include "pqxx/internal/header-pre.hxx"
+#include "pqxx/prepared_statement.hxx"
+#include "pqxx/internal/header-post.hxx"

--- a/include/pqxx/prepared_statement.hxx
+++ b/include/pqxx/prepared_statement.hxx
@@ -69,6 +69,7 @@ namespace pqxx
 class PQXX_LIBEXPORT prepped : public zview
 {
 public:
+  // XXX: May not have to be a zview!  Because exec() draws a copy anyway.
   prepped(zview name) : zview{name} {}
 };
 } // namespace pqxx

--- a/include/pqxx/prepared_statement.hxx
+++ b/include/pqxx/prepared_statement.hxx
@@ -13,10 +13,58 @@
 
 namespace pqxx
 {
+/**
+ * @name Prepared statements
+ *
+ * These are very similar to parameterised statements.  The difference is
+ * that you prepare a statement in advance, before you execute it, giving it an
+ * identifying name.  You can then call it by this name, as many times as you
+ * like, passing in separate sets of argument values appropriate for each call.
+ *
+ * You prepare a statement on the connection, using
+ * @ref pqxx::connection::prepare().  But you then call the statement in a
+ * transaction, by calling
+ * @ref pqxx::transaction_base::exec(pqxx::prepped, pqxx::params).
+ *
+ * The @ref pqxx::prepped type is really just a zero-terminated string, but
+ * wrapped in its own type.  This type only exists for one reason: it indicates
+ * that the string is not an SQL statement itself, but the _name_ of a prepared
+ * statement.
+ *
+ * See \ref prepared for a full discussion.
+ *
+ * @warning Beware of "nul" bytes.  Any string you pass as a parameter will
+ * end at the first char with value zero.  If you pass a string that contains
+ * a zero byte, the last byte in the value will be the one just before the
+ * zero.  If you need a zero byte, you're dealing with binary strings, not
+ * regular strings.  Represent binary strings on the SQL side as `BYTEA`
+ * (or as large objects).  On the C++ side, use types like `pqxx::bytes` or
+ * `pqxx::bytes_view` or (in C++20) `std::vector<std::byte>`.  Also, consider
+ * large objects on the SQL side and @ref blob on the C++ side.
+ *
+ * @warning Passing the wrong number of parameters to a prepared or
+ * parameterised statement will _break the connection._  The usual exception
+ * that occurs in this situation is @ref pqxx::protocol_violation.  It's a
+ * subclass of @ref pqxx::broken_connection, but where `broken_connection`
+ * usually indicates a networking problem, `protocol_violation` indicates
+ * that the communication with the server has deviated from protocol.  Once
+ * something like that happens, communication is broken and there is nothing
+ * for it but to discard the connection.  A networking problem is usually
+ * worth retrying, but a protocol violation is not.  Once the two ends of the
+ * connection disagree about where they are in their conversation, they can't
+ * get back on track.  This is beyond libpqxx's control.
+ */
+//@{
+
 /// A string that is the name of a prepared statement.
-/** When calling on libpqxx to execute a prepared statement, wrap its name in
+/**
+ * When calling on libpqxx to execute a prepared statement, wrap its name in
  * a `prepped` object to indicate to libpqxx that it is a statement name, not
  * SQL.
+ *
+ * The string must be like a C-style string: it should contain no bytes with
+ * value zero, but it must have a single byte with value zero directly behind
+ * it in memory.
  */
 class PQXX_LIBEXPORT prepped : public zview
 {

--- a/include/pqxx/prepared_statement.hxx
+++ b/include/pqxx/prepared_statement.hxx
@@ -69,7 +69,7 @@ namespace pqxx
 class PQXX_LIBEXPORT prepped : public zview
 {
 public:
-  // XXX: May not have to be a zview!  Because exec() draws a copy anyway.
+  // TODO: May not have to be a zview!  Because exec() draws a copy anyway.
   prepped(zview name) : zview{name} {}
 };
 } // namespace pqxx

--- a/include/pqxx/prepared_statement.hxx
+++ b/include/pqxx/prepared_statement.hxx
@@ -1,3 +1,28 @@
-/// @deprecated Include @c <pqxx/params> instead.
+/* Definition of the pqxx::prepped.
+ *
+ * DO NOT INCLUDE THIS FILE DIRECTLY; include pqxx/prepared_statement instead.
+ *
+ * Copyright (c) 2000-2024, Jeroen T. Vermeulen.
+ *
+ * See COPYING for copyright license.  If you did not receive a file called
+ * COPYING with this source code, please notify the distributor of this
+ * mistake, or contact the author.
+ */
+#ifndef PQXX_H_PREPARED_STATEMENT
+#define PQXX_H_PREPARED_STATEMENT
 
-#include "params.hxx"
+namespace pqxx
+{
+/// A string that is the name of a prepared statement.
+/** When calling on libpqxx to execute a prepared statement, wrap its name in
+ * a `prepped` object to indicate to libpqxx that it is a statement name, not
+ * SQL.
+ */
+class PQXX_LIBEXPORT prepped : public zview
+{
+public:
+  prepped(zview name) : zview{name} {}
+};
+} // namespace pqxx
+
+#endif

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -307,10 +307,11 @@ public:
       // TODO: See whether result contains a generated statement.
       if (not m_query or m_query->empty())
         throw unexpected_rows{pqxx::internal::concat(
-	  "Expected ", n, " row(s) from query, got ", sz, ".")};
+          "Expected ", n, " row(s) from query, got ", sz, ".")};
       else
         throw unexpected_rows{pqxx::internal::concat(
-          "Expected ", n, " row(s) from query '", *m_query, "', got ", sz, ".")};
+          "Expected ", n, " row(s) from query '", *m_query, "', got ", sz,
+          ".")};
     }
     return *this;
   }
@@ -348,10 +349,10 @@ public:
       // TODO: See whether result contains a generated statement.
       if (not m_query or m_query->empty())
         throw usage_error{pqxx::internal::concat(
-	  "Expected 1 column from query, got ", actual, ".")};
+          "Expected 1 column from query, got ", actual, ".")};
       else
         throw usage_error{pqxx::internal::concat(
-	  "Expected 1 column from query '", *m_query, "', got ", actual, ".")};
+          "Expected 1 column from query '", *m_query, "', got ", actual, ".")};
     }
     return *this;
   }

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -295,6 +295,67 @@ public:
    */
   template<typename CALLABLE> inline void for_each(CALLABLE &&func) const;
 
+  /// Check that result contains exactly `n` rows.
+  /** @return The result itself, for convenience.
+   * @throw @ref unexpected_rows if the actual count is not equal to `n`.
+   */
+  result expect_rows(size_type n) const
+  {
+    auto const sz{size()};
+    if (sz != n)
+    {
+      // TODO: See whether result contains a generated statement.
+      if (not m_query or m_query->empty())
+        throw unexpected_rows{pqxx::internal::concat(
+	  "Expected ", n, " row(s) from query, got ", sz, ".")};
+      else
+        throw unexpected_rows{pqxx::internal::concat(
+          "Expected ", n, " row(s) from query '", *m_query, "', got ", sz, ".")};
+    }
+    return *this;
+  }
+
+  /// Check that result contains exactly 1 row, and return that row.
+  /** @return @ref pqxx::row
+   * @throw @ref unexpected_rows if the actual count is not equal to `n`.
+   */
+  row one_row() const;
+
+  /// Expect that result contains at moost one row, and return as optional.
+  /** Returns an empty `std::optional` if the result is empty, or if it has
+   * exactly one row, a `std::optional` containing the row.
+   *
+   * @throw @ref unexpected_rows is the row count is not 0 or 1.
+   */
+  std::optional<row> opt_row() const;
+
+  /// Expect that result contains no rows.  Return result for convenience.
+  result no_rows() const
+  {
+    expect_rows(0);
+    return *this;
+  }
+
+  /// Expect that result consists of exactly `cols` columns.
+  /** @return The result itself, for convenience.
+   * @throw @ref usage_error otherwise.
+   */
+  result expect_columns(row_size_type cols) const
+  {
+    auto const actual{columns()};
+    if (actual != cols)
+    {
+      // TODO: See whether result contains a generated statement.
+      if (not m_query or m_query->empty())
+        throw usage_error{pqxx::internal::concat(
+	  "Expected 1 column from query, got ", actual, ".")};
+      else
+        throw usage_error{pqxx::internal::concat(
+	  "Expected 1 column from query '", *m_query, "', got ", actual, ".")};
+    }
+    return *this;
+  }
+
 private:
   using data_pointer = std::shared_ptr<internal::pq::PGresult const>;
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -34,6 +34,7 @@
 #include "pqxx/internal/encoding_group.hxx"
 #include "pqxx/internal/stream_query.hxx"
 #include "pqxx/isolation.hxx"
+#include "pqxx/prepared_statement.hxx"
 #include "pqxx/result.hxx"
 #include "pqxx/row.hxx"
 #include "pqxx/util.hxx"
@@ -944,8 +945,8 @@ public:
   //@{
 
   /// Execute a prepared statement, with optional arguments.
-  [[deprecated("Use exec(prepped, params) instead.")]]
   template<typename... Args>
+  [[deprecated("Use exec(prepped, params) instead.")]]
   result exec_prepared(zview statement, Args &&...args)
   {
     params pp(args...);
@@ -995,7 +996,7 @@ public:
   result
   exec_prepared_n(result::size_type rows, zview statement, Args &&...args)
   {
-    auto const r{exec_prepared(statement, std::forward<Args>(args)...)};
+    auto const r{exec(pqxx::prepped{statement}, params{args...})};
     check_rowcount_prepared(statement, rows, std::size(r));
     return r;
   }

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -944,6 +944,7 @@ public:
   //@{
 
   /// Execute a prepared statement, with optional arguments.
+  [[deprecated("Use exec(prepped, params) instead.")]]
   template<typename... Args>
   result exec_prepared(zview statement, Args &&...args)
   {
@@ -951,6 +952,21 @@ public:
     return internal_exec_prepared(statement, pp.make_c_params());
   }
 
+  /// Execute a prepared statement taking no parameters.
+  result exec(prepped statement)
+  {
+    params pp;
+    // TODO: Can we shortcut the creation of the empty params?
+    return internal_exec_prepared(statement, pp.make_c_params());
+  }
+
+  /// Execute a prepared statement with parameters.
+  result exec(prepped statement, params parms)
+  {
+    return internal_exec_prepared(statement, parms.make_c_params());
+  }
+
+  // TODO: Extract rows check.
   /// Execute a prepared statement, and expect a single-row result.
   /** @throw pqxx::unexpected_rows if the result was not exactly 1 row.
    */
@@ -960,6 +976,7 @@ public:
     return exec_prepared_n(1, statement, std::forward<Args>(args)...).front();
   }
 
+  // TODO: Extract rows check.
   /// Execute a prepared statement, and expect a result with zero rows.
   /** @throw pqxx::unexpected_rows if the result contained rows.
    */
@@ -969,6 +986,7 @@ public:
     return exec_prepared_n(0, statement, std::forward<Args>(args)...);
   }
 
+  // TODO: Extract rows check.
   /// Execute a prepared statement, expect a result with given number of rows.
   /** @throw pqxx::unexpected_rows if the result did not contain exactly the
    *  given number of rows.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -902,48 +902,6 @@ public:
   }
   //@}
 
-  /**
-   * @name Prepared statements
-   *
-   * These are very similar to parameterised statements.  The difference is
-   * that you prepare them in advance, giving them identifying names.  You can
-   * then call them by these names, passing in the argument values appropriate
-   * for that call.
-   *
-   * You prepare a statement on the connection, using
-   * @ref pqxx::connection::prepare().  But you then call the statement in a
-   * transaction, using the functions you see here.
-   *
-   * Never try to prepare, execute, or unprepare a prepared statement manually
-   * using direct SQL queries when you also use the libpqxx equivalents.  For
-   * any given statement, either prepare, manage, and execute it through the
-   * dedicated libpqxx functions; or do it all directly in SQL.  Don't mix the
-   * two, or the code may get confused.
-   *
-   * See \ref prepared for a full discussion.
-   *
-   * @warning Beware of "nul" bytes.  Any string you pass as a parameter will
-   * end at the first char with value zero.  If you pass a string that contains
-   * a zero byte, the last byte in the value will be the one just before the
-   * zero.  If you need a zero byte, you're dealing with binary strings, not
-   * regular strings.  Represent binary strings on the SQL side as `BYTEA`
-   * (or as large objects).  On the C++ side, use types like `pqxx::bytes` or
-   * `pqxx::bytes_view` or (in C++20) `std::vector<std::byte>`.  Also, consider
-   * large objects on the SQL side and @ref blob on the C++ side.
-   *
-   * @warning Passing the wrong number of parameters to a prepared or
-   * parameterised statement will _break the connection._  The usual exception
-   * that occurs in this situation is @ref pqxx::protocol_violation.  It's a
-   * subclass of @ref pqxx::broken_connection, but where `broken_connection`
-   * usually indicates a networking problem, `protocol_violation` indicates
-   * that the communication with the server has deviated from protocol.  Once
-   * something like that happens, communication is broken and there is nothing
-   * for it but to discard the connection.  A networking problem is usually
-   * worth retrying, but a protocol violation is not.  The same violation will
-   * probably just happen again.
-   */
-  //@{
-
   /// Execute a prepared statement, with optional arguments.
   template<typename... Args>
   [[deprecated("Use exec(prepped, params) instead.")]]
@@ -1000,8 +958,6 @@ public:
     check_rowcount_prepared(statement, rows, std::size(r));
     return r;
   }
-
-  //@}
 
   /**
    * @name Error/warning output

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -348,7 +348,9 @@ public:
   // TODO: Wrap PQdescribePrepared().
 
   result exec(std::string_view query, params parms)
-  { return internal_exec_params(query, parms.make_c_params()); }
+  {
+    return internal_exec_params(query, parms.make_c_params());
+  }
 
   /// Execute a command.
   /**
@@ -399,7 +401,9 @@ public:
    */
   [[deprecated("Use exec() and call no_rows() on the result.")]]
   result exec0(zview query)
-  { return exec(query).no_rows(); }
+  {
+    return exec(query).no_rows();
+  }
 
   /// Execute command returning a single row of data.
   /** Works like @ref exec, but requires the result to contain exactly one row.
@@ -425,7 +429,9 @@ public:
    */
   [[deprecated("Use exec() instead, and call one_row() on the result.")]]
   row exec1(zview query)
-  { return exec(query).one_row(); }
+  {
+    return exec(query).one_row();
+  }
 
   /// Execute command, expect given number of rows.
   /** Works like @ref exec, but checks that the result has exactly the expected
@@ -471,7 +477,9 @@ public:
    * @throw usage_error If the row did not contain exactly 1 field.
    */
   template<typename TYPE> TYPE query_value(zview query)
-  { return exec(query).expect_columns(1).one_row()[0].as<TYPE>(); }
+  {
+    return exec(query).expect_columns(1).one_row()[0].as<TYPE>();
+  }
 
   /// Perform query returning exactly one row, and convert its fields.
   /** This is a convenient way of querying one row's worth of data, and
@@ -499,8 +507,10 @@ public:
   [[nodiscard]] std::optional<std::tuple<TYPE...>> query01(zview query)
   {
     std::optional<row> const r{exec(query).opt_row()};
-    if (r) return {r->as<TYPE...>()};
-    else return {};
+    if (r)
+      return {r->as<TYPE...>()};
+    else
+      return {};
   }
 
   /// Execute a query, in streaming fashion; loop over the results row by row.
@@ -659,7 +669,9 @@ public:
   template<typename... TYPE>
   [[deprecated("Use query() instead, and call expect_rows() on the result.")]]
   auto query_n(result::size_type rows, zview query)
-  { return exec(query).expect_rows(rows).iter<TYPE...>(); }
+  {
+    return exec(query).expect_rows(rows).iter<TYPE...>();
+  }
 
   // C++20: Concept like std::invocable, but without specifying param types.
   /// Execute a query, load the full result, and perform `func` for each row.
@@ -714,7 +726,9 @@ public:
   template<typename... Args>
   [[deprecated("Use exec(zview, params) instead.")]]
   result exec_params(std::string_view query, Args &&...args)
-  { return exec(query, params{args...}); }
+  {
+    return exec(query, params{args...});
+  }
 
   // Execute parameterised statement, expect a single-row result.
   /** @throw unexpected_rows if the result does not consist of exactly one row.
@@ -731,10 +745,11 @@ public:
    */
   template<typename... Args>
   [[deprecated(
-    "Use exec(string_view, params) and call no_rows() on the result."
-  )]]
+    "Use exec(string_view, params) and call no_rows() on the result.")]]
   result exec_params0(zview query, Args &&...args)
-  { return exec(query, params{args...}).no_rows(); }
+  {
+    return exec(query, params{args...}).no_rows();
+  }
 
   // Execute parameterised statement, expect exactly a given number of rows.
   /** @throw unexpected_rows if the result contains the wrong number of rows.
@@ -743,9 +758,8 @@ public:
   [[deprecated("Use exec(), and call expect_rows() on the result.")]]
   result exec_params_n(std::size_t rows, zview query, Args &&...args)
   {
-    return exec(
-      query, params{args...}
-    ).expect_rows(check_cast<result_size_type>(rows, "number of rows"));
+    return exec(query, params{args...})
+      .expect_rows(check_cast<result_size_type>(rows, "number of rows"));
   }
 
   // Execute parameterised statement, expect exactly a given number of rows.
@@ -754,7 +768,9 @@ public:
   template<typename... Args>
   [[deprecated("Use exec(), and call expect_rows() on the result.")]]
   result exec_params_n(result::size_type rows, zview query, Args &&...args)
-  { return exec(query, params{args...}).expect_rows(rows); }
+  {
+    return exec(query, params{args...}).expect_rows(rows);
+  }
 
   /// Execute parameterised query, read full results, iterate rows of data.
   /** Like @ref query, but the query can contain parameters.
@@ -808,7 +824,9 @@ public:
   template<typename... TYPE>
   [[deprecated("Use exec(), and call check_rows() & iter() on the result.")]]
   auto query_n(result::size_type rows, zview query, params const &parms)
-  { return exec(query, parms).expect_rows(rows).iter<TYPE...>(); }
+  {
+    return exec(query, parms).expect_rows(rows).iter<TYPE...>();
+  }
 
   /// Perform query, expecting exactly 1 row with 1 field, and convert it.
   /** This is convenience shorthand for querying exactly one value from the
@@ -818,7 +836,9 @@ public:
    * @throw usage_error If the row did not contain exactly 1 field.
    */
   template<typename TYPE> TYPE query_value(zview query, params const &parms)
-  { return exec(query, parms).expect_columns(1).one_row()[0].as<TYPE>(); }
+  {
+    return exec(query, parms).expect_columns(1).one_row()[0].as<TYPE>();
+  }
 
   /// Perform query returning exactly one row, and convert its fields.
   /** This is a convenient way of querying one row's worth of data, and
@@ -831,7 +851,9 @@ public:
   template<typename... TYPE>
   [[nodiscard]]
   std::tuple<TYPE...> query1(zview query, params const &parms)
-  { return exec(query, parms).one_row().as<TYPE...>(); }
+  {
+    return exec(query, parms).one_row().as<TYPE...>();
+  }
 
   /// Query at most one row of data, and if there is one, convert it.
   /** If the query produced a row of data, this converts it to a tuple of the
@@ -846,8 +868,10 @@ public:
   query01(zview query, params const &parms)
   {
     std::optional<row> r{exec(query, parms).opt_row()};
-    if (r) return {r->as<TYPE...>()};
-    else return {};
+    if (r)
+      return {r->as<TYPE...>()};
+    else
+      return {};
   }
 
   // C++20: Concept like std::invocable, but without specifying param types.
@@ -891,8 +915,8 @@ public:
    * @return Something you can iterate using "range `for`" syntax.  The actual
    * type details may change.
    */
-  template<typename... TYPE> auto query(
-    prepped statement, params const &parms={})
+  template<typename... TYPE>
+  auto query(prepped statement, params const &parms = {})
   {
     return exec(statement, parms).iter<TYPE...>();
   }
@@ -902,15 +926,17 @@ public:
    * statement.
    */
   template<typename TYPE>
-  TYPE query_value(prepped statement, params const &parms={})
-  { return exec(statement, parms).expect_columns(1).one_row()[0].as<TYPE>(); }
+  TYPE query_value(prepped statement, params const &parms = {})
+  {
+    return exec(statement, parms).expect_columns(1).one_row()[0].as<TYPE>();
+  }
 
   // C++20: Concept like std::invocable, but without specifying param types.
   /// Execute prepared statement, load result, perform `func` for each row.
   /** This is just like @ref for_query(zview), but using a prepared statement.
    */
   template<typename CALLABLE>
-  void for_query(prepped statement, CALLABLE &&func, params const &parms={})
+  void for_query(prepped statement, CALLABLE &&func, params const &parms = {})
   {
     exec(statement, parms).for_each(std::forward<CALLABLE>(func));
   }
@@ -929,18 +955,22 @@ public:
    */
   template<typename... Args>
   [[deprecated(
-    "Use exec(string_view, params) and call one_row() on the result."
-  )]]
+    "Use exec(string_view, params) and call one_row() on the result.")]]
   row exec_prepared1(zview statement, Args &&...args)
-  { return exec(prepped{statement}, params{args...}).one_row(); }
+  {
+    return exec(prepped{statement}, params{args...}).one_row();
+  }
 
   /// Execute a prepared statement, and expect a result with zero rows.
   /** @throw pqxx::unexpected_rows if the result contained rows.
    */
   template<typename... Args>
-  [[deprecated("Use exec(prepped, params), and call no_rows() on the result.")]]
+  [[deprecated(
+    "Use exec(prepped, params), and call no_rows() on the result.")]]
   result exec_prepared0(zview statement, Args &&...args)
-  { return exec(prepped{statement}, params{args...}).no_rows(); }
+  {
+    return exec(prepped{statement}, params{args...}).no_rows();
+  }
 
   /// Execute a prepared statement, expect a result with given number of rows.
   /** @throw pqxx::unexpected_rows if the result did not contain exactly the
@@ -948,8 +978,7 @@ public:
    */
   template<typename... Args>
   [[deprecated(
-    "Use exec(prepped, params), and call expect_rows() on the result."
-  )]]
+    "Use exec(prepped, params), and call expect_rows() on the result.")]]
   result
   exec_prepared_n(result::size_type rows, zview statement, Args &&...args)
   {
@@ -1058,12 +1087,11 @@ private:
 
   PQXX_PRIVATE void check_pending_error();
 
-  result
-  internal_exec_prepared(
+  result internal_exec_prepared(
     std::string_view statement, internal::c_params const &args);
 
-  result internal_exec_params(
-    std::string_view query, internal::c_params const &args);
+  result
+  internal_exec_params(std::string_view query, internal::c_params const &args);
 
   /// Describe this transaction to humans, e.g. "transaction 'foo'".
   [[nodiscard]] std::string description() const;

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -526,42 +526,42 @@ int pqxx::result::column_type_modifier(
 
 pqxx::row pqxx::result::one_row() const
 {
-    auto const sz{size()};
-    if (sz != 1)
-    {
-      // TODO: See whether result contains a generated statement.
-      if (not m_query or m_query->empty())
-        throw unexpected_rows{pqxx::internal::concat(
-          "Expected 1 row from query, got ", sz, ".")};
-      else
-        throw unexpected_rows{pqxx::internal::concat(
-	  "Expected 1 row from query '", *m_query, "', got ", sz, ".")};
-    }
-    return front();
+  auto const sz{size()};
+  if (sz != 1)
+  {
+    // TODO: See whether result contains a generated statement.
+    if (not m_query or m_query->empty())
+      throw unexpected_rows{
+        pqxx::internal::concat("Expected 1 row from query, got ", sz, ".")};
+    else
+      throw unexpected_rows{pqxx::internal::concat(
+        "Expected 1 row from query '", *m_query, "', got ", sz, ".")};
+  }
+  return front();
 }
 
 
 std::optional<pqxx::row> pqxx::result::opt_row() const
 {
-    auto const sz{size()};
-    if (sz > 1)
-    {
-      // TODO: See whether result contains a generated statement.
-      if (not m_query or m_query->empty())
-        throw unexpected_rows{pqxx::internal::concat(
-	  "Expected at most 1 row from query, got ", sz, ".")};
-      else
-        throw unexpected_rows{pqxx::internal::concat(
-	  "Expected at most 1 row from query '", *m_query, "', got ", sz, ".")};
-    }
-    else if (sz == 1)
-    {
-      return {front()};
-    }
+  auto const sz{size()};
+  if (sz > 1)
+  {
+    // TODO: See whether result contains a generated statement.
+    if (not m_query or m_query->empty())
+      throw unexpected_rows{pqxx::internal::concat(
+        "Expected at most 1 row from query, got ", sz, ".")};
     else
-    {
-      return {};
-    }
+      throw unexpected_rows{pqxx::internal::concat(
+        "Expected at most 1 row from query '", *m_query, "', got ", sz, ".")};
+  }
+  else if (sz == 1)
+  {
+    return {front()};
+  }
+  else
+  {
+    return {};
+  }
 }
 
 

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -524,6 +524,47 @@ int pqxx::result::column_type_modifier(
 }
 
 
+pqxx::row pqxx::result::one_row() const
+{
+    auto const sz{size()};
+    if (sz != 1)
+    {
+      // TODO: See whether result contains a generated statement.
+      if (not m_query or m_query->empty())
+        throw unexpected_rows{pqxx::internal::concat(
+          "Expected 1 row from query, got ", sz, ".")};
+      else
+        throw unexpected_rows{pqxx::internal::concat(
+	  "Expected 1 row from query '", *m_query, "', got ", sz, ".")};
+    }
+    return front();
+}
+
+
+std::optional<pqxx::row> pqxx::result::opt_row() const
+{
+    auto const sz{size()};
+    if (sz > 1)
+    {
+      // TODO: See whether result contains a generated statement.
+      if (not m_query or m_query->empty())
+        throw unexpected_rows{pqxx::internal::concat(
+	  "Expected at most 1 row from query, got ", sz, ".")};
+      else
+        throw unexpected_rows{pqxx::internal::concat(
+	  "Expected at most 1 row from query '", *m_query, "', got ", sz, ".")};
+    }
+    else if (sz == 1)
+    {
+      return {front()};
+    }
+    else
+    {
+      return {};
+    }
+}
+
+
 // const_result_iterator
 
 pqxx::const_result_iterator pqxx::const_result_iterator::operator++(int) &

--- a/src/robusttransaction.cxx
+++ b/src/robusttransaction.cxx
@@ -78,7 +78,7 @@ tx_stat query_status(std::string const &xid, std::string const &conn_str)
   auto const query{pqxx::internal::concat("SELECT txid_status(", xid, ")")};
   pqxx::connection c{conn_str};
   pqxx::nontransaction w{c, name};
-  auto const status_row{w.exec1(query)};
+  auto const status_row{w.exec(query).one_row()};
   auto const status_field{status_row[0]};
   if (std::size(status_field) == 0)
     throw pqxx::internal_error{"Transaction status string is empty."};

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -50,7 +50,8 @@ pqxx::stream_from::stream_from(
   transaction_base &tx, from_table_t, std::string_view table) :
         transaction_focus{tx, class_name, table}, m_char_finder{get_finder(tx)}
 {
-  tx.exec(internal::concat("COPY "sv, tx.quote_name(table), " TO STDOUT"sv)).no_rows();
+  tx.exec(internal::concat("COPY "sv, tx.quote_name(table), " TO STDOUT"sv))
+    .no_rows();
   register_me();
 }
 
@@ -63,9 +64,9 @@ pqxx::stream_from::stream_from(
   if (std::empty(columns))
     PQXX_UNLIKELY
   tx.exec(internal::concat("COPY "sv, table, " TO STDOUT"sv)).no_rows();
-  else PQXX_LIKELY tx.exec(
-    internal::concat("COPY "sv, table, "("sv, columns, ") TO STDOUT"sv)
-  ).no_rows();
+  else PQXX_LIKELY tx
+    .exec(internal::concat("COPY "sv, table, "("sv, columns, ") TO STDOUT"sv))
+    .no_rows();
   register_me();
 }
 

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -41,7 +41,7 @@ pqxx::stream_from::stream_from(
   transaction_base &tx, from_query_t, std::string_view query) :
         transaction_focus{tx, class_name}, m_char_finder{get_finder(tx)}
 {
-  tx.exec0(internal::concat("COPY ("sv, query, ") TO STDOUT"sv));
+  tx.exec(internal::concat("COPY ("sv, query, ") TO STDOUT"sv)).no_rows();
   register_me();
 }
 
@@ -50,7 +50,7 @@ pqxx::stream_from::stream_from(
   transaction_base &tx, from_table_t, std::string_view table) :
         transaction_focus{tx, class_name, table}, m_char_finder{get_finder(tx)}
 {
-  tx.exec0(internal::concat("COPY "sv, tx.quote_name(table), " TO STDOUT"sv));
+  tx.exec(internal::concat("COPY "sv, tx.quote_name(table), " TO STDOUT"sv)).no_rows();
   register_me();
 }
 
@@ -62,9 +62,10 @@ pqxx::stream_from::stream_from(
 {
   if (std::empty(columns))
     PQXX_UNLIKELY
-  tx.exec0(internal::concat("COPY "sv, table, " TO STDOUT"sv));
-  else PQXX_LIKELY tx.exec0(
-    internal::concat("COPY "sv, table, "("sv, columns, ") TO STDOUT"sv));
+  tx.exec(internal::concat("COPY "sv, table, " TO STDOUT"sv)).no_rows();
+  else PQXX_LIKELY tx.exec(
+    internal::concat("COPY "sv, table, "("sv, columns, ") TO STDOUT"sv)
+  ).no_rows();
   register_me();
 }
 

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -27,11 +27,12 @@ using namespace std::literals;
 void begin_copy(
   pqxx::transaction_base &tx, std::string_view table, std::string_view columns)
 {
-  tx.exec0(
+  tx.exec(
     std::empty(columns) ?
       pqxx::internal::concat("COPY "sv, table, " FROM STDIN"sv) :
       pqxx::internal::concat(
-        "COPY "sv, table, "("sv, columns, ") FROM STDIN"sv));
+        "COPY "sv, table, "("sv, columns, ") FROM STDIN"sv)
+  ).no_rows();
 }
 
 

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -28,11 +28,11 @@ void begin_copy(
   pqxx::transaction_base &tx, std::string_view table, std::string_view columns)
 {
   tx.exec(
-    std::empty(columns) ?
-      pqxx::internal::concat("COPY "sv, table, " FROM STDIN"sv) :
-      pqxx::internal::concat(
-        "COPY "sv, table, "("sv, columns, ") FROM STDIN"sv)
-  ).no_rows();
+      std::empty(columns) ?
+        pqxx::internal::concat("COPY "sv, table, " FROM STDIN"sv) :
+        pqxx::internal::concat(
+          "COPY "sv, table, "("sv, columns, ") FROM STDIN"sv))
+    .no_rows();
 }
 
 

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -278,41 +278,13 @@ pqxx::result pqxx::transaction_base::exec_n(
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
   result r{exec(query, desc)};
 #include "pqxx/internal/ignore-deprecated-post.hxx"
-  if (std::size(r) != rows)
-  {
-    std::string const N{
-      std::empty(desc) ? "" : internal::concat("'", desc, "'")};
-    throw unexpected_rows{internal::concat(
-      "Expected ", rows, " row(s) of data from query ", N, ", got ",
-      std::size(r), ".")};
-  }
+  r.expect_rows(rows);
   return r;
 }
 
 
-void pqxx::transaction_base::check_rowcount_prepared(
-  zview statement, result::size_type expected_rows,
-  result::size_type actual_rows)
-{
-  if (actual_rows != expected_rows)
-    throw unexpected_rows{internal::concat(
-      "Expected ", expected_rows, " row(s) of data from prepared statement '",
-      statement, "', got ", actual_rows, ".")};
-}
-
-
-void pqxx::transaction_base::check_rowcount_params(
-  std::size_t expected_rows, std::size_t actual_rows)
-{
-  if (actual_rows != expected_rows)
-    throw unexpected_rows{internal::concat(
-      "Expected ", expected_rows,
-      " row(s) of data from parameterised query, got ", actual_rows, ".")};
-}
-
-
 pqxx::result pqxx::transaction_base::internal_exec_prepared(
-  zview statement, internal::c_params const &args)
+  std::string_view statement, internal::c_params const &args)
 {
   command const cmd{*this, statement};
   return pqxx::internal::gate::connection_transaction{conn()}.exec_prepared(
@@ -321,7 +293,7 @@ pqxx::result pqxx::transaction_base::internal_exec_prepared(
 
 
 pqxx::result pqxx::transaction_base::internal_exec_params(
-  zview query, internal::c_params const &args)
+  std::string_view query, internal::c_params const &args)
 {
   command const cmd{*this, query};
   return pqxx::internal::gate::connection_transaction{conn()}.exec_params(

--- a/test/test04.cxx
+++ b/test/test04.cxx
@@ -53,7 +53,7 @@ void test_004()
   // Trigger our notification receiver.
   perform([&cx, &L] {
     work tx(cx);
-    tx.exec0("NOTIFY " + cx.quote_name(L.channel()));
+    tx.exec("NOTIFY " + cx.quote_name(L.channel())).no_rows();
     Backend_PID = cx.backendpid();
     tx.commit();
   });

--- a/test/test07.cxx
+++ b/test/test07.cxx
@@ -123,7 +123,7 @@ void test_007()
         " "
         "WHERE year=" +
         to_string(c.first)};
-      R = tx.exec0(query);
+      R = tx.exec(query).no_rows();
     }
   });
 }

--- a/test/test10.cxx
+++ b/test/test10.cxx
@@ -51,11 +51,12 @@ void Test(connection &C, bool ExplicitAbort)
       EventCounts.second, 0, "Can't run, boring year is already in table.");
 
     // Now let's try to introduce a row for our Boring Year
-    Doomed.exec0(
+    Doomed.exec(
       "INSERT INTO " + Table +
       "(year, event) "
       "VALUES (" +
-      to_string(BoringYear) + ", 'yawn')");
+      to_string(BoringYear) + ", 'yawn')"
+    ).no_rows();
 
     auto const Recount{CountEvents(Doomed)};
     PQXX_CHECK_EQUAL(

--- a/test/test10.cxx
+++ b/test/test10.cxx
@@ -51,12 +51,13 @@ void Test(connection &C, bool ExplicitAbort)
       EventCounts.second, 0, "Can't run, boring year is already in table.");
 
     // Now let's try to introduce a row for our Boring Year
-    Doomed.exec(
-      "INSERT INTO " + Table +
-      "(year, event) "
-      "VALUES (" +
-      to_string(BoringYear) + ", 'yawn')"
-    ).no_rows();
+    Doomed
+      .exec(
+        "INSERT INTO " + Table +
+        "(year, event) "
+        "VALUES (" +
+        to_string(BoringYear) + ", 'yawn')")
+      .no_rows();
 
     auto const Recount{CountEvents(Doomed)};
     PQXX_CHECK_EQUAL(

--- a/test/test13.cxx
+++ b/test/test13.cxx
@@ -39,10 +39,10 @@ void failed_insert(connection &C, std::string const &table)
 {
   work tx(C);
   result R = tx.exec(
-    "INSERT INTO " + table + " VALUES (" + to_string(BoringYear) +
-    ", "
-    "'yawn')"
-  ).no_rows();
+                 "INSERT INTO " + table + " VALUES (" + to_string(BoringYear) +
+                 ", "
+                 "'yawn')")
+               .no_rows();
 
   PQXX_CHECK_EQUAL(R.affected_rows(), 1, "Bad affected_rows().");
   throw deliberate_error();

--- a/test/test13.cxx
+++ b/test/test13.cxx
@@ -38,10 +38,11 @@ struct deliberate_error : std::exception
 void failed_insert(connection &C, std::string const &table)
 {
   work tx(C);
-  result R = tx.exec0(
+  result R = tx.exec(
     "INSERT INTO " + table + " VALUES (" + to_string(BoringYear) +
     ", "
-    "'yawn')");
+    "'yawn')"
+  ).no_rows();
 
   PQXX_CHECK_EQUAL(R.affected_rows(), 1, "Bad affected_rows().");
   throw deliberate_error();

--- a/test/test18.cxx
+++ b/test/test18.cxx
@@ -56,9 +56,10 @@ void test_018()
     PQXX_CHECK_THROWS(
       perform([&cx, Table] {
         robusttransaction<serializable> tx{cx};
-        tx.exec0(
+        tx.exec(
           "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
-          ", '" + tx.esc("yawn") + "')");
+          ", '" + tx.esc("yawn") + "')"
+	).no_rows();
 
         throw deliberate_error();
       }),

--- a/test/test18.cxx
+++ b/test/test18.cxx
@@ -57,9 +57,9 @@ void test_018()
       perform([&cx, Table] {
         robusttransaction<serializable> tx{cx};
         tx.exec(
-          "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
-          ", '" + tx.esc("yawn") + "')"
-	).no_rows();
+            "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
+            ", '" + tx.esc("yawn") + "')")
+          .no_rows();
 
         throw deliberate_error();
       }),

--- a/test/test20.cxx
+++ b/test/test20.cxx
@@ -38,14 +38,15 @@ void test_020()
   PQXX_CHECK(std::empty(R), "result::clear() is broken.");
 
   // OK.  Having laid that worry to rest, add a record for 1977.
-  t1.exec0(
+  t1.exec(
     "INSERT INTO " + Table +
     " VALUES"
     "(" +
     to_string(BoringYear) +
     ","
     "'Yawn'"
-    ")");
+    ")"
+  ).no_rows();
 
   // Abort T1.  Since T1 is a nontransaction, which provides only the
   // transaction class interface without providing any form of transactional
@@ -70,11 +71,12 @@ void test_020()
   PQXX_CHECK(std::empty(R), "result::clear() doesn't work.");
 
   // Now remove our record again
-  t2.exec0(
+  t2.exec(
     "DELETE FROM " + Table +
     " "
     "WHERE year=" +
-    to_string(BoringYear));
+    to_string(BoringYear)
+  ).no_rows();
 
   t2.commit();
 

--- a/test/test20.cxx
+++ b/test/test20.cxx
@@ -39,14 +39,14 @@ void test_020()
 
   // OK.  Having laid that worry to rest, add a record for 1977.
   t1.exec(
-    "INSERT INTO " + Table +
-    " VALUES"
-    "(" +
-    to_string(BoringYear) +
-    ","
-    "'Yawn'"
-    ")"
-  ).no_rows();
+      "INSERT INTO " + Table +
+      " VALUES"
+      "(" +
+      to_string(BoringYear) +
+      ","
+      "'Yawn'"
+      ")")
+    .no_rows();
 
   // Abort T1.  Since T1 is a nontransaction, which provides only the
   // transaction class interface without providing any form of transactional
@@ -72,11 +72,11 @@ void test_020()
 
   // Now remove our record again
   t2.exec(
-    "DELETE FROM " + Table +
-    " "
-    "WHERE year=" +
-    to_string(BoringYear)
-  ).no_rows();
+      "DELETE FROM " + Table +
+      " "
+      "WHERE year=" +
+      to_string(BoringYear))
+    .no_rows();
 
   t2.commit();
 

--- a/test/test26.cxx
+++ b/test/test26.cxx
@@ -51,13 +51,14 @@ std::map<int, int> update_years(connection &C)
   // occur in the table.  Since we're in a transaction, any changes made by
   // others at the same time will not affect us.
   for (auto const &c : conversions)
-    tx.exec0(
+    tx.exec(
       "UPDATE pqxxevents "
       "SET year=" +
       to_string(c.second) +
       " "
       "WHERE year=" +
-      to_string(c.first));
+      to_string(c.first)
+    ).no_rows();
 
   tx.commit();
 

--- a/test/test26.cxx
+++ b/test/test26.cxx
@@ -52,13 +52,13 @@ std::map<int, int> update_years(connection &C)
   // others at the same time will not affect us.
   for (auto const &c : conversions)
     tx.exec(
-      "UPDATE pqxxevents "
-      "SET year=" +
-      to_string(c.second) +
-      " "
-      "WHERE year=" +
-      to_string(c.first)
-    ).no_rows();
+        "UPDATE pqxxevents "
+        "SET year=" +
+        to_string(c.second) +
+        " "
+        "WHERE year=" +
+        to_string(c.first))
+      .no_rows();
 
   tx.commit();
 

--- a/test/test29.cxx
+++ b/test/test29.cxx
@@ -58,11 +58,12 @@ void Test(connection &cx, bool ExplicitAbort)
       "Can't run; " + to_string(BoringYear) + " is already in the table.");
 
     // Now let's try to introduce a row for our Boring Year
-    Doomed.exec0(
+    Doomed.exec(
       "INSERT INTO " + Table +
       "(year, event) "
       "VALUES (" +
-      to_string(BoringYear) + ", 'yawn')");
+      to_string(BoringYear) + ", 'yawn')"
+    ).no_rows();
 
     auto Recount{CountEvents(Doomed)};
     PQXX_CHECK_EQUAL(Recount.second, 1, "Unexpected number of events.");

--- a/test/test29.cxx
+++ b/test/test29.cxx
@@ -58,12 +58,13 @@ void Test(connection &cx, bool ExplicitAbort)
       "Can't run; " + to_string(BoringYear) + " is already in the table.");
 
     // Now let's try to introduce a row for our Boring Year
-    Doomed.exec(
-      "INSERT INTO " + Table +
-      "(year, event) "
-      "VALUES (" +
-      to_string(BoringYear) + ", 'yawn')"
-    ).no_rows();
+    Doomed
+      .exec(
+        "INSERT INTO " + Table +
+        "(year, event) "
+        "VALUES (" +
+        to_string(BoringYear) + ", 'yawn')")
+      .no_rows();
 
     auto Recount{CountEvents(Doomed)};
     PQXX_CHECK_EQUAL(Recount.second, 1, "Unexpected number of events.");

--- a/test/test32.cxx
+++ b/test/test32.cxx
@@ -54,10 +54,11 @@ void test_032()
     quiet_errorhandler d(cx);
     PQXX_CHECK_THROWS(
       perform([&cx, &Table] {
-        work{cx}.exec0(
+        work{cx}.exec(
           "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
           ", "
-          "'yawn')");
+          "'yawn')"
+	).no_rows();
         throw deliberate_error();
       }),
       deliberate_error,

--- a/test/test32.cxx
+++ b/test/test32.cxx
@@ -54,11 +54,12 @@ void test_032()
     quiet_errorhandler d(cx);
     PQXX_CHECK_THROWS(
       perform([&cx, &Table] {
-        work{cx}.exec(
-          "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
-          ", "
-          "'yawn')"
-	).no_rows();
+        work{cx}
+          .exec(
+            "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
+            ", "
+            "'yawn')")
+          .no_rows();
         throw deliberate_error();
       }),
       deliberate_error,

--- a/test/test37.cxx
+++ b/test/test37.cxx
@@ -53,10 +53,11 @@ void test_037()
     PQXX_CHECK_THROWS(
       perform([&cx, &Table] {
         robusttransaction<> tx{cx};
-        tx.exec0(
+        tx.exec(
           "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
           ", "
-          "'yawn')");
+          "'yawn')"
+	).no_rows();
 
         throw deliberate_error();
       }),

--- a/test/test37.cxx
+++ b/test/test37.cxx
@@ -54,10 +54,10 @@ void test_037()
       perform([&cx, &Table] {
         robusttransaction<> tx{cx};
         tx.exec(
-          "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
-          ", "
-          "'yawn')"
-	).no_rows();
+            "INSERT INTO " + Table + " VALUES (" + to_string(BoringYear) +
+            ", "
+            "'yawn')")
+          .no_rows();
 
         throw deliberate_error();
       }),

--- a/test/test39.cxx
+++ b/test/test39.cxx
@@ -35,14 +35,15 @@ void test_039()
   PQXX_CHECK(std::empty(R), "Result is non-empty after clear().");
 
   // OK.  Having laid that worry to rest, add a record for 1977.
-  tx1.exec0(
+  tx1.exec(
     "INSERT INTO " + Table +
     " VALUES"
     "(" +
     to_string(BoringYear) +
     ","
     "'Yawn'"
-    ")");
+    ")"
+  ).no_rows();
 
   // Abort tx1.  Since tx1 is a nontransaction, which provides only the
   // transaction class interface without providing any form of transactional
@@ -64,11 +65,12 @@ void test_039()
   PQXX_CHECK(std::empty(R), "result::clear() is broken.");
 
   // Now remove our record again
-  tx2.exec0(
+  tx2.exec(
     "DELETE FROM " + Table +
     " "
     "WHERE year=" +
-    to_string(BoringYear));
+    to_string(BoringYear)
+  ).no_rows();
 
   tx2.commit();
 

--- a/test/test39.cxx
+++ b/test/test39.cxx
@@ -35,15 +35,16 @@ void test_039()
   PQXX_CHECK(std::empty(R), "Result is non-empty after clear().");
 
   // OK.  Having laid that worry to rest, add a record for 1977.
-  tx1.exec(
-    "INSERT INTO " + Table +
-    " VALUES"
-    "(" +
-    to_string(BoringYear) +
-    ","
-    "'Yawn'"
-    ")"
-  ).no_rows();
+  tx1
+    .exec(
+      "INSERT INTO " + Table +
+      " VALUES"
+      "(" +
+      to_string(BoringYear) +
+      ","
+      "'Yawn'"
+      ")")
+    .no_rows();
 
   // Abort tx1.  Since tx1 is a nontransaction, which provides only the
   // transaction class interface without providing any form of transactional
@@ -65,12 +66,13 @@ void test_039()
   PQXX_CHECK(std::empty(R), "result::clear() is broken.");
 
   // Now remove our record again
-  tx2.exec(
-    "DELETE FROM " + Table +
-    " "
-    "WHERE year=" +
-    to_string(BoringYear)
-  ).no_rows();
+  tx2
+    .exec(
+      "DELETE FROM " + Table +
+      " "
+      "WHERE year=" +
+      to_string(BoringYear))
+    .no_rows();
 
   tx2.commit();
 

--- a/test/test46.cxx
+++ b/test/test46.cxx
@@ -18,7 +18,7 @@ void test_046()
   connection cx;
   work tx{cx};
 
-  row R{tx.exec1("SELECT count(*) FROM pg_tables")};
+  row R{tx.exec("SELECT count(*) FROM pg_tables").one_row()};
 
   // Read the value into a stringstream.
   std::stringstream I;

--- a/test/test62.cxx
+++ b/test/test62.cxx
@@ -21,16 +21,16 @@ void test_062()
     "Nasty\n\030Test\n\t String with \200\277 weird bytes "
     "\r\0 and Trailer\\\\\0"};
 
-  tx.exec0("CREATE TEMP TABLE pqxxbin (binfield bytea)");
+  tx.exec("CREATE TEMP TABLE pqxxbin (binfield bytea)").no_rows();
 
   std::string const Esc{tx.esc_raw(bytes{
     reinterpret_cast<std::byte const *>(std::data(TestStr)),
     std::size(TestStr)})};
 
-  tx.exec0("INSERT INTO pqxxbin VALUES ('" + Esc + "')");
+  tx.exec("INSERT INTO pqxxbin VALUES ('" + Esc + "')").no_rows();
 
   result R{tx.exec("SELECT * from pqxxbin")};
-  tx.exec0("DELETE FROM pqxxbin");
+  tx.exec("DELETE FROM pqxxbin").no_rows();
 
   auto const B{R.at(0).at(0).as<bytes>()};
 

--- a/test/test76.cxx
+++ b/test/test76.cxx
@@ -10,8 +10,7 @@ void test_076()
   pqxx::connection cx;
   pqxx::nontransaction tx{cx};
 
-  auto
-    RFalse{tx.exec("SELECT 1=0").one_row()},
+  auto RFalse{tx.exec("SELECT 1=0").one_row()},
     RTrue{tx.exec("SELECT 1=1").one_row()};
   auto False{pqxx::from_string<bool>(RFalse[0])},
     True{pqxx::from_string<bool>(RTrue[0])};

--- a/test/test76.cxx
+++ b/test/test76.cxx
@@ -10,14 +10,16 @@ void test_076()
   pqxx::connection cx;
   pqxx::nontransaction tx{cx};
 
-  auto RFalse{tx.exec1("SELECT 1=0")}, RTrue{tx.exec1("SELECT 1=1")};
+  auto
+    RFalse{tx.exec("SELECT 1=0").one_row()},
+    RTrue{tx.exec("SELECT 1=1").one_row()};
   auto False{pqxx::from_string<bool>(RFalse[0])},
     True{pqxx::from_string<bool>(RTrue[0])};
   PQXX_CHECK(not False, "False bool converted to true.");
   PQXX_CHECK(True, "True bool converted to false.");
 
-  RFalse = tx.exec1("SELECT " + pqxx::to_string(False));
-  RTrue = tx.exec1("SELECT " + pqxx::to_string(True));
+  RFalse = tx.exec("SELECT " + pqxx::to_string(False)).one_row();
+  RTrue = tx.exec("SELECT " + pqxx::to_string(True)).one_row();
   False = pqxx::from_string<bool>(RFalse[0]);
   True = pqxx::from_string<bool>(RTrue[0]);
   PQXX_CHECK(not False, "False bool converted to true.");
@@ -29,7 +31,7 @@ void test_076()
     auto s{pqxx::from_string<short>(pqxx::to_string(svals[i]))};
     PQXX_CHECK_EQUAL(s, svals[i], "short/string conversion not bijective.");
     s = pqxx::from_string<short>(
-      tx.exec1("SELECT " + pqxx::to_string(svals[i]))[0].c_str());
+      tx.exec("SELECT " + pqxx::to_string(svals[i])).one_row()[0].c_str());
     PQXX_CHECK_EQUAL(s, svals[i], "Roundtrip through backend changed short.");
   }
 
@@ -41,7 +43,7 @@ void test_076()
       u, uvals[i], "unsigned short/string conversion not bijective.");
 
     u = pqxx::from_string<unsigned short>(
-      tx.exec1("SELECT " + pqxx::to_string(uvals[i]))[0].c_str());
+      tx.exec("SELECT " + pqxx::to_string(uvals[i])).one_row()[0].c_str());
     PQXX_CHECK_EQUAL(
       u, uvals[i], "Roundtrip through backend changed unsigned short.");
   }

--- a/test/test78.cxx
+++ b/test/test78.cxx
@@ -47,7 +47,7 @@ void test_078()
 
   pqxx::perform([&cx, &L] {
     pqxx::work tx{cx};
-    tx.exec0("NOTIFY " + tx.quote_name(L.channel()));
+    tx.exec("NOTIFY " + tx.quote_name(L.channel())).no_rows();
     tx.commit();
   });
 

--- a/test/test79.cxx
+++ b/test/test79.cxx
@@ -49,7 +49,7 @@ void test_079()
 
   pqxx::perform([&cx, &L] {
     pqxx::work tx{cx};
-    tx.exec0("NOTIFY " + L.channel());
+    tx.exec("NOTIFY " + L.channel()).no_rows();
     tx.commit();
   });
 

--- a/test/test84.cxx
+++ b/test/test84.cxx
@@ -35,12 +35,15 @@ void test_084()
     Query{"SELECT * FROM " + Table + " ORDER BY " + Key};
   constexpr int InitialSkip{2}, GetRows{3};
 
-  tx.exec0("DECLARE " + tx.quote_name(CurName) + " CURSOR FOR " + Query);
-  tx.exec0(
+  tx.exec(
+    "DECLARE " + tx.quote_name(CurName) + " CURSOR FOR " + Query
+  ).no_rows();
+  tx.exec(
     "MOVE " + pqxx::to_string(InitialSkip * GetRows) +
     " "
     "IN " +
-    tx.quote_name(CurName));
+    tx.quote_name(CurName)
+  ).no_rows();
 
   // Wrap cursor in cursor stream.  Apply some trickery to get its name inside
   // a result field for this purpose.  This isn't easy because it's not

--- a/test/test84.cxx
+++ b/test/test84.cxx
@@ -35,15 +35,14 @@ void test_084()
     Query{"SELECT * FROM " + Table + " ORDER BY " + Key};
   constexpr int InitialSkip{2}, GetRows{3};
 
+  tx.exec("DECLARE " + tx.quote_name(CurName) + " CURSOR FOR " + Query)
+    .no_rows();
   tx.exec(
-    "DECLARE " + tx.quote_name(CurName) + " CURSOR FOR " + Query
-  ).no_rows();
-  tx.exec(
-    "MOVE " + pqxx::to_string(InitialSkip * GetRows) +
-    " "
-    "IN " +
-    tx.quote_name(CurName)
-  ).no_rows();
+      "MOVE " + pqxx::to_string(InitialSkip * GetRows) +
+      " "
+      "IN " +
+      tx.quote_name(CurName))
+    .no_rows();
 
   // Wrap cursor in cursor stream.  Apply some trickery to get its name inside
   // a result field for this purpose.  This isn't easy because it's not

--- a/test/test87.cxx
+++ b/test/test87.cxx
@@ -58,7 +58,7 @@ void test_087()
 
   pqxx::perform([&cx, &L] {
     pqxx::work tx{cx};
-    tx.exec0("NOTIFY " + tx.quote_name(L.channel()));
+    tx.exec("NOTIFY " + tx.quote_name(L.channel())).no_rows();
     tx.commit();
   });
 

--- a/test/test88.cxx
+++ b/test/test88.cxx
@@ -17,46 +17,46 @@ void test_088()
   pqxx::test::create_pqxxevents(tx0);
 
   // Trivial test: create subtransactions, and commit/abort
-  std::cout << tx0.exec1("SELECT 'tx0 starts'")[0].c_str() << std::endl;
+  std::cout << tx0.query_value<std::string>("SELECT 'tx0 starts'") << std::endl;
 
   pqxx::subtransaction T0a(static_cast<pqxx::dbtransaction &>(tx0), "T0a");
   T0a.commit();
 
   pqxx::subtransaction T0b(static_cast<pqxx::dbtransaction &>(tx0), "T0b");
   T0b.abort();
-  std::cout << tx0.exec1("SELECT 'tx0 ends'")[0].c_str() << std::endl;
+  std::cout << tx0.query_value<std::string>("SELECT 'tx0 ends'") << std::endl;
   tx0.commit();
 
   // Basic functionality: perform query in subtransaction; abort, continue
   pqxx::work tx1{cx, "tx1"};
-  std::cout << tx1.exec1("SELECT 'tx1 starts'")[0].c_str() << std::endl;
+  std::cout << tx1.query_value<std::string>("SELECT 'tx1 starts'") << std::endl;
   pqxx::subtransaction tx1a{tx1, "tx1a"};
-  std::cout << tx1a.exec1("SELECT '  a'")[0].c_str() << std::endl;
+  std::cout << tx1a.query_value<std::string>("SELECT '  a'") << std::endl;
   tx1a.commit();
   pqxx::subtransaction tx1b{tx1, "tx1b"};
-  std::cout << tx1b.exec1("SELECT '  b'")[0].c_str() << std::endl;
+  std::cout << tx1b.query_value<std::string>("SELECT '  b'") << std::endl;
   tx1b.abort();
   pqxx::subtransaction tx1c{tx1, "tx1c"};
-  std::cout << tx1c.exec1("SELECT '  c'")[0].c_str() << std::endl;
+  std::cout << tx1c.query_value<std::string>("SELECT '  c'") << std::endl;
   tx1c.commit();
-  std::cout << tx1.exec1("SELECT 'tx1 ends'")[0].c_str() << std::endl;
+  std::cout << tx1.query_value<std::string>("SELECT 'tx1 ends'") << std::endl;
   tx1.commit();
 
   // Commit/rollback functionality
   pqxx::work tx2{cx, "tx2"};
   std::string const Table{"test088"};
-  tx2.exec0("CREATE TEMP TABLE " + Table + "(no INTEGER, text VARCHAR)");
+  tx2.exec("CREATE TEMP TABLE " + Table + "(no INTEGER, text VARCHAR)").no_rows();
 
-  tx2.exec0("INSERT INTO " + Table + " VALUES(1,'tx2')");
+  tx2.exec("INSERT INTO " + Table + " VALUES(1,'tx2')").no_rows();
 
   pqxx::subtransaction tx2a{tx2, "tx2a"};
-  tx2a.exec0("INSERT INTO " + Table + " VALUES(2,'tx2a')");
+  tx2a.exec("INSERT INTO " + Table + " VALUES(2,'tx2a')").no_rows();
   tx2a.commit();
   pqxx::subtransaction tx2b{tx2, "tx2b"};
-  tx2b.exec0("INSERT INTO " + Table + " VALUES(3,'tx2b')");
+  tx2b.exec("INSERT INTO " + Table + " VALUES(3,'tx2b')").no_rows();
   tx2b.abort();
   pqxx::subtransaction tx2c{tx2, "tx2c"};
-  tx2c.exec0("INSERT INTO " + Table + " VALUES(4,'tx2c')");
+  tx2c.exec("INSERT INTO " + Table + " VALUES(4,'tx2c')").no_rows();
   tx2c.commit();
   auto const R{tx2.exec("SELECT * FROM " + Table + " ORDER BY no")};
   for (auto const &i : R)
@@ -81,7 +81,7 @@ void test_088()
   // Subtransaction can only be aborted now, because there was an error.
   tx3a.abort();
   // We're back in our top-level transaction.  This did not abort.
-  tx3.exec1("SELECT count(*) FROM pqxxevents");
+  tx3.exec("SELECT count(*) FROM pqxxevents").one_row();
   // Make sure we can commit exactly one more level of transaction.
   tx3.commit();
 }

--- a/test/test88.cxx
+++ b/test/test88.cxx
@@ -17,7 +17,8 @@ void test_088()
   pqxx::test::create_pqxxevents(tx0);
 
   // Trivial test: create subtransactions, and commit/abort
-  std::cout << tx0.query_value<std::string>("SELECT 'tx0 starts'") << std::endl;
+  std::cout << tx0.query_value<std::string>("SELECT 'tx0 starts'")
+            << std::endl;
 
   pqxx::subtransaction T0a(static_cast<pqxx::dbtransaction &>(tx0), "T0a");
   T0a.commit();
@@ -29,7 +30,8 @@ void test_088()
 
   // Basic functionality: perform query in subtransaction; abort, continue
   pqxx::work tx1{cx, "tx1"};
-  std::cout << tx1.query_value<std::string>("SELECT 'tx1 starts'") << std::endl;
+  std::cout << tx1.query_value<std::string>("SELECT 'tx1 starts'")
+            << std::endl;
   pqxx::subtransaction tx1a{tx1, "tx1a"};
   std::cout << tx1a.query_value<std::string>("SELECT '  a'") << std::endl;
   tx1a.commit();
@@ -45,7 +47,8 @@ void test_088()
   // Commit/rollback functionality
   pqxx::work tx2{cx, "tx2"};
   std::string const Table{"test088"};
-  tx2.exec("CREATE TEMP TABLE " + Table + "(no INTEGER, text VARCHAR)").no_rows();
+  tx2.exec("CREATE TEMP TABLE " + Table + "(no INTEGER, text VARCHAR)")
+    .no_rows();
 
   tx2.exec("INSERT INTO " + Table + " VALUES(1,'tx2')").no_rows();
 

--- a/test/test89.cxx
+++ b/test/test89.cxx
@@ -15,27 +15,27 @@ void test_089()
 
   // Trivial test: create subtransactions, and commit/abort
   pqxx::work T0(C, "T0");
-  T0.exec1("SELECT 'T0 starts'");
+  T0.exec("SELECT 'T0 starts'").one_row();
   pqxx::subtransaction T0a(T0, "T0a");
   T0a.commit();
   pqxx::subtransaction T0b(T0, "T0b");
   T0b.abort();
-  T0.exec1("SELECT 'T0 ends'");
+  T0.exec("SELECT 'T0 ends'").one_row();
   T0.commit();
 
   // Basic functionality: perform query in subtransaction; abort, continue
   pqxx::work T1(C, "T1");
-  T1.exec1("SELECT 'T1 starts'");
+  T1.exec("SELECT 'T1 starts'").one_row();
   pqxx::subtransaction T1a(T1, "T1a");
-  T1a.exec1("SELECT '  a'");
+  T1a.exec("SELECT '  a'").one_row();
   T1a.commit();
   pqxx::subtransaction T1b(T1, "T1b");
-  T1b.exec1("SELECT '  b'");
+  T1b.exec("SELECT '  b'").one_row();
   T1b.abort();
   pqxx::subtransaction T1c(T1, "T1c");
-  T1c.exec1("SELECT '  c'");
+  T1c.exec("SELECT '  c'").one_row();
   T1c.commit();
-  T1.exec1("SELECT 'T1 ends'");
+  T1.exec("SELECT 'T1 ends'").one_row();
   T1.commit();
 }
 } // namespace

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -454,7 +454,7 @@ void test_array_roundtrip()
   pqxx::work w{c};
 
   std::vector<int> const in{0, 1, 2, 3, 5};
-  auto text{
+  auto const text{
     w.query_value<std::string>("SELECT " + c.quote(in) + "::integer[]")
   };
   pqxx::array_parser parser{text};

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -454,9 +454,10 @@ void test_array_roundtrip()
   pqxx::work w{c};
 
   std::vector<int> const in{0, 1, 2, 3, 5};
-  pqxx::array_parser parser{
-    w.query_value<std::string_view>("SELECT " + c.quote(in) + "::integer[]")
+  auto text{
+    w.query_value<std::string>("SELECT " + c.quote(in) + "::integer[]")
   };
+  pqxx::array_parser parser{text};
   auto item{parser.get_next()};
   PQXX_CHECK_EQUAL(
     item.first, pqxx::array_parser::juncture::row_start,

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -455,8 +455,7 @@ void test_array_roundtrip()
 
   std::vector<int> const in{0, 1, 2, 3, 5};
   auto const text{
-    w.query_value<std::string>("SELECT " + c.quote(in) + "::integer[]")
-  };
+    w.query_value<std::string>("SELECT " + c.quote(in) + "::integer[]")};
   pqxx::array_parser parser{text};
   auto item{parser.get_next()};
   PQXX_CHECK_EQUAL(

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -165,7 +165,8 @@ void test_binarystring_array_stream()
 {
   pqxx::connection cx;
   pqxx::transaction tx{cx};
-  tx.exec("CREATE TEMP TABLE pqxxbinstream(id integer, vec bytea[])").no_rows();
+  tx.exec("CREATE TEMP TABLE pqxxbinstream(id integer, vec bytea[])")
+    .no_rows();
 
   constexpr char bytes1[]{"a\tb\0c"}, bytes2[]{"1\0.2"};
   std::string_view const data1{bytes1}, data2{bytes2};

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -144,7 +144,7 @@ void test_binarystring_stream()
 
   pqxx::connection cx;
   pqxx::transaction tx{cx};
-  tx.exec0("CREATE TEMP TABLE pqxxbinstream(id integer, bin bytea)");
+  tx.exec("CREATE TEMP TABLE pqxxbinstream(id integer, bin bytea)").no_rows();
 
   auto to{pqxx::stream_to::table(tx, {"pqxxbinstream"})};
   to.write_values(0, bin);
@@ -165,7 +165,7 @@ void test_binarystring_array_stream()
 {
   pqxx::connection cx;
   pqxx::transaction tx{cx};
-  tx.exec0("CREATE TEMP TABLE pqxxbinstream(id integer, vec bytea[])");
+  tx.exec("CREATE TEMP TABLE pqxxbinstream(id integer, vec bytea[])").no_rows();
 
   constexpr char bytes1[]{"a\tb\0c"}, bytes2[]{"1\0.2"};
   std::string_view const data1{bytes1}, data2{bytes2};

--- a/test/unit/test_column.cxx
+++ b/test/unit/test_column.cxx
@@ -9,9 +9,8 @@ void test_table_column()
   pqxx::connection cx;
   pqxx::work tx{cx};
 
-  tx.exec(
-    "CREATE TEMP TABLE pqxxfoo (x varchar, y integer, z integer)"
-  ).no_rows();
+  tx.exec("CREATE TEMP TABLE pqxxfoo (x varchar, y integer, z integer)")
+    .no_rows();
   tx.exec("INSERT INTO pqxxfoo VALUES ('xx', 1, 2)").no_rows();
   auto R{tx.exec("SELECT z,y,x FROM pqxxfoo")};
   auto X{tx.exec("SELECT x,y,z,99 FROM pqxxfoo")};

--- a/test/unit/test_column.cxx
+++ b/test/unit/test_column.cxx
@@ -9,8 +9,10 @@ void test_table_column()
   pqxx::connection cx;
   pqxx::work tx{cx};
 
-  tx.exec0("CREATE TEMP TABLE pqxxfoo (x varchar, y integer, z integer)");
-  tx.exec0("INSERT INTO pqxxfoo VALUES ('xx', 1, 2)");
+  tx.exec(
+    "CREATE TEMP TABLE pqxxfoo (x varchar, y integer, z integer)"
+  ).no_rows();
+  tx.exec("INSERT INTO pqxxfoo VALUES ('xx', 1, 2)").no_rows();
   auto R{tx.exec("SELECT z,y,x FROM pqxxfoo")};
   auto X{tx.exec("SELECT x,y,z,99 FROM pqxxfoo")};
 

--- a/test/unit/test_composite.cxx
+++ b/test/unit/test_composite.cxx
@@ -80,8 +80,7 @@ void test_composite_renders_to_string()
 
   tx.exec("CREATE TYPE pqxxcomp AS (a integer, b text, c text)").no_rows();
   auto const r{
-    tx.exec("SELECT '" + std::string{buf} + "'::pqxxcomp").one_row()
-  };
+    tx.exec("SELECT '" + std::string{buf} + "'::pqxxcomp").one_row()};
 
   int a;
   std::string b, c;

--- a/test/unit/test_error_verbosity.cxx
+++ b/test/unit/test_error_verbosity.cxx
@@ -27,9 +27,9 @@ void test_error_verbosity()
   pqxx::connection cx;
   pqxx::work tx{cx};
   cx.set_verbosity(pqxx::error_verbosity::terse);
-  tx.exec1("SELECT 1");
+  tx.exec("SELECT 1").one_row();
   cx.set_verbosity(pqxx::error_verbosity::verbose);
-  tx.exec1("SELECT 2");
+  tx.exec("SELECT 2").one_row();
 }
 
 

--- a/test/unit/test_field.cxx
+++ b/test/unit/test_field.cxx
@@ -8,7 +8,7 @@ void test_field()
 {
   pqxx::connection c;
   pqxx::work tx{c};
-  auto const r1{tx.exec1("SELECT 9")};
+  auto const r1{tx.exec("SELECT 9").one_row()};
   auto const &f1{r1[0]};
 
   PQXX_CHECK_EQUAL(f1.as<std::string>(), "9", "as<string>() is broken.");
@@ -32,7 +32,7 @@ void test_field()
   PQXX_CHECK(f1.to(i, 12), "to(int, int) failed.");
   PQXX_CHECK_EQUAL(i, 9, "to(int, int) is broken.");
 
-  auto const r2{tx.exec1("SELECT NULL")};
+  auto const r2{tx.exec("SELECT NULL").one_row()};
   auto const f2{r2[0]};
   i = 100;
   PQXX_CHECK_THROWS(

--- a/test/unit/test_float.cxx
+++ b/test/unit/test_float.cxx
@@ -51,7 +51,7 @@ template<typename T> void bug_262()
 
   // Nothing bad here, select a float value.
   // The stream is clear, so just fill it with the value and extract str().
-  row = tr.exec1("SELECT 1.0");
+  row = tr.exec("SELECT 1.0").one_row();
 
   // This works properly, but as we parse the value from the stream, the
   // seeking cursor moves towards the EOF. When the inevitable EOF happens
@@ -67,14 +67,14 @@ template<typename T> void bug_262()
   // OOPS. stream.str("") does not reset 'eof' flag and 'good' flag! We are
   // trying to read from EOF! This is no good.
   // Throws on unpatched pqxx v6.4.5
-  row = tr.exec1("SELECT 2.0");
+  row = tr.exec("SELECT 2.0").one_row();
 
   // We won't get here without patch. The following statements are just for
   // demonstration of how are intended to work. If we
   // simply just reset the stream flags properly, this would work fine.
   // The most obvious patch is just explicitly stream.seekg(0).
   row[0].as<T>();
-  row = tr.exec1("SELECT 3.0");
+  row = tr.exec("SELECT 3.0").one_row();
   row[0].as<T>();
 }
 

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -68,7 +68,8 @@ void test_registration_and_invocation()
 
   // The statement returns exactly what you'd expect.
   COMPARE_RESULTS(
-    "CountToFive", tx1.exec(pqxx::prepped{"CountToFive"}), tx1.exec(count_to_5));
+    "CountToFive", tx1.exec(pqxx::prepped{"CountToFive"}),
+    tx1.exec(count_to_5));
 
   // Re-preparing it is an error.
   PQXX_CHECK_THROWS(
@@ -111,8 +112,7 @@ void test_multiple_params()
   c.prepare("CountSeries", "SELECT * FROM generate_series($1::int, $2::int)");
   pqxx::work tx{c};
   auto r{
-    tx.exec(pqxx::prepped{"CountSeries"}, pqxx::params{7, 10}).expect_rows(4)
-  };
+    tx.exec(pqxx::prepped{"CountSeries"}, pqxx::params{7, 10}).expect_rows(4)};
   PQXX_CHECK_EQUAL(
     std::size(r), 4, "Wrong number of rows, but no error raised.");
   PQXX_CHECK_EQUAL(r.front().front().as<int>(), 7, "Wrong $1.");
@@ -156,9 +156,9 @@ void test_strings()
     rw.front().as<std::string>(), std::string(nasty_string),
     "Prepared statement did not quote/escape correctly.");
 
-  rw = tx.exec(
-    pqxx::prepped{"EchoStr"}, pqxx::params{std::string{nasty_string}}
-  ).one_row();
+  rw =
+    tx.exec(pqxx::prepped{"EchoStr"}, pqxx::params{std::string{nasty_string}})
+      .one_row();
   PQXX_CHECK_EQUAL(
     rw.front().as<std::string>(), std::string(nasty_string),
     "Quoting/escaping went wrong in std::string.");
@@ -255,16 +255,15 @@ void test_params()
   params.append_multi(values);
 
   auto const rw39{
-    tx.exec(pqxx::prepped{"Concat2Numbers"}, pqxx::params{params}).one_row()
-  };
+    tx.exec(pqxx::prepped{"Concat2Numbers"}, pqxx::params{params}).one_row()};
   PQXX_CHECK_EQUAL(
     rw39.front().as<int>(), 39,
     "Dynamic prepared-statement parameters went wrong.");
 
   c.prepare("Concat4Numbers", "SELECT 1000*$1 + 100*$2 + 10*$3 + $4");
   auto const rw1396{
-    tx.exec(pqxx::prepped{"Concat4Numbers"}, pqxx::params{1, params, 6}
-  ).one_row()};
+    tx.exec(pqxx::prepped{"Concat4Numbers"}, pqxx::params{1, params, 6})
+      .one_row()};
   PQXX_CHECK_EQUAL(
     rw1396.front().as<int>(), 1396,
     "Dynamic params did not interleave with static ones properly.");
@@ -276,19 +275,16 @@ void test_optional()
   pqxx::connection c;
   pqxx::work tx{c};
   c.prepare("EchoNum", "SELECT $1::int");
-  pqxx::row rw{
-    tx.exec(
-      pqxx::prepped{"EchoNum"},
-      pqxx::params{std::optional<int>{std::in_place, 10}}
-    ).one_row()
-  };
+  pqxx::row rw{tx.exec(
+                   pqxx::prepped{"EchoNum"},
+                   pqxx::params{std::optional<int>{std::in_place, 10}})
+                 .one_row()};
   PQXX_CHECK_EQUAL(
     rw.front().as<int>(), 10,
     "optional (with value) did not return the right value.");
 
-  rw = tx.exec(
-    pqxx::prepped{"EchoNum"}, pqxx::params{std::optional<int>{}}
-  ).one_row();
+  rw = tx.exec(pqxx::prepped{"EchoNum"}, pqxx::params{std::optional<int>{}})
+         .one_row();
   PQXX_CHECK(
     rw.front().is_null(), "optional without value did not come out as null.");
 }
@@ -362,8 +358,7 @@ void test_wrong_number_of_params()
     pqxx::transaction tx2{conn2};
     conn2.prepare("broken2", "SELECT $1::int + $2::int");
     PQXX_CHECK_THROWS(
-      tx2.exec(pqxx::prepped{"broken2"}, {5, 4, 3}),
-      pqxx::protocol_violation,
+      tx2.exec(pqxx::prepped{"broken2"}, {5, 4, 3}), pqxx::protocol_violation,
       "Passing too many params no longer thrws protocol violation.");
   }
 }
@@ -375,8 +370,7 @@ void test_query_prepped()
   pqxx::transaction tx{cx};
   cx.prepare("hop", "SELECT x * 3 FROM generate_series(1, 2) AS x");
   std::vector<int> out;
-  for (auto [i] : tx.query<int>(pqxx::prepped{"hop"}))
-    out.push_back(i);
+  for (auto [i] : tx.query<int>(pqxx::prepped{"hop"})) out.push_back(i);
   PQXX_CHECK_EQUAL(std::size(out), 2u, "Wrong number of results.");
   PQXX_CHECK_EQUAL(out.at(0), 3, "Wrong data came out of prepped query.");
   PQXX_CHECK_EQUAL(out.at(1), 6, "First item was correct, second was not!");
@@ -399,7 +393,7 @@ void test_for_query_prepped()
   pqxx::transaction tx{cx};
   cx.prepare("series", "SELECT * FROM generate_series(3, 4)");
   std::vector<int> out;
-  tx.for_query(pqxx::prepped("series"), [&out](int x){ out.push_back(x); });
+  tx.for_query(pqxx::prepped("series"), [&out](int x) { out.push_back(x); });
   PQXX_CHECK_EQUAL(std::size(out), 2u, "Wrong result size.");
   PQXX_CHECK_EQUAL(out.at(0), 3, "Wrong data came out of prepped query.");
   PQXX_CHECK_EQUAL(out.at(1), 4, "First item was correct, second was not.");

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -68,7 +68,7 @@ void test_registration_and_invocation()
 
   // The statement returns exactly what you'd expect.
   COMPARE_RESULTS(
-    "CountToFive", tx1.exec_prepared("CountToFive"), tx1.exec(count_to_5));
+    "CountToFive", tx1.exec(pqxx::prepped{"CountToFive"}), tx1.exec(count_to_5));
 
   // Re-preparing it is an error.
   PQXX_CHECK_THROWS(
@@ -80,7 +80,7 @@ void test_registration_and_invocation()
 
   // Executing a nonexistent prepared statement is also an error.
   PQXX_CHECK_THROWS(
-    tx2.exec_prepared("NonexistentStatement"), pqxx::sql_error,
+    tx2.exec(pqxx::prepped{"NonexistentStatement"}), pqxx::sql_error,
     "Did not report invocation of nonexistent prepared statement.");
 }
 
@@ -90,7 +90,7 @@ void test_basic_args()
   pqxx::connection c;
   c.prepare("EchoNum", "SELECT $1::int");
   pqxx::work tx{c};
-  auto r{tx.exec_prepared("EchoNum", 7)};
+  auto r{tx.exec(pqxx::prepped{"EchoNum"}, 7)};
   PQXX_CHECK_EQUAL(
     std::size(r), 1, "Did not get 1 row from prepared statement.");
   PQXX_CHECK_EQUAL(std::size(r.front()), 1, "Did not get exactly one column.");
@@ -336,7 +336,7 @@ void test_wrong_number_of_params()
     pqxx::transaction tx1{conn1};
     conn1.prepare("broken1", "SELECT $1::int + $2::int");
     PQXX_CHECK_THROWS(
-      tx1.exec_prepared("broken1", 10), pqxx::protocol_violation,
+      tx1.exec(pqxx::prepped{"broken1"}, 10), pqxx::protocol_violation,
       "Incomplete params no longer thrws protocol violation.");
   }
 
@@ -345,7 +345,7 @@ void test_wrong_number_of_params()
     pqxx::transaction tx2{conn2};
     conn2.prepare("broken2", "SELECT $1::int + $2::int");
     PQXX_CHECK_THROWS(
-      tx2.exec_prepared("broken2", 5, 4, 3), pqxx::protocol_violation,
+      tx2.exec(pqxx::prepped{"broken2"}, {5, 4, 3}), pqxx::protocol_violation,
       "Passing too many params no longer thrws protocol violation.");
   }
 }

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -96,10 +96,12 @@ void test_basic_args()
   PQXX_CHECK_EQUAL(std::size(r.front()), 1, "Did not get exactly one column.");
   PQXX_CHECK_EQUAL(r[0][0].as<int>(), 7, "Got wrong result.");
 
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   auto rw{tx.exec_prepared1("EchoNum", 8)};
   PQXX_CHECK_EQUAL(
     std::size(rw), 1, "Did not get 1 column from exec_prepared1.");
   PQXX_CHECK_EQUAL(rw[0].as<int>(), 8, "Got wrong result.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
@@ -108,14 +110,16 @@ void test_multiple_params()
   pqxx::connection c;
   c.prepare("CountSeries", "SELECT * FROM generate_series($1::int, $2::int)");
   pqxx::work tx{c};
-  auto r{tx.exec_prepared_n(4, "CountSeries", 7, 10)};
+  auto r{
+    tx.exec(pqxx::prepped{"CountSeries"}, pqxx::params{7, 10}).expect_rows(4)
+  };
   PQXX_CHECK_EQUAL(
     std::size(r), 4, "Wrong number of rows, but no error raised.");
   PQXX_CHECK_EQUAL(r.front().front().as<int>(), 7, "Wrong $1.");
   PQXX_CHECK_EQUAL(r.back().front().as<int>(), 10, "Wrong $2.");
 
   c.prepare("Reversed", "SELECT * FROM generate_series($2::int, $1::int)");
-  r = tx.exec_prepared_n(3, "Reversed", 8, 6);
+  r = tx.exec(pqxx::prepped{"Reversed"}, pqxx::params{8, 6}).expect_rows(3);
   PQXX_CHECK_EQUAL(
     r.front().front().as<int>(), 6, "Did parameters get reordered?");
   PQXX_CHECK_EQUAL(
@@ -128,11 +132,11 @@ void test_nulls()
   pqxx::connection c;
   pqxx::work tx{c};
   c.prepare("EchoStr", "SELECT $1::varchar");
-  auto rw{tx.exec_prepared1("EchoStr", nullptr)};
+  auto rw{tx.exec(pqxx::prepped{"EchoStr"}, pqxx::params{nullptr}).one_row()};
   PQXX_CHECK(rw.front().is_null(), "nullptr did not translate to null.");
 
   char const *n{nullptr};
-  rw = tx.exec_prepared1("EchoStr", n);
+  rw = tx.exec(pqxx::prepped{"EchoStr"}, pqxx::params{n}).one_row();
   PQXX_CHECK(rw.front().is_null(), "Null pointer did not translate to null.");
 }
 
@@ -142,23 +146,25 @@ void test_strings()
   pqxx::connection c;
   pqxx::work tx{c};
   c.prepare("EchoStr", "SELECT $1::varchar");
-  auto rw{tx.exec_prepared1("EchoStr", "foo")};
+  auto rw{tx.exec(pqxx::prepped{"EchoStr"}, pqxx::params{"foo"}).one_row()};
   PQXX_CHECK_EQUAL(
     rw.front().as<std::string>(), "foo", "Wrong string result.");
 
   char const nasty_string[]{R"--('\"\)--"};
-  rw = tx.exec_prepared1("EchoStr", nasty_string);
+  rw = tx.exec(pqxx::prepped{"EchoStr"}, pqxx::params{nasty_string}).one_row();
   PQXX_CHECK_EQUAL(
     rw.front().as<std::string>(), std::string(nasty_string),
     "Prepared statement did not quote/escape correctly.");
 
-  rw = tx.exec_prepared1("EchoStr", std::string{nasty_string});
+  rw = tx.exec(
+    pqxx::prepped{"EchoStr"}, pqxx::params{std::string{nasty_string}}
+  ).one_row();
   PQXX_CHECK_EQUAL(
     rw.front().as<std::string>(), std::string(nasty_string),
     "Quoting/escaping went wrong in std::string.");
 
   char nonconst[]{"non-const C string"};
-  rw = tx.exec_prepared1("EchoStr", nonconst);
+  rw = tx.exec(pqxx::prepped{"EchoStr"}, pqxx::params{nonconst}).one_row();
   PQXX_CHECK_EQUAL(
     rw.front().as<std::string>(), std::string(nonconst),
     "Non-const C string passed incorrectly.");
@@ -176,7 +182,7 @@ void test_binary()
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
   {
     pqxx::binarystring const bin{input};
-    auto rw{tx.exec_prepared1("EchoBin", bin)};
+    auto rw{tx.exec(pqxx::prepped{"EchoBin"}, pqxx::params{bin}).one_row()};
     PQXX_CHECK_EQUAL(
       pqxx::binarystring(rw[0]).str(), input,
       "Binary string came out damaged.");
@@ -186,7 +192,7 @@ void test_binary()
   {
     pqxx::bytes bytes{
       reinterpret_cast<std::byte const *>(raw_bytes), std::size(raw_bytes)};
-    auto bp{tx.exec_prepared1("EchoBin", bytes)};
+    auto bp{tx.exec(pqxx::prepped{"EchoBin"}, pqxx::params{bytes}).one_row()};
     auto bval{bp[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       (std::string_view{
@@ -202,7 +208,7 @@ void test_binary()
   {
     auto ptr{std::make_shared<pqxx::bytes>(
       reinterpret_cast<std::byte const *>(raw_bytes), std::size(raw_bytes))};
-    auto rp{tx.exec_prepared1("EchoBin", ptr)};
+    auto rp{tx.exec(pqxx::prepped{"EchoBin"}, pqxx::params{ptr}).one_row()};
     auto pval{rp[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       (std::string_view{
@@ -214,7 +220,7 @@ void test_binary()
     auto opt{std::optional<pqxx::bytes>{
       std::in_place, reinterpret_cast<std::byte const *>(raw_bytes),
       std::size(raw_bytes)}};
-    auto op{tx.exec_prepared1("EchoBin", opt)};
+    auto op{tx.exec(pqxx::prepped{"EchoBin"}, pqxx::params{opt}).one_row()};
     auto oval{op[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       (std::string_view{
@@ -227,7 +233,7 @@ void test_binary()
   // will do.
   {
     std::vector<std::byte> data{std::byte{'x'}, std::byte{'v'}};
-    auto op{tx.exec_prepared1("EchoBin", data)};
+    auto op{tx.exec(pqxx::prepped{"EchoBin"}, pqxx::params{data}).one_row()};
     auto oval{op[0].as<pqxx::bytes>()};
     PQXX_CHECK_EQUAL(
       std::size(oval), 2u, "Binary data came back as wrong length.");
@@ -248,13 +254,17 @@ void test_params()
   params.reserve(std::size(values));
   params.append_multi(values);
 
-  auto const rw39{tx.exec_prepared1("Concat2Numbers", params)};
+  auto const rw39{
+    tx.exec(pqxx::prepped{"Concat2Numbers"}, pqxx::params{params}).one_row()
+  };
   PQXX_CHECK_EQUAL(
     rw39.front().as<int>(), 39,
     "Dynamic prepared-statement parameters went wrong.");
 
   c.prepare("Concat4Numbers", "SELECT 1000*$1 + 100*$2 + 10*$3 + $4");
-  auto const rw1396{tx.exec_prepared1("Concat4Numbers", 1, params, 6)};
+  auto const rw1396{
+    tx.exec(pqxx::prepped{"Concat4Numbers"}, pqxx::params{1, params, 6}
+  ).one_row()};
   PQXX_CHECK_EQUAL(
     rw1396.front().as<int>(), 1396,
     "Dynamic params did not interleave with static ones properly.");
@@ -267,12 +277,18 @@ void test_optional()
   pqxx::work tx{c};
   c.prepare("EchoNum", "SELECT $1::int");
   pqxx::row rw{
-    tx.exec_prepared1("EchoNum", std::optional<int>{std::in_place, 10})};
+    tx.exec(
+      pqxx::prepped{"EchoNum"},
+      pqxx::params{std::optional<int>{std::in_place, 10}}
+    ).one_row()
+  };
   PQXX_CHECK_EQUAL(
     rw.front().as<int>(), 10,
     "optional (with value) did not return the right value.");
 
-  rw = tx.exec_prepared1("EchoNum", std::optional<int>{});
+  rw = tx.exec(
+    pqxx::prepped{"EchoNum"}, pqxx::params{std::optional<int>{}}
+  ).one_row();
   PQXX_CHECK(
     rw.front().is_null(), "optional without value did not come out as null.");
 }
@@ -336,7 +352,8 @@ void test_wrong_number_of_params()
     pqxx::transaction tx1{conn1};
     conn1.prepare("broken1", "SELECT $1::int + $2::int");
     PQXX_CHECK_THROWS(
-      tx1.exec(pqxx::prepped{"broken1"}, 10), pqxx::protocol_violation,
+      tx1.exec(pqxx::prepped{"broken1"}, pqxx::params{10}),
+      pqxx::protocol_violation,
       "Incomplete params no longer thrws protocol violation.");
   }
 
@@ -345,7 +362,8 @@ void test_wrong_number_of_params()
     pqxx::transaction tx2{conn2};
     conn2.prepare("broken2", "SELECT $1::int + $2::int");
     PQXX_CHECK_THROWS(
-      tx2.exec(pqxx::prepped{"broken2"}, {5, 4, 3}), pqxx::protocol_violation,
+      tx2.exec(pqxx::prepped{"broken2"}, {5, 4, 3}),
+      pqxx::protocol_violation,
       "Passing too many params no longer thrws protocol violation.");
   }
 }

--- a/test/unit/test_result_iteration.cxx
+++ b/test/unit/test_result_iteration.cxx
@@ -87,7 +87,7 @@ void test_result_for_each()
 {
   pqxx::connection cx;
   pqxx::work tx{cx};
-  tx.exec0("CREATE TEMP TABLE employee(name varchar, salary int)");
+  tx.exec("CREATE TEMP TABLE employee(name varchar, salary int)").no_rows();
   auto fill{pqxx::stream_to::table(tx, {"employee"}, {"name", "salary"})};
   fill.write_values("x", 1000);
   fill.write_values("y", 1200);

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -61,7 +61,7 @@ void test_row_as()
   pqxx::connection cx;
   pqxx::work tx{cx};
 
-  pqxx::row const r{tx.exec1("SELECT 1, 2, 3")};
+  pqxx::row const r{tx.exec("SELECT 1, 2, 3").one_row()};
   auto [one, two, three]{r.as<int, float, pqxx::zview>()};
   static_assert(std::is_same_v<decltype(one), int>);
   static_assert(std::is_same_v<decltype(two), float>);
@@ -73,7 +73,7 @@ void test_row_as()
     three, "3"_zv, "row::as() did not produce the right zview.");
 
   PQXX_CHECK_EQUAL(
-    std::get<0>(tx.exec1("SELECT 999").as<int>()), 999,
+    std::get<0>(tx.exec("SELECT 999").one_row().as<int>()), 999,
     "Unary tuple did not extract right.");
 }
 
@@ -83,7 +83,7 @@ void test_row_iterator_array_index_offsets_iterator()
 {
   pqxx::connection cx;
   pqxx::work tx{cx};
-  auto const row{tx.exec1("SELECT 5, 4, 3, 2")};
+  auto const row{tx.exec("SELECT 5, 4, 3, 2").one_row()};
   PQXX_CHECK_EQUAL(
     row.begin()[1].as<std::string>(), "4",
     "Row iterator indexing went wrong.");

--- a/test/unit/test_sql_cursor.cxx
+++ b/test/unit/test_sql_cursor.cxx
@@ -174,9 +174,9 @@ void test_adopted_sql_cursor()
   pqxx::work tx{cx};
 
   tx.exec(
-    "DECLARE adopted SCROLL CURSOR FOR "
-    "SELECT generate_series(1, 3)"
-  ).no_rows();
+      "DECLARE adopted SCROLL CURSOR FOR "
+      "SELECT generate_series(1, 3)")
+    .no_rows();
   pqxx::internal::sql_cursor adopted(tx, "adopted", pqxx::cursor_base::owned);
   PQXX_CHECK_EQUAL(adopted.pos(), -1, "Adopted cursor has known pos()");
   PQXX_CHECK_EQUAL(adopted.endpos(), -1, "Adopted cursor has known endpos()");
@@ -207,10 +207,11 @@ void test_adopted_sql_cursor()
   // Owned adopted cursors are cleaned up on destruction.
   pqxx::connection conn2;
   pqxx::work tx2(conn2, "tx2");
-  tx2.exec(
-    "DECLARE adopted2 CURSOR FOR "
-    "SELECT generate_series(1, 3)"
-  ).no_rows();
+  tx2
+    .exec(
+      "DECLARE adopted2 CURSOR FOR "
+      "SELECT generate_series(1, 3)")
+    .no_rows();
   {
     pqxx::internal::sql_cursor(tx2, "adopted2", pqxx::cursor_base::owned);
   }

--- a/test/unit/test_sql_cursor.cxx
+++ b/test/unit/test_sql_cursor.cxx
@@ -173,9 +173,10 @@ void test_adopted_sql_cursor()
   pqxx::connection cx;
   pqxx::work tx{cx};
 
-  tx.exec0(
+  tx.exec(
     "DECLARE adopted SCROLL CURSOR FOR "
-    "SELECT generate_series(1, 3)");
+    "SELECT generate_series(1, 3)"
+  ).no_rows();
   pqxx::internal::sql_cursor adopted(tx, "adopted", pqxx::cursor_base::owned);
   PQXX_CHECK_EQUAL(adopted.pos(), -1, "Adopted cursor has known pos()");
   PQXX_CHECK_EQUAL(adopted.endpos(), -1, "Adopted cursor has known endpos()");
@@ -206,9 +207,10 @@ void test_adopted_sql_cursor()
   // Owned adopted cursors are cleaned up on destruction.
   pqxx::connection conn2;
   pqxx::work tx2(conn2, "tx2");
-  tx2.exec0(
+  tx2.exec(
     "DECLARE adopted2 CURSOR FOR "
-    "SELECT generate_series(1, 3)");
+    "SELECT generate_series(1, 3)"
+  ).no_rows();
   {
     pqxx::internal::sql_cursor(tx2, "adopted2", pqxx::cursor_base::owned);
   }

--- a/test/unit/test_strconv.cxx
+++ b/test/unit/test_strconv.cxx
@@ -100,7 +100,7 @@ void test_strconv_class_enum()
   pqxx::connection cx;
   pqxx::work tx{cx};
   std::tuple<weather> out;
-  tx.exec1("SELECT 0").to(out);
+  tx.exec("SELECT 0").one_row().to(out);
 }
 
 

--- a/test/unit/test_stream_query.cxx
+++ b/test/unit/test_stream_query.cxx
@@ -133,8 +133,8 @@ void test_stream_parses_awkward_strings()
   // that aren't really there.
   cx.set_client_encoding("SJIS");
   pqxx::work tx{cx};
-  tx.exec0("CREATE TEMP TABLE nasty(id integer, value varchar)");
-  tx.exec0(
+  tx.exec("CREATE TEMP TABLE nasty(id integer, value varchar)").no_rows();
+  tx.exec(
     "INSERT INTO nasty(id, value) VALUES "
     // A proper null.
     "(0, NULL), "
@@ -147,7 +147,8 @@ void test_stream_parses_awkward_strings()
     // injection can break out of a string.
     "(4, '\x81\x5c'), "
     "(5, '\t'), "
-    "(6, '\\\\\\\n\\\\')");
+    "(6, '\\\\\\\n\\\\')"
+  ).no_rows();
 
   std::vector<std::optional<std::string>> values;
   for (auto [id, value] : tx.stream<std::size_t, std::optional<std::string>>(

--- a/test/unit/test_stream_query.cxx
+++ b/test/unit/test_stream_query.cxx
@@ -135,20 +135,20 @@ void test_stream_parses_awkward_strings()
   pqxx::work tx{cx};
   tx.exec("CREATE TEMP TABLE nasty(id integer, value varchar)").no_rows();
   tx.exec(
-    "INSERT INTO nasty(id, value) VALUES "
-    // A proper null.
-    "(0, NULL), "
-    // Some strings that could easily be mis-parsed as null.
-    "(1, 'NULL'), "
-    "(2, '\\N'), "
-    "(3, '''NULL'''), "
-    // An SJIS multibyte character that ends in a byte that happens to be the
-    // ASCII value for a backslash.  This is one example of how an SJIS SQL
-    // injection can break out of a string.
-    "(4, '\x81\x5c'), "
-    "(5, '\t'), "
-    "(6, '\\\\\\\n\\\\')"
-  ).no_rows();
+      "INSERT INTO nasty(id, value) VALUES "
+      // A proper null.
+      "(0, NULL), "
+      // Some strings that could easily be mis-parsed as null.
+      "(1, 'NULL'), "
+      "(2, '\\N'), "
+      "(3, '''NULL'''), "
+      // An SJIS multibyte character that ends in a byte that happens to be the
+      // ASCII value for a backslash.  This is one example of how an SJIS SQL
+      // injection can break out of a string.
+      "(4, '\x81\x5c'), "
+      "(5, '\t'), "
+      "(6, '\\\\\\\n\\\\')")
+    .no_rows();
 
   std::vector<std::optional<std::string>> values;
   for (auto [id, value] : tx.stream<std::size_t, std::optional<std::string>>(

--- a/test/unit/test_stream_to.cxx
+++ b/test/unit/test_stream_to.cxx
@@ -39,7 +39,8 @@ void test_nonoptionals(pqxx::connection &connection)
 
   inserter.complete();
 
-  auto r1{tx.exec("SELECT * FROM stream_to_test WHERE number0 = 1234").one_row()};
+  auto r1{
+    tx.exec("SELECT * FROM stream_to_test WHERE number0 = 1234").one_row()};
   PQXX_CHECK_EQUAL(r1[0].as<int>(), 1234, "Read back wrong first int.");
   PQXX_CHECK_EQUAL(
     r1[4].as<std::string>(), "hello nonoptional world",
@@ -47,7 +48,8 @@ void test_nonoptionals(pqxx::connection &connection)
   PQXX_CHECK_EQUAL(r1[3].as<ipv4>(), ipv4(8, 8, 4, 4), "Read back wrong ip.");
   PQXX_CHECK_EQUAL(r1[5].as<bytea>(), binary, "Read back wrong bytea.");
 
-  auto r2{tx.exec("SELECT * FROM stream_to_test WHERE number0 = 5678").one_row()};
+  auto r2{
+    tx.exec("SELECT * FROM stream_to_test WHERE number0 = 5678").one_row()};
   PQXX_CHECK_EQUAL(r2[0].as<int>(), 5678, "Wrong int on second row.");
   PQXX_CHECK(r2[2].is_null(), "Field 2 was meant to be null.");
   PQXX_CHECK(r2[3].is_null(), "Field 3 was meant to be null.");
@@ -74,7 +76,8 @@ void test_nonoptionals_fold(pqxx::connection &connection)
 
   inserter.complete();
 
-  auto r1{tx.exec("SELECT * FROM stream_to_test WHERE number0 = 1234").one_row()};
+  auto r1{
+    tx.exec("SELECT * FROM stream_to_test WHERE number0 = 1234").one_row()};
   PQXX_CHECK_EQUAL(r1[0].as<int>(), 1234, "Read back wrong first int.");
   PQXX_CHECK_EQUAL(
     r1[4].as<std::string>(), "hello nonoptional world",
@@ -82,7 +85,8 @@ void test_nonoptionals_fold(pqxx::connection &connection)
   PQXX_CHECK_EQUAL(r1[3].as<ipv4>(), ipv4(8, 8, 4, 4), "Read back wrong ip.");
   PQXX_CHECK_EQUAL(r1[5].as<bytea>(), binary, "Read back wrong bytera.");
 
-  auto r2{tx.exec("SELECT * FROM stream_to_test WHERE number0 = 5678").one_row()};
+  auto r2{
+    tx.exec("SELECT * FROM stream_to_test WHERE number0 = 5678").one_row()};
   PQXX_CHECK_EQUAL(r2[0].as<int>(), 5678, "Wrong int on second row.");
   PQXX_CHECK(r2[2].is_null(), "Field 2 was meant to be null.");
   PQXX_CHECK(r2[3].is_null(), "Field 3 was meant to be null.");
@@ -336,15 +340,15 @@ void test_stream_to()
   pqxx::work tx{cx};
 
   tx.exec(
-    "CREATE TEMP TABLE stream_to_test ("
-    "number0 INT NOT NULL,"
-    "ts1     TIMESTAMP NULL,"
-    "number2 INT NULL,"
-    "addr3   INET NULL,"
-    "txt4    TEXT NULL,"
-    "bin5    BYTEA NOT NULL"
-    ")"
-  ).no_rows();
+      "CREATE TEMP TABLE stream_to_test ("
+      "number0 INT NOT NULL,"
+      "ts1     TIMESTAMP NULL,"
+      "number2 INT NULL,"
+      "addr3   INET NULL,"
+      "txt4    TEXT NULL,"
+      "bin5    BYTEA NOT NULL"
+      ")")
+    .no_rows();
   tx.commit();
 
   test_nonoptionals(cx);
@@ -428,9 +432,9 @@ void test_stream_to_quotes_arguments()
   std::string const table{R"--(pqxx_Stream"'x)--"}, column{R"--(a'"b)--"};
 
   tx.exec(
-    "CREATE TEMP TABLE " + tx.quote_name(table) + "(" + tx.quote_name(column) +
-    " integer)"
-  ).no_rows();
+      "CREATE TEMP TABLE " + tx.quote_name(table) + "(" +
+      tx.quote_name(column) + " integer)")
+    .no_rows();
   auto write{pqxx::stream_to::table(tx, {table}, {column})};
   write.write_values<int>(12);
   write.complete();
@@ -447,7 +451,8 @@ void test_stream_to_optionals()
   pqxx::connection cx;
   pqxx::work tx{cx};
 
-  tx.exec("CREATE TEMP TABLE pqxx_strings(key integer, value varchar)").no_rows();
+  tx.exec("CREATE TEMP TABLE pqxx_strings(key integer, value varchar)")
+    .no_rows();
 
   auto stream{pqxx::stream_to::table(tx, {"pqxx_strings"}, {"key", "value"})};
   stream.write_values(1, std::optional<std::string>{});

--- a/test/unit/test_subtransaction.cxx
+++ b/test/unit/test_subtransaction.cxx
@@ -7,13 +7,13 @@ namespace
 {
 void make_table(pqxx::transaction_base &tx)
 {
-  tx.exec0("CREATE TEMP TABLE foo (x INTEGER)");
+  tx.exec("CREATE TEMP TABLE foo (x INTEGER)").no_rows();
 }
 
 
 void insert_row(pqxx::transaction_base &tx)
 {
-  tx.exec0("INSERT INTO foo(x) VALUES (1)");
+  tx.exec("INSERT INTO foo(x) VALUES (1)").no_rows();
 }
 
 

--- a/test/unit/test_transaction.cxx
+++ b/test/unit/test_transaction.cxx
@@ -39,8 +39,8 @@ void create_temp_table(pqxx::transaction_base &tx)
 void insert_temp_table(pqxx::transaction_base &tx, int value)
 {
   tx.exec(
-    "INSERT INTO " + table + " (x) VALUES (" + pqxx::to_string(value) + ")"
-  ).no_rows();
+      "INSERT INTO " + table + " (x) VALUES (" + pqxx::to_string(value) + ")")
+    .no_rows();
 }
 
 int count_temp_table(pqxx::transaction_base &tx)

--- a/test/unit/test_transaction.cxx
+++ b/test/unit/test_transaction.cxx
@@ -26,20 +26,21 @@ std::string const table{"pqxx_test_transaction"};
 
 void delete_temp_table(pqxx::transaction_base &tx)
 {
-  tx.exec0(std::string{"DROP TABLE IF EXISTS "} + table);
+  tx.exec(std::string{"DROP TABLE IF EXISTS "} + table).no_rows();
 }
 
 
 void create_temp_table(pqxx::transaction_base &tx)
 {
-  tx.exec0("CREATE TEMP TABLE " + table + " (x integer)");
+  tx.exec("CREATE TEMP TABLE " + table + " (x integer)").no_rows();
 }
 
 
 void insert_temp_table(pqxx::transaction_base &tx, int value)
 {
-  tx.exec0(
-    "INSERT INTO " + table + " (x) VALUES (" + pqxx::to_string(value) + ")");
+  tx.exec(
+    "INSERT INTO " + table + " (x) VALUES (" + pqxx::to_string(value) + ")"
+  ).no_rows();
 }
 
 int count_temp_table(pqxx::transaction_base &tx)
@@ -74,24 +75,24 @@ template<typename TX> void test_double_close()
   pqxx::connection c;
 
   TX tx1{c};
-  tx1.exec1("SELECT 1");
+  tx1.exec("SELECT 1").one_row();
   tx1.commit();
   tx1.commit();
 
   TX tx2{c};
-  tx2.exec1("SELECT 2");
+  tx2.exec("SELECT 2").one_row();
   tx2.abort();
   tx2.abort();
 
   TX tx3{c};
-  tx3.exec1("SELECT 3");
+  tx3.exec("SELECT 3").one_row();
   tx3.commit();
   PQXX_CHECK_THROWS(
     tx3.abort(), pqxx::usage_error, "Abort after commit not caught.");
   ;
 
   TX tx4{c};
-  tx4.exec1("SELECT 4");
+  tx4.exec("SELECT 4").one_row();
   tx4.abort();
   PQXX_CHECK_THROWS(
     tx4.commit(), pqxx::usage_error, "Commit after abort not caught.");

--- a/test/unit/test_transaction_base.cxx
+++ b/test/unit/test_transaction_base.cxx
@@ -7,17 +7,20 @@ namespace
 {
 void test_exec0(pqxx::transaction_base &tx)
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   pqxx::result E{tx.exec0("SELECT * FROM pg_tables WHERE 0 = 1")};
   PQXX_CHECK(std::empty(E), "Nonempty result from exec0.");
 
   PQXX_CHECK_THROWS(
     tx.exec0("SELECT 99"), pqxx::unexpected_rows,
     "Nonempty exec0 result did not throw unexpected_rows.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_exec1(pqxx::transaction_base &tx)
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   pqxx::row R{tx.exec1("SELECT 99")};
   PQXX_CHECK_EQUAL(std::size(R), 1, "Wrong size result from exec1.");
   PQXX_CHECK_EQUAL(R.front().as<int>(), 99, "Wrong result from exec1.");
@@ -28,11 +31,13 @@ void test_exec1(pqxx::transaction_base &tx)
   PQXX_CHECK_THROWS(
     tx.exec1("SELECT * FROM generate_series(1, 2)"), pqxx::unexpected_rows,
     "Two-row exec1 result did not throw unexpected_rows.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_exec_n(pqxx::transaction_base &tx)
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   pqxx::result R{tx.exec_n(3u, "SELECT * FROM generate_series(1, 3)")};
   PQXX_CHECK_EQUAL(std::size(R), 3, "Wrong result size from exec_n.");
 
@@ -44,6 +49,7 @@ void test_exec_n(pqxx::transaction_base &tx)
     tx.exec_n(4u, "SELECT * FROM generate_series(1, 3)"),
     pqxx::unexpected_rows,
     "exec_n did not throw unexpected_rows for an oversized result.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
@@ -55,7 +61,7 @@ void test_query_value(pqxx::connection &cx)
     tx.query_value<int>("SELECT 84 / 2"), 42,
     "Got wrong value from query_value.");
   PQXX_CHECK_THROWS(
-    tx.query_value<int>("SAVEPOINT dummy"), pqxx::unexpected_rows,
+    tx.query_value<int>("SAVEPOINT dummy"), pqxx::usage_error,
     "Got field when none expected.");
   PQXX_CHECK_THROWS(
     tx.query_value<int>("SELECT generate_series(1, 2)"), pqxx::unexpected_rows,
@@ -127,6 +133,7 @@ void test_transaction_query_params()
     outcome, 64, "Parameterised query() produced wrong result.");
 
   outcome = -1;
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   for (auto [value] :
        tx.query_n<int>(1, "SELECT * FROM generate_series(1, $1)", {1}))
   {
@@ -172,6 +179,7 @@ void test_transaction_query_params()
     opt3_a, 12, "Multi-column query01() with params gave wrong result.");
   PQXX_CHECK_EQUAL(
     opt3_b, 99, "Multi-column query01() with params gave wrong result.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
@@ -232,6 +240,7 @@ void test_transaction_query01()
   pqxx::connection c;
   pqxx::work w{c};
 
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::optional<std::tuple<int>> o{
     w.query01<int>("SELECT * FROM generate_series(1, 1) AS i WHERE i = 5")};
   PQXX_CHECK(not o.has_value(), "Why did we get a row?");
@@ -250,6 +259,7 @@ void test_transaction_query01()
   PQXX_CHECK_THROWS(
     o = w.query01<int>("SELECT 1, 2"), pqxx::usage_error,
     "Wrong number of columns did not throw usage_error.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
@@ -281,6 +291,7 @@ void test_transaction_query_n()
   pqxx::connection c;
   pqxx::work w{c};
 
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   PQXX_CHECK_THROWS(
     pqxx::ignore_unused(w.query_n<int>(5, "SELECT generate_series(1, 3)")),
     pqxx::unexpected_rows, "No exception when query_n returns too few rows.");
@@ -291,6 +302,7 @@ void test_transaction_query_n()
   std::vector<int> v;
   for (auto [n] : w.query_n<int>(3, "SELECT generate_series(7, 9)"))
     v.push_back(n);
+#include "pqxx/internal/ignore-deprecated-post.hxx"
   PQXX_CHECK_EQUAL(std::size(v), 3u, "Wrong number of rows.");
   PQXX_CHECK_EQUAL(v[0], 7, "Wrong result data.");
   PQXX_CHECK_EQUAL(v[2], 9, "Data started out right but went wrong.");

--- a/test/unit/test_transaction_focus.cxx
+++ b/test/unit/test_transaction_focus.cxx
@@ -41,10 +41,10 @@ void test_cannot_run_params_statement_during_focus()
 {
   pqxx::connection cx;
   pqxx::transaction tx{cx};
-  tx.exec_params("select $1", 10);
+  tx.exec("select $1", pqxx::params{10});
   auto focus{make_focus(tx)};
   PQXX_CHECK_THROWS(
-    tx.exec_params("select $1", 10), pqxx::usage_error,
+    tx.exec("select $1", pqxx::params{10}), pqxx::usage_error,
     "Parameterized statement during focus did not throw expected error.");
 }
 

--- a/test/unit/test_transaction_focus.cxx
+++ b/test/unit/test_transaction_focus.cxx
@@ -30,10 +30,10 @@ void test_cannot_run_prepared_statement_during_focus()
   pqxx::connection cx;
   cx.prepare("foo", "SELECT 1");
   pqxx::transaction tx{cx};
-  tx.exec_prepared("foo");
+  tx.exec(pqxx::prepped{"foo"});
   auto focus{make_focus(tx)};
   PQXX_CHECK_THROWS(
-    tx.exec_prepared("foo"), pqxx::usage_error,
+    tx.exec(pqxx::prepped{"foo"}), pqxx::usage_error,
     "Prepared statement during focus did not throw expected error.");
 }
 


### PR DESCRIPTION
Simplify the plethora of "exec" function names by making prepared statement calls look just like regular or parameterised statement calls.  You call `exec()` as with a regular SQL statement, but you wrap the statement name in a new type `pqxx::prepped` to indicate that it's a prepared statement name, not an SQL statement in itself.

At the same time, the functionality to check that a result contain a specific number of rows (usually either zero, or one) moves into `result` member functions.  That means separate functions for e.g. "check that this result contains exactly 1 row."  With that, we can start cutting down on all those versions that every exec function needs.

The bulk of the exec functions will be:
* Just an SQL statement, like the current `exec()`, calling libpq's `PQexec()`.
* An SQL statement with parameters, like the new `params` overload to `exec()`, calling libpq's `PQexecParams()`.
* A `pqxx::prepped` with optional parameters, in a new overload of `exec()`, calling libpq's `PQexecPrepared()`.

It will be similar for `query()`, `query_value()`, and hopefully `stream()` and `stream_like()`.  From the caller's perspective, calling any of these functions pretty much does the same thing regardless of whether you pass parameters.  And now it should also be the same when you pass a prepared statement instead of an SQL string — it's just that the query is of a different type.

Streamlining these function variants is really urgent.  We were getting to a situation where we should logically support a Cartesian product of `{plain SQL, parameterised, prepared}` × `{exec, exec0, exec1, exec_n, query, query_value, for_query, stream, for_stream, stream_like}` × `{with description, with source_location, without}` (3×10×3 == 90 functions) — and it'd keep getting worse if we wanted more exotic row-count restrictions such as "at most 1 row" or "between `a` and `b` rows."  That's just not sustainable.

I'm hoping to get to something like `{plain SQL, parameterised, prepared}` × `{exec, query, query_value, for_query, stream, for_stream, stream_like}` × `{with source_location}` (3×6×1 == 18 functions).  And maybe with clever use of templates we can eventually get it down to `{plain SQL, parameterised, prepared}` _+_ `{exec, exec0, query, query_value, stream, for_stream, stream_like}` (10 functions).

Of course this will take time to complete.  The statement descriptions go away in 8.0.  But all those _newly_ deprecated functions will stick around for another whole major release.  That's still much better than continuing along the old road.