### PR TITLE
885: Call `true`, not `/bin/true`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 7.9.3
  - Bump minimum CMake version to 3.28. (#874)
  - Fixed error message on clashing transaction focuses. (#879)
+ - Don't call`/bin/true`; macOS doesn't have it.  Just call `true`. (#885)
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/tools/format
+++ b/tools/format
@@ -17,5 +17,5 @@ virtualenv -q --python="$(which python3)" "$WORKDIR/venv"
 # shellcheck disable=SC1091
 source "$WORKDIR"/venv/bin/activate
 pip install -q six pyaml cmake-format
-(find . -name '*.cmake' -print0 | xargs -0 -n1 cmake-format -i) || /bin/true
+(find . -name '*.cmake' -print0 | xargs -0 -n1 cmake-format -i) || true
 rm -rf "$WORKDIR"

--- a/tools/lint
+++ b/tools/lint
@@ -85,7 +85,7 @@ count_includes() {
     PAT='^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"]'"$HEADER_NAME"'[>"]'
     # It's OK for the grep to fail.
     find "$SRCDIR/include/pqxx" -type f -print0 |
-        ( xargs -0 grep -c "$PAT" || /bin/true ) |
+        ( xargs -0 grep -c "$PAT" || true ) |
         sort
 }
 
@@ -100,7 +100,7 @@ match_pre_post_headers() {
     POST="$TEMPDIR/post"
     count_includes "$SRCDIR/$NAME-pre.hxx" >"$PRE"
     count_includes "$SRCDIR/$NAME-post.hxx" >"$POST"
-    DIFF="$(diff "$PRE" "$POST")" || /bin/true
+    DIFF="$(diff "$PRE" "$POST")" || true
     rm -r -- "$TEMPDIR"
     if test -n "$DIFF"
     then


### PR DESCRIPTION
Fixes #885.

Recent macOS systems have only `/usr/bin/true`, not `/bin/true`.