### PR TITLE
879: Fix error message for txn focus clash.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 7.9.3
  - Bump minimum CMake version to 3.28. (#874)
+ - Fixed error message on clashing transaction focuses. (#879)
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -73,7 +73,7 @@ void pqxx::internal::check_unique_register(
         concat("Started twice: ", describe_object(old_class, old_name), ".") :
         concat(
           "Started new ", describe_object(new_class, new_name), " while ",
-          describe_object(new_class, new_name), " was still active.")};
+          describe_object(old_class, old_name), " was still active.")};
 }
 
 


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/discussions/879

If you try to create a new transaction focus while the transaction is already focused on something else, you get an exception whose message should tell you what's going on.

Unfortunately, due to a silly oversight, it only mentions the _new_ focus but not the _existing_ focus.