### PR TITLE
Clean up more legacy connection/transation names.

### DIFF
--- a/include/pqxx/dbtransaction.hxx
+++ b/include/pqxx/dbtransaction.hxx
@@ -54,16 +54,16 @@ class PQXX_LIBEXPORT PQXX_NOVTABLE dbtransaction : public transaction_base
 {
 protected:
   /// Begin transaction.
-  explicit dbtransaction(connection &c) : transaction_base{c} {}
+  explicit dbtransaction(connection &cx) : transaction_base{cx} {}
   /// Begin transaction.
-  dbtransaction(connection &c, std::string_view tname) :
-          transaction_base{c, tname}
+  dbtransaction(connection &cx, std::string_view tname) :
+          transaction_base{cx, tname}
   {}
   /// Begin transaction.
   dbtransaction(
-    connection &c, std::string_view tname,
+    connection &cx, std::string_view tname,
     std::shared_ptr<std::string> rollback_cmd) :
-          transaction_base{c, tname, rollback_cmd}
+          transaction_base{cx, tname, rollback_cmd}
   {}
 };
 } // namespace pqxx

--- a/include/pqxx/doc/getting-started.md
+++ b/include/pqxx/doc/getting-started.md
@@ -51,20 +51,20 @@ an `int`, and prints it out.  It also contains some basic error handling.
         // The constructor parses options exactly like libpq's
         // PQconnectdb/PQconnect, see:
         // https://www.postgresql.org/docs/10/static/libpq-connect.html
-        pqxx::connection c;
+        pqxx::connection cx;
 
         // Start a transaction.  In libpqxx, you always work in one.
-        pqxx::work w(c);
+        pqxx::work tx(cx);
 
         // work::exec1() executes a query returning a single row of data.
         // We'll just ask the database to return the number 1 to us.
-        pqxx::row r = w.exec1("SELECT 1");
+        pqxx::row r = tx.exec1("SELECT 1");
 
         // Commit your transaction.  If an exception occurred before this
         // point, execution will have left the block, and the transaction will
         // have been destroyed along the way.  In that case, the failed
         // transaction would implicitly abort instead of getting to this point.
-        w.commit();
+        tx.commit();
 
         // Look at the first and only field in the row, parse it as an integer,
         // and print it.
@@ -94,9 +94,9 @@ You can also convert an entire row to a series of C++-side types in one go,
 using the @c as member function on the row:
 
 ```cxx
-    pqxx::connection c;
-    pqxx::work w(c);
-    pqxx::row r = w.exec1("SELECT 1, 2, 'Hello'");
+    pqxx::connection cx;
+    pqxx::work tx(cx);
+    pqxx::row r = tx.exec1("SELECT 1, 2, 'Hello'");
     auto [one, two, hello] = r.as<int, int, std::string>();
     std::cout << (one + two) << ' ' << std::strlen(hello) << std::endl;
 ```
@@ -118,15 +118,15 @@ plain C-style string using its `c_str` function.
       {
         if (!argv[1]) throw std::runtime_error("Give me a string!");
 
-        pqxx::connection c;
-        pqxx::work w(c);
+        pqxx::connection cx;
+        pqxx::work tx(cx);
 
         // work::exec() returns a full result set, which can consist of any
         // number of rows.
-        pqxx::result r = w.exec("SELECT " + w.quote(argv[1]));
+        pqxx::result r = tx.exec("SELECT " + tx.quote(argv[1]));
 
         // End our transaction here.  We can still use the result afterwards.
-        w.commit();
+        tx.commit();
 
         // Print the first field of the first row.  Read it as a C string,
         // just like std::string::c_str() does.

--- a/include/pqxx/doc/prepared-statement.md
+++ b/include/pqxx/doc/prepared-statement.md
@@ -25,9 +25,9 @@ should consist of ASCII letters, digits, and underscores only, and start with
 an ASCII letter.  The name is case-sensitive.
 
 ```cxx
-    void prepare_my_statement(pqxx::connection &c)
+    void prepare_my_statement(pqxx::connection &cx)
     {
-      c.prepare(
+      cx.prepare(
           "my_statement",
           "SELECT * FROM Employee WHERE name = 'Xavier'");
     }
@@ -59,12 +59,12 @@ See @ref parameters for more about this.  And here's a simple example of
 preparing a statement and invoking it with parameters:
 
 ```cxx
-    void prepare_find(pqxx::connection &c)
+    void prepare_find(pqxx::connection &cx)
     {
       // Prepare a statement called "find" that looks for employees with a
       // given name (parameter 1) whose salary exceeds a given number
       // (parameter 2).
-      c.prepare(
+      cx.prepare(
         "find",
         "SELECT * FROM Employee WHERE name = $1 AND salary > $2");
     }

--- a/include/pqxx/nontransaction.hxx
+++ b/include/pqxx/nontransaction.hxx
@@ -57,12 +57,12 @@ class PQXX_LIBEXPORT nontransaction final : public transaction_base
 public:
   /// Constructor.
   /** Create a "dummy" transaction.
-   * @param c Connection in which this "transaction" will operate.
+   * @param cx Connection in which this "transaction" will operate.
    * @param tname Optional tname for the transaction, beginning with a letter
    * and containing only letters and digits.
    */
-  nontransaction(connection &c, std::string_view tname = ""sv) :
-          transaction_base{c, tname, std::shared_ptr<std::string>{}}
+  nontransaction(connection &cx, std::string_view tname = ""sv) :
+          transaction_base{cx, tname, std::shared_ptr<std::string>{}}
   {
     register_transaction();
   }

--- a/include/pqxx/notification.hxx
+++ b/include/pqxx/notification.hxx
@@ -58,10 +58,10 @@ class PQXX_LIBEXPORT PQXX_NOVTABLE notification_receiver
 public:
   /// Register the receiver with a connection.
   /**
-   * @param c Connnection to operate on.
+   * @param cx Connnection to operate on.
    * @param channel Name of the notification to listen for.
    */
-  notification_receiver(connection &c, std::string_view channel);
+  notification_receiver(connection &cx, std::string_view channel);
   /// Register the receiver with a connection.
   notification_receiver(notification_receiver const &) = delete;
   /// Register the receiver with a connection.

--- a/include/pqxx/robusttransaction.hxx
+++ b/include/pqxx/robusttransaction.hxx
@@ -30,8 +30,8 @@ public:
 
 protected:
   basic_robusttransaction(
-    connection &c, zview begin_command, std::string_view tname);
-  basic_robusttransaction(connection &c, zview begin_command);
+    connection &cx, zview begin_command, std::string_view tname);
+  basic_robusttransaction(connection &cx, zview begin_command);
 
 private:
   using IDType = unsigned long;
@@ -83,31 +83,31 @@ class robusttransaction final : public internal::basic_robusttransaction
 {
 public:
   /** Create robusttransaction of given name.
-   * @param c Connection inside which this robusttransaction should live.
+   * @param cx Connection inside which this robusttransaction should live.
    * @param tname optional human-readable name for this transaction.
    */
-  robusttransaction(connection &c, std::string_view tname) :
+  robusttransaction(connection &cx, std::string_view tname) :
           internal::basic_robusttransaction{
-            c, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>,
+            cx, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>,
             tname}
   {}
 
   /** Create robusttransaction of given name.
-   * @param c Connection inside which this robusttransaction should live.
+   * @param cx Connection inside which this robusttransaction should live.
    * @param tname optional human-readable name for this transaction.
    */
-  robusttransaction(connection &c, std::string &&tname) :
+  robusttransaction(connection &cx, std::string &&tname) :
           internal::basic_robusttransaction{
-            c, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>,
+            cx, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>,
             std::move(tname)}
   {}
 
   /** Create robusttransaction of given name.
-   * @param c Connection inside which this robusttransaction should live.
+   * @param cx Connection inside which this robusttransaction should live.
    */
-  explicit robusttransaction(connection &c) :
+  explicit robusttransaction(connection &cx) :
           internal::basic_robusttransaction{
-            c, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>}
+            cx, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>}
   {}
 
   virtual ~robusttransaction() noexcept override { close(); }

--- a/include/pqxx/subtransaction.hxx
+++ b/include/pqxx/subtransaction.hxx
@@ -32,17 +32,17 @@ namespace pqxx
  * dropped before re-creating it, without failing if the table did not exist:
  *
  * ```cxx
- * void do_job(connection &C)
+ * void do_job(connection &cx)
  * {
  *   string const temptable = "fleetingtable";
  *
- *   work W(C, "do_job");
- *   do_firstpart(W);
+ *   work tx(cx, "do_job");
+ *   do_firstpart(tx);
  *
  *   // Attempt to delete our temporary table if it already existed.
  *   try
  *   {
- *     subtransaction S(W, "droptemp");
+ *     subtransaction S(tx, "droptemp");
  *     S.exec0("DROP TABLE " + temptable);
  *     S.commit();
  *   }
@@ -53,11 +53,11 @@ namespace pqxx
  *   }
  *
  *   // S may have gone into a failed state and been destroyed, but the
- *   // upper-level transaction W is still fine.  We can continue to use it.
- *   W.exec0("CREATE TEMP TABLE " + temptable + "(bar integer, splat
+ *   // upper-level transaction tx is still fine.  We can continue to use it.
+ *   tx.exec0("CREATE TEMP TABLE " + temptable + "(bar integer, splat
  * varchar)");
  *
- *   do_lastpart(W);
+ *   do_lastpart(tx);
  * }
  * ```
  *

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -25,9 +25,9 @@ class PQXX_LIBEXPORT basic_transaction : public dbtransaction
 {
 protected:
   basic_transaction(
-    connection &c, zview begin_command, std::string_view tname);
-  basic_transaction(connection &c, zview begin_command, std::string &&tname);
-  basic_transaction(connection &c, zview begin_command);
+    connection &cx, zview begin_command, std::string_view tname);
+  basic_transaction(connection &cx, zview begin_command, std::string &&tname);
+  basic_transaction(connection &cx, zview begin_command);
 
   virtual ~basic_transaction() noexcept override = 0;
 
@@ -51,17 +51,17 @@ namespace pqxx
  * Usage example: double all wages.
  *
  * ```cxx
- * extern connection C;
- * work T(C);
+ * extern connection cx;
+ * work tx(cx);
  * try
  * {
- *   T.exec0("UPDATE employees SET wage=wage*2");
- *   T.commit();  // NOTE: do this inside try block
+ *   tx.exec("UPDATE employees SET wage=wage*2").no_rows();
+ *   tx.commit();  // NOTE: do this inside try block
  * }
  * catch (exception const &e)
  * {
  *   cerr << e.what() << endl;
- *   T.abort();  // Usually not needed; same happens when T's life ends.
+ *   tx.abort();  // Usually not needed; same happens when tx's life ends.
  * }
  * ```
  */
@@ -73,23 +73,23 @@ class transaction final : public internal::basic_transaction
 public:
   /// Begin a transaction.
   /**
-   * @param c Connection for this transaction to operate on.
+   * @param cx Connection for this transaction to operate on.
    * @param tname Optional name for transaction.  Must begin with a letter and
    * may contain letters and digits only.
    */
-  transaction(connection &c, std::string_view tname) :
+  transaction(connection &cx, std::string_view tname) :
           internal::basic_transaction{
-            c, internal::begin_cmd<ISOLATION, READWRITE>, tname}
+            cx, internal::begin_cmd<ISOLATION, READWRITE>, tname}
   {}
 
   /// Begin a transaction.
   /**
-   * @param c Connection for this transaction to operate on.
+   * @param cx Connection for this transaction to operate on.
    * may contain letters and digits only.
    */
-  explicit transaction(connection &c) :
+  explicit transaction(connection &cx) :
           internal::basic_transaction{
-            c, internal::begin_cmd<ISOLATION, READWRITE>}
+            cx, internal::begin_cmd<ISOLATION, READWRITE>}
   {}
 
   virtual ~transaction() noexcept override { close(); }

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -1034,9 +1034,9 @@ protected:
    * and digits only.
    */
   transaction_base(
-    connection &c, std::string_view tname,
+    connection &cx, std::string_view tname,
     std::shared_ptr<std::string> rollback_cmd) :
-          m_conn{c}, m_name{tname}, m_rollback_cmd{rollback_cmd}
+          m_conn{cx}, m_name{tname}, m_rollback_cmd{rollback_cmd}
   {}
 
   /// Create a transaction (to be called by implementation classes only).
@@ -1045,10 +1045,10 @@ protected:
    * The name, if nonempty, must begin with a letter and may contain letters
    * and digits only.
    */
-  transaction_base(connection &c, std::string_view tname);
+  transaction_base(connection &cx, std::string_view tname);
 
   /// Create a transaction (to be called by implementation classes only).
-  explicit transaction_base(connection &c);
+  explicit transaction_base(connection &cx);
 
   /// Register this transaction with the connection.
   void register_transaction();

--- a/src/largeobject.cxx
+++ b/src/largeobject.cxx
@@ -144,11 +144,11 @@ pqxx::largeobject::raw_connection(dbtransaction const &t)
 
 
 std::string PQXX_COLD
-pqxx::largeobject::reason(connection const &c, int err) const
+pqxx::largeobject::reason(connection const &cx, int err) const
 {
   if (err == ENOMEM)
     return "Out of memory";
-  return pqxx::internal::gate::const_connection_largeobject{c}.error_message();
+  return pqxx::internal::gate::const_connection_largeobject{cx}.error_message();
 }
 
 

--- a/src/notification.cxx
+++ b/src/notification.cxx
@@ -21,10 +21,10 @@
 
 
 pqxx::notification_receiver::notification_receiver(
-  connection &c, std::string_view channel) :
-        m_conn{c}, m_channel{channel}
+  connection &cx, std::string_view channel) :
+        m_conn{cx}, m_channel{channel}
 {
-  pqxx::internal::gate::connection_notification_receiver{c}.add_receiver(this);
+  pqxx::internal::gate::connection_notification_receiver{cx}.add_receiver(this);
 }
 
 

--- a/src/robusttransaction.cxx
+++ b/src/robusttransaction.cxx
@@ -76,9 +76,9 @@ tx_stat query_status(std::string const &xid, std::string const &conn_str)
 {
   static std::string const name{"robusttxck"sv};
   auto const query{pqxx::internal::concat("SELECT txid_status(", xid, ")")};
-  pqxx::connection c{conn_str};
-  pqxx::nontransaction w{c, name};
-  auto const status_row{w.exec(query).one_row()};
+  pqxx::connection cx{conn_str};
+  pqxx::nontransaction tx{cx, name};
+  auto const status_row{tx.exec(query).one_row()};
   auto const status_field{status_row[0]};
   if (std::size(status_field) == 0)
     throw pqxx::internal_error{"Transaction status string is empty."};
@@ -102,16 +102,16 @@ void pqxx::internal::basic_robusttransaction::init(zview begin_command)
 
 
 pqxx::internal::basic_robusttransaction::basic_robusttransaction(
-  connection &c, zview begin_command, std::string_view tname) :
-        dbtransaction(c, tname), m_conn_string{c.connection_string()}
+  connection &cx, zview begin_command, std::string_view tname) :
+        dbtransaction(cx, tname), m_conn_string{cx.connection_string()}
 {
   init(begin_command);
 }
 
 
 pqxx::internal::basic_robusttransaction::basic_robusttransaction(
-  connection &c, zview begin_command) :
-        dbtransaction(c), m_conn_string{c.connection_string()}
+  connection &cx, zview begin_command) :
+        dbtransaction(cx), m_conn_string{cx.connection_string()}
 {
   init(begin_command);
 }

--- a/src/transaction.cxx
+++ b/src/transaction.cxx
@@ -22,8 +22,8 @@
 
 
 pqxx::internal::basic_transaction::basic_transaction(
-  connection &c, zview begin_command, std::string_view tname) :
-        dbtransaction(c, tname)
+  connection &cx, zview begin_command, std::string_view tname) :
+        dbtransaction(cx, tname)
 {
   register_transaction();
   direct_exec(begin_command);
@@ -31,8 +31,8 @@ pqxx::internal::basic_transaction::basic_transaction(
 
 
 pqxx::internal::basic_transaction::basic_transaction(
-  connection &c, zview begin_command, std::string &&tname) :
-        dbtransaction(c, std::move(tname))
+  connection &cx, zview begin_command, std::string &&tname) :
+        dbtransaction(cx, std::move(tname))
 {
   register_transaction();
   direct_exec(begin_command);
@@ -40,8 +40,8 @@ pqxx::internal::basic_transaction::basic_transaction(
 
 
 pqxx::internal::basic_transaction::basic_transaction(
-  connection &c, zview begin_command) :
-        dbtransaction(c)
+  connection &cx, zview begin_command) :
+        dbtransaction(cx)
 {
   register_transaction();
   direct_exec(begin_command);

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -45,14 +45,14 @@ std::shared_ptr<std::string> make_rollback_cmd()
 }
 } // namespace
 
-pqxx::transaction_base::transaction_base(connection &c) :
-        m_conn{c}, m_rollback_cmd{make_rollback_cmd()}
+pqxx::transaction_base::transaction_base(connection &cx) :
+        m_conn{cx}, m_rollback_cmd{make_rollback_cmd()}
 {}
 
 
 pqxx::transaction_base::transaction_base(
-  connection &c, std::string_view tname) :
-        m_conn{c}, m_name{tname}, m_rollback_cmd{make_rollback_cmd()}
+  connection &cx, std::string_view tname) :
+        m_conn{cx}, m_name{tname}, m_rollback_cmd{make_rollback_cmd()}
 {}
 
 

--- a/test/test02.cxx
+++ b/test/test02.cxx
@@ -25,19 +25,19 @@ void test_002()
 
   // Set up connection to database
   std::string ConnectString;
-  connection C{ConnectString};
+  connection cx{ConnectString};
 
   // Start transaction within context of connection.
-  work T{C, "test2"};
+  work tx{cx, "test2"};
 
   // Perform query within transaction.
-  result R(T.exec("SELECT * FROM pg_tables"));
+  result R(tx.exec("SELECT * FROM pg_tables"));
 
   // Let's keep the database waiting as briefly as possible: commit now,
   // before we start processing results.  We could do this later, or since
   // we're not making any changes in the database that need to be committed,
   // we could in this case even omit it altogether.
-  T.commit();
+  tx.commit();
 
   // Ah, this version of postgres will tell you which table a column in a
   // result came from.  Let's just test that functionality...

--- a/test/test10.cxx
+++ b/test/test10.cxx
@@ -95,10 +95,10 @@ void Test(connection &C, bool ExplicitAbort)
 void test_abort()
 {
   connection cx;
-  nontransaction t{cx};
-  test::create_pqxxevents(t);
-  connection &c(t.conn());
-  t.commit();
+  nontransaction tx{cx};
+  test::create_pqxxevents(tx);
+  connection &c(tx.conn());
+  tx.commit();
   Test(c, true);
   Test(c, false);
 }

--- a/test/test13.cxx
+++ b/test/test13.cxx
@@ -35,9 +35,9 @@ struct deliberate_error : std::exception
 {};
 
 
-void failed_insert(connection &C, std::string const &table)
+void failed_insert(connection &cx, std::string const &table)
 {
-  work tx(C);
+  work tx(cx);
   result R = tx.exec(
                  "INSERT INTO " + table + " VALUES (" + to_string(BoringYear) +
                  ", "

--- a/test/test89.cxx
+++ b/test/test89.cxx
@@ -11,32 +11,32 @@ namespace
 {
 void test_089()
 {
-  pqxx::connection C;
+  pqxx::connection cx;
 
   // Trivial test: create subtransactions, and commit/abort
-  pqxx::work T0(C, "T0");
-  T0.exec("SELECT 'T0 starts'").one_row();
-  pqxx::subtransaction T0a(T0, "T0a");
-  T0a.commit();
-  pqxx::subtransaction T0b(T0, "T0b");
-  T0b.abort();
-  T0.exec("SELECT 'T0 ends'").one_row();
-  T0.commit();
+  pqxx::work tx0(cx, "tx0");
+  tx0.exec("SELECT 'tx0 starts'").one_row();
+  pqxx::subtransaction tx0a(tx0, "tx0a");
+  tx0a.commit();
+  pqxx::subtransaction tx0b(tx0, "tx0b");
+  tx0b.abort();
+  tx0.exec("SELECT 'tx0 ends'").one_row();
+  tx0.commit();
 
   // Basic functionality: perform query in subtransaction; abort, continue
-  pqxx::work T1(C, "T1");
-  T1.exec("SELECT 'T1 starts'").one_row();
-  pqxx::subtransaction T1a(T1, "T1a");
-  T1a.exec("SELECT '  a'").one_row();
-  T1a.commit();
-  pqxx::subtransaction T1b(T1, "T1b");
-  T1b.exec("SELECT '  b'").one_row();
-  T1b.abort();
-  pqxx::subtransaction T1c(T1, "T1c");
-  T1c.exec("SELECT '  c'").one_row();
-  T1c.commit();
-  T1.exec("SELECT 'T1 ends'").one_row();
-  T1.commit();
+  pqxx::work tx1(cx, "tx1");
+  tx1.exec("SELECT 'tx1 starts'").one_row();
+  pqxx::subtransaction tx1a(tx1, "tx1a");
+  tx1a.exec("SELECT '  a'").one_row();
+  tx1a.commit();
+  pqxx::subtransaction tx1b(tx1, "tx1b");
+  tx1b.exec("SELECT '  b'").one_row();
+  tx1b.abort();
+  pqxx::subtransaction tx1c(tx1, "tx1c");
+  tx1c.exec("SELECT '  c'").one_row();
+  tx1c.commit();
+  tx1.exec("SELECT 'tx1 ends'").one_row();
+  tx1.commit();
 }
 } // namespace
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -450,12 +450,12 @@ void test_array_generate()
 
 void test_array_roundtrip()
 {
-  pqxx::connection c;
-  pqxx::work w{c};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
 
   std::vector<int> const in{0, 1, 2, 3, 5};
   auto const text{
-    w.query_value<std::string>("SELECT " + c.quote(in) + "::integer[]")};
+    tx.query_value<std::string>("SELECT " + cx.quote(in) + "::integer[]")};
   pqxx::array_parser parser{text};
   auto item{parser.get_next()};
   PQXX_CHECK_EQUAL(

--- a/test/unit/test_escape.cxx
+++ b/test/unit/test_escape.cxx
@@ -10,11 +10,11 @@ using namespace std::literals;
 
 
 void compare_esc(
-  pqxx::connection &c, pqxx::transaction_base &t, char const text[])
+  pqxx::connection &cx, pqxx::transaction_base &t, char const text[])
 {
   std::size_t const len{std::size(std::string{text})};
   PQXX_CHECK_EQUAL(
-    c.esc(std::string_view{text, len}), t.esc(std::string_view{text, len}),
+    cx.esc(std::string_view{text, len}), t.esc(std::string_view{text, len}),
     "Connection & transaction escape differently.");
 
   PQXX_CHECK_EQUAL(
@@ -37,7 +37,7 @@ void compare_esc(
 }
 
 
-void test_esc(pqxx::connection &c, pqxx::transaction_base &t)
+void test_esc(pqxx::connection &cx, pqxx::transaction_base &t)
 {
   PQXX_CHECK_EQUAL(
     t.esc(std::string_view{"", 0}), "",
@@ -49,11 +49,11 @@ void test_esc(pqxx::connection &c, pqxx::transaction_base &t)
     t.esc(std::string_view{"hello"}), "hello", "Trivial escape went wrong.");
   char const *const escstrings[]{"x", " ", "", nullptr};
   for (std::size_t i{0}; escstrings[i] != nullptr; ++i)
-    compare_esc(c, t, escstrings[i]);
+    compare_esc(cx, t, escstrings[i]);
 }
 
 
-void test_quote(pqxx::connection &c, pqxx::transaction_base &t)
+void test_quote(pqxx::connection &cx, pqxx::transaction_base &t)
 {
   PQXX_CHECK_EQUAL(t.quote("x"), "'x'", "Basic quote() fails.");
   PQXX_CHECK_EQUAL(
@@ -65,7 +65,7 @@ void test_quote(pqxx::connection &c, pqxx::transaction_base &t)
     t.quote(std::string{"'"}), "''''", "Escaping quotes goes wrong.");
 
   PQXX_CHECK_EQUAL(
-    t.quote("x"), c.quote("x"),
+    t.quote("x"), cx.quote("x"),
     "Connection and transaction quote differently.");
 
   char const *test_strings[]{"",   "x",   "\\", "\\\\", "'",

--- a/test/unit/test_field.cxx
+++ b/test/unit/test_field.cxx
@@ -6,8 +6,8 @@ namespace
 {
 void test_field()
 {
-  pqxx::connection c;
-  pqxx::work tx{c};
+  pqxx::connection cx;
+  pqxx::work tx{cx};
   auto const r1{tx.exec("SELECT 9").one_row()};
   auto const &f1{r1[0]};
 

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -19,8 +19,8 @@ public:
   std::string payload;
   int backend_pid;
 
-  TestReceiver(pqxx::connection &c, std::string const &channel_name) :
-          pqxx::notification_receiver(c, channel_name),
+  TestReceiver(pqxx::connection &cx, std::string const &channel_name) :
+          pqxx::notification_receiver(cx, channel_name),
           payload(),
           backend_pid(0)
   {}


### PR DESCRIPTION
I've standardised on `cx` and `tx` for the typical names of a connection and a transaction, respectively.  But I've gone through a bunch of naming schemes over the almost quarter century of libpqxx, and I still found some "legacy" names.