### PR TITLE
Retire references to `exec_params()` & `exec_prepared()`.

### DIFF
--- a/include/pqxx/doc/escaping.md
+++ b/include/pqxx/doc/escaping.md
@@ -10,15 +10,16 @@ an SQL injection vulnerability there, where users can enter nasty stuff like
 discover when `name` happens to be "d'Arcy".  Or...  Well, I was born in a
 place called _'s-Gravenhage..._
 
-There are two ways of dealing with this.  One is statement _parameters:_ some
-SQL execution functions in libpqxx let you write placeholders for such values
-in your SQL, like `$1`, `$2`, etc.  When you then pass your variables as the
-parameter values, they get substituted into the query, but in a safe form.
+There are two ways of dealing with this.  One is statement @ref parameters —
+many SQL execution functions in libpqxx let you write _placeholders_ for
+variable values in your SQL, like `$1`, `$2`, etc.  When you then pass your
+variables as the parameter values, they get substituted into the query, but in
+a safe form.
 
 The other is to _escape_ the values yourself, before inserting them into your
 SQL.  This isn't as safe as using parameters, since you need to be really
-conscientious about it.  Use parameters if you can... and libpqxx will do the
-escaping for you.
+conscientious about it.  Use @ref parameters if you can... and libpqxx will do
+the escaping for you.
 
 In escaping, quotes and other problematic characters are marked as "this is
 just a character inside the string, not the end of the string."  There are
@@ -44,7 +45,7 @@ authorized to view.  The userid and password strings are variables entered
 by the user himself.
 
 Now, if the user is actually an attacker who knows (or can guess) the
-general shape of this SQL statement, imagine getting following password:
+general shape of this SQL statement, imagine getting the following password:
 
 ```text
     x') OR ('x' = 'x
@@ -89,7 +90,7 @@ they can't "break out" of the quoted SQL string they were meant to go into:
 
 If you look carefully, you'll see that thanks to the added escape characters
 (a single-quote is escaped in SQL by doubling it) all we get is a very
-strange-looking password string--but not a change in the SQL statement.
+strange-looking password string — but not a change in the SQL statement.
 
 In practice, of course, it would be better to use parameters:
 

--- a/include/pqxx/doc/escaping.md
+++ b/include/pqxx/doc/escaping.md
@@ -94,9 +94,9 @@ strange-looking password string--but not a change in the SQL statement.
 In practice, of course, it would be better to use parameters:
 
 ```cxx
-    tx.exec_params(
+    tx.exec(
         " SELECT number, amount "
         "FROM account "
         "WHERE allowed_to_see($1, $2)",
-	userid, password);
+	pqxx::params{userid, password});
 ```

--- a/include/pqxx/doc/getting-started.md
+++ b/include/pqxx/doc/getting-started.md
@@ -123,7 +123,7 @@ plain C-style string using its `c_str` function.
 
         // work::exec() returns a full result set, which can consist of any
         // number of rows.
-        pqxx::result r = tx.exec("SELECT " + tx.quote(argv[1]));
+        pqxx::result r = tx.exec("SELECT $1", pqxx::params{argv[1]});
 
         // End our transaction here.  We can still use the result afterwards.
         tx.commit();

--- a/include/pqxx/internal/statement_parameters.hxx
+++ b/include/pqxx/internal/statement_parameters.hxx
@@ -30,25 +30,7 @@ constexpr inline auto const iterator_identity{
   [](decltype(*std::declval<ITERATOR>()) x) { return x; }};
 
 
-/// Marker type: pass a dynamically-determined number of statement parameters.
-/** @deprecated Use @ref params instead.
- *
- * Normally when invoking a prepared or parameterised statement, the number
- * of parameters is known at compile time.  For instance,
- * `t.exec_prepared("foo", 1, "x");` executes statement `foo` with two
- * parameters, an `int` and a C string.
- *
- * But sometimes you may want to pass a number of parameters known only at run
- * time.  In those cases, a @ref dynamic_params encodes a dynamically
- * determined number of parameters.  You can mix these with regular, static
- * parameter lists, and you can re-use them for multiple statement invocations.
- *
- * A dynamic_params object does not store copies of its parameters, so make
- * sure they remain accessible until you've executed the statement.
- *
- * The ACCESSOR is an optional callable (such as a lambda).  If you pass an
- * accessor `a`, then each parameter `p` goes into your statement as `a(p)`.
- */
+/// @deprecated Use @ref params instead.
 template<typename IT, typename ACCESSOR = decltype(iterator_identity<IT>)>
 class dynamic_params
 {

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -25,22 +25,9 @@
 namespace pqxx
 {
 /// Build a parameter list for a parameterised or prepared statement.
-/** When calling a parameterised statement or a prepared statement, in some
- * cases you can pass parameters into the statement directly in the invocation,
- * as additional arguments to e.g. `exec_prepared` or `exec_params`.  But not
- * all functions accept that, plus, sometimes you want to build the lists at
- * run time.
- *
- * In those situations, you can create a `params` and append your parameters
- * into that, one by one.  Then you pass the `params` to  the function that
- * executes your SQL statement.
- *
- * Combinations also work: if you have a `params` containing a string
- * parameter, and you call `exec_params` with an `int` argument followed by
- * your `params`, you'll be passing the `int` as the first parameter and
- * the string as the second.  You can even insert a `params` in a `params`,
- * or pass two `params` objects to a statement.  In the end all the embedded
- * parameters show up in their natural order.
+/** When calling a parameterised statement or a prepared statement, in many
+ * cases you can pass parameters into the statement in the form of a
+ * `pqxx::params` object.
  */
 class PQXX_LIBEXPORT params
 {
@@ -298,24 +285,7 @@ private:
 /// @deprecated The new @ref params class replaces all of this.
 namespace pqxx::prepare
 {
-/// Pass a number of statement parameters only known at runtime.
-/** @deprecated Use @ref params instead.
- *
- * When you call any of the `exec_params` functions, the number of arguments
- * is normally known at compile time.  This helper function supports the case
- * where it is not.
- *
- * Use this function to pass a variable number of parameters, based on a
- * sequence ranging from `begin` to `end` exclusively.
- *
- * The technique combines with the regular static parameters.  You can use it
- * to insert dynamic parameter lists in any place, or places, among the call's
- * parameters.  You can even insert multiple dynamic sequences.
- *
- * @param begin A pointer or iterator for iterating parameters.
- * @param end A pointer or iterator for iterating parameters.
- * @return An object representing the parameters.
- */
+/// @deprecated Use @ref params instead.
 template<typename IT>
 [[deprecated("Use the params class instead.")]] constexpr inline auto
 make_dynamic_params(IT begin, IT end)
@@ -324,23 +294,7 @@ make_dynamic_params(IT begin, IT end)
 }
 
 
-/// Pass a number of statement parameters only known at runtime.
-/** @deprecated Use @ref params instead.
- *
- * When you call any of the `exec_params` functions, the number of arguments
- * is normally known at compile time.  This helper function supports the case
- * where it is not.
- *
- * Use this function to pass a variable number of parameters, based on a
- * container of parameter values.
- *
- * The technique combines with the regular static parameters.  You can use it
- * to insert dynamic parameter lists in any place, or places, among the call's
- * parameters.  You can even insert multiple dynamic containers.
- *
- * @param container A container of parameter values.
- * @return An object representing the parameters.
- */
+/// @deprecated Use @ref params instead.
 template<typename C>
 [[deprecated("Use the params class instead.")]] constexpr inline auto
 make_dynamic_params(C const &container)
@@ -352,24 +306,7 @@ make_dynamic_params(C const &container)
 }
 
 
-/// Pass a number of statement parameters only known at runtime.
-/** @deprecated Use @ref params instead.
- *
- * When you call any of the `exec_params` functions, the number of arguments
- * is normally known at compile time.  This helper function supports the case
- * where it is not.
- *
- * Use this function to pass a variable number of parameters, based on a
- * container of parameter values.
- *
- * The technique combines with the regular static parameters.  You can use it
- * to insert dynamic parameter lists in any place, or places, among the call's
- * parameters.  You can even insert multiple dynamic containers.
- *
- * @param container A container of parameter values.
- * @param accessor For each parameter `p`, pass `accessor(p)`.
- * @return An object representing the parameters.
- */
+/// @deprecated Use @ref params instead.
 template<typename C, typename ACCESSOR>
 [[deprecated("Use the params class instead.")]] constexpr inline auto
 make_dynamic_params(C &container, ACCESSOR accessor)

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -357,6 +357,12 @@ public:
     return *this;
   }
 
+  /// Expect that result consists of exactly 1 row and 1 column.
+  /** @return The one @ref pqxx::field in the result.
+   * @throw @ref usage_error otherwise.
+   */
+  field one_field() const;
+
 private:
   using data_pointer = std::shared_ptr<internal::pq::PGresult const>;
 

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -465,7 +465,7 @@ public:
   TYPE query_value(zview query, std::string_view desc)
   {
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
-    return exec(query, desc).expect_columns(1).one_row()[0].as<TYPE>();
+    return exec(query, desc).one_field().as<TYPE>();
 #include "pqxx/internal/ignore-deprecated-post.hxx"
   }
 
@@ -478,7 +478,7 @@ public:
    */
   template<typename TYPE> TYPE query_value(zview query)
   {
-    return exec(query).expect_columns(1).one_row()[0].as<TYPE>();
+    return exec(query).one_field().as<TYPE>();
   }
 
   /// Perform query returning exactly one row, and convert its fields.
@@ -837,7 +837,7 @@ public:
    */
   template<typename TYPE> TYPE query_value(zview query, params const &parms)
   {
-    return exec(query, parms).expect_columns(1).one_row()[0].as<TYPE>();
+    return exec(query, parms).expect_columns(1).one_field().as<TYPE>();
   }
 
   /// Perform query returning exactly one row, and convert its fields.
@@ -928,7 +928,7 @@ public:
   template<typename TYPE>
   TYPE query_value(prepped statement, params const &parms = {})
   {
-    return exec(statement, parms).expect_columns(1).one_row()[0].as<TYPE>();
+    return exec(statement, parms).expect_columns(1).one_field().as<TYPE>();
   }
 
   // C++20: Concept like std::invocable, but without specifying param types.

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -291,9 +291,9 @@ std::string pqxx::connection::get_variable(std::string_view var)
 std::string pqxx::connection::get_var(std::string_view var)
 {
   // (Variables can't be null, so far as I can make out.)
-  return exec(
-    internal::concat("SHOW "sv, quote_name(var))
-  ).one_field().as<std::string>();
+  return exec(internal::concat("SHOW "sv, quote_name(var)))
+    .one_field()
+    .as<std::string>();
 }
 
 

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -291,8 +291,9 @@ std::string pqxx::connection::get_variable(std::string_view var)
 std::string pqxx::connection::get_var(std::string_view var)
 {
   // (Variables can't be null, so far as I can make out.)
-  return exec(internal::concat("SHOW "sv, quote_name(var)))[0][0]
-    .as<std::string>();
+  return exec(
+    internal::concat("SHOW "sv, quote_name(var))
+  ).one_field().as<std::string>();
 }
 
 

--- a/src/largeobject.cxx
+++ b/src/largeobject.cxx
@@ -148,7 +148,8 @@ pqxx::largeobject::reason(connection const &cx, int err) const
 {
   if (err == ENOMEM)
     return "Out of memory";
-  return pqxx::internal::gate::const_connection_largeobject{cx}.error_message();
+  return pqxx::internal::gate::const_connection_largeobject{cx}
+    .error_message();
 }
 
 

--- a/src/notification.cxx
+++ b/src/notification.cxx
@@ -24,7 +24,8 @@ pqxx::notification_receiver::notification_receiver(
   connection &cx, std::string_view channel) :
         m_conn{cx}, m_channel{channel}
 {
-  pqxx::internal::gate::connection_notification_receiver{cx}.add_receiver(this);
+  pqxx::internal::gate::connection_notification_receiver{cx}.add_receiver(
+    this);
 }
 
 

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -541,6 +541,13 @@ pqxx::row pqxx::result::one_row() const
 }
 
 
+pqxx::field pqxx::result::one_field() const
+{
+  expect_columns(1);
+  return one_row()[0];
+}
+
+
 std::optional<pqxx::row> pqxx::result::opt_row() const
 {
   auto const sz{size()};

--- a/src/robusttransaction.cxx
+++ b/src/robusttransaction.cxx
@@ -97,7 +97,7 @@ void pqxx::internal::basic_robusttransaction::init(zview begin_command)
     std::make_shared<std::string>("SELECT txid_current()"sv)};
   m_backendpid = conn().backendpid();
   direct_exec(begin_command);
-  direct_exec(txid_q)[0][0].to(m_xid);
+  direct_exec(txid_q).one_field().to(m_xid);
 }
 
 

--- a/src/transaction.cxx
+++ b/src/transaction.cxx
@@ -79,7 +79,7 @@ void pqxx::internal::basic_transaction::do_commit()
     // Strip newline.  It was only needed for process_notice().
     msg.pop_back();
     throw in_doubt_error{
-      std::move(msg)
+      msg
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
         ,
       e.location
@@ -101,7 +101,7 @@ void pqxx::internal::basic_transaction::do_commit()
       process_notice(msg);
       // Strip newline.  It was only needed for process_notice().
       msg.pop_back();
-      throw in_doubt_error{std::move(msg)};
+      throw in_doubt_error{msg};
     }
     else
     {

--- a/src/transaction.cxx
+++ b/src/transaction.cxx
@@ -81,7 +81,7 @@ void pqxx::internal::basic_transaction::do_commit()
     throw in_doubt_error{
       msg
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
-        ,
+      ,
       e.location
 #endif
     };

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -102,10 +102,8 @@ void pqxx::internal::check_unique_unregister(
 namespace
 {
 constexpr std::array<char, 16u> hex_digits{
-  '0', '1', '2', '3',
-  '4', '5', '6', '7',
-  '8', '9', 'a', 'b',
-  'c', 'd', 'e', 'f',
+  '0', '1', '2', '3', '4', '5', '6', '7',
+  '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
 };
 
 

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -101,9 +101,12 @@ void pqxx::internal::check_unique_unregister(
 
 namespace
 {
-constexpr std::array<char, 16u> hex_digits{'0', '1', '2', '3', '4', '5',
-                                           '6', '7', '8', '9', 'a', 'b',
-                                           'c', 'd', 'e', 'f'};
+constexpr std::array<char, 16u> hex_digits{
+  '0', '1', '2', '3',
+  '4', '5', '6', '7',
+  '8', '9', 'a', 'b',
+  'c', 'd', 'e', 'f',
+};
 
 
 /// Translate a number (must be between 0 and 16 exclusive) to a hex digit.

--- a/test/test46.cxx
+++ b/test/test46.cxx
@@ -18,43 +18,43 @@ void test_046()
   connection cx;
   work tx{cx};
 
-  row R{tx.exec("SELECT count(*) FROM pg_tables").one_row()};
+  pqxx::field R{tx.exec("SELECT count(*) FROM pg_tables").one_field()};
 
   // Read the value into a stringstream.
   std::stringstream I;
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
-  I << R[0];
+  I << R;
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 
   // Now convert the stringstream into a numeric type
   long L{}, L2{};
   I >> L;
 
-  R[0].to(L2);
+  R.to(L2);
   PQXX_CHECK_EQUAL(L, L2, "Inconsistency between conversion methods.");
 
   float F{}, F2{};
   std::stringstream I2;
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
-  I2 << R[0];
+  I2 << R;
 #include "pqxx/internal/ignore-deprecated-post.hxx"
   I2 >> F;
-  R[0].to(F2);
+  R.to(F2);
   PQXX_CHECK_BOUNDS(F2, F - 0.01, F + 0.01, "Bad floating-point result.");
 
-  auto F3{from_string<float>(R[0].c_str())};
+  auto F3{from_string<float>(R.c_str())};
   PQXX_CHECK_BOUNDS(F3, F - 0.01, F + 0.01, "Bad float from from_string.");
 
-  auto D{from_string<double>(R[0].c_str())};
+  auto D{from_string<double>(R.c_str())};
   PQXX_CHECK_BOUNDS(D, F - 0.01, F + 0.01, "Bad double from from_string.");
 
-  auto LD{from_string<long double>(R[0].c_str())};
+  auto LD{from_string<long double>(R.c_str())};
   PQXX_CHECK_BOUNDS(
     LD, F - 0.01, F + 0.01, "Bad long double from from_string.");
 
-  auto S{from_string<std::string>(R[0].c_str())},
-    S2{from_string<std::string>(std::string{R[0].c_str()})},
-    S3{from_string<std::string>(R[0])};
+  auto S{from_string<std::string>(R.c_str())},
+    S2{from_string<std::string>(std::string{R.c_str()})},
+    S3{from_string<std::string>(R)};
 
   PQXX_CHECK_EQUAL(
     S2, S,

--- a/test/test69.cxx
+++ b/test/test69.cxx
@@ -31,10 +31,10 @@ void TestPipeline(pipeline &P, int numqueries)
 
     if (res != 0)
       PQXX_CHECK_EQUAL(
-        R.second[0][0].as<int>(), res,
+        R.second.one_field().as<int>(), res,
         "Got unexpected result out of pipeline.");
 
-    res = R.second[0][0].as<int>();
+    res = R.second.one_field().as<int>();
   }
 
   PQXX_CHECK(std::empty(P), "Pipeline not empty after retrieval.");

--- a/test/test76.cxx
+++ b/test/test76.cxx
@@ -10,17 +10,17 @@ void test_076()
   pqxx::connection cx;
   pqxx::nontransaction tx{cx};
 
-  auto RFalse{tx.exec("SELECT 1=0").one_row()},
-    RTrue{tx.exec("SELECT 1=1").one_row()};
-  auto False{pqxx::from_string<bool>(RFalse[0])},
-    True{pqxx::from_string<bool>(RTrue[0])};
+  auto RFalse{tx.exec("SELECT 1=0").one_field()},
+    RTrue{tx.exec("SELECT 1=1").one_field()};
+  auto False{pqxx::from_string<bool>(RFalse)},
+    True{pqxx::from_string<bool>(RTrue)};
   PQXX_CHECK(not False, "False bool converted to true.");
   PQXX_CHECK(True, "True bool converted to false.");
 
-  RFalse = tx.exec("SELECT " + pqxx::to_string(False)).one_row();
-  RTrue = tx.exec("SELECT " + pqxx::to_string(True)).one_row();
-  False = pqxx::from_string<bool>(RFalse[0]);
-  True = pqxx::from_string<bool>(RTrue[0]);
+  RFalse = tx.exec("SELECT " + pqxx::to_string(False)).one_field();
+  RTrue = tx.exec("SELECT " + pqxx::to_string(True)).one_field();
+  False = pqxx::from_string<bool>(RFalse);
+  True = pqxx::from_string<bool>(RTrue);
   PQXX_CHECK(not False, "False bool converted to true.");
   PQXX_CHECK(True, "True bool converted to false.");
 
@@ -30,7 +30,7 @@ void test_076()
     auto s{pqxx::from_string<short>(pqxx::to_string(svals[i]))};
     PQXX_CHECK_EQUAL(s, svals[i], "short/string conversion not bijective.");
     s = pqxx::from_string<short>(
-      tx.exec("SELECT " + pqxx::to_string(svals[i])).one_row()[0].c_str());
+      tx.exec("SELECT " + pqxx::to_string(svals[i])).one_field().c_str());
     PQXX_CHECK_EQUAL(s, svals[i], "Roundtrip through backend changed short.");
   }
 
@@ -42,7 +42,7 @@ void test_076()
       u, uvals[i], "unsigned short/string conversion not bijective.");
 
     u = pqxx::from_string<unsigned short>(
-      tx.exec("SELECT " + pqxx::to_string(uvals[i])).one_row()[0].c_str());
+      tx.exec("SELECT " + pqxx::to_string(uvals[i])).one_field().c_str());
     PQXX_CHECK_EQUAL(
       u, uvals[i], "Roundtrip through backend changed unsigned short.");
   }

--- a/test/test84.cxx
+++ b/test/test84.cxx
@@ -49,7 +49,7 @@ void test_084()
   // supposed to be easy; normally we'd only construct streams around existing
   // SQL cursors if they were being returned by functions.
   pqxx::icursorstream C{
-    tx, tx.exec("SELECT '" + tx.esc(CurName) + "'")[0][0], GetRows};
+    tx, tx.exec("SELECT $1", pqxx::params{CurName}).one_row()[0], GetRows};
 
   // Create parallel cursor to check results
   pqxx::icursorstream C2{tx, Query, "CHECKCUR", GetRows};

--- a/test/test84.cxx
+++ b/test/test84.cxx
@@ -49,7 +49,7 @@ void test_084()
   // supposed to be easy; normally we'd only construct streams around existing
   // SQL cursors if they were being returned by functions.
   pqxx::icursorstream C{
-    tx, tx.exec("SELECT $1", pqxx::params{CurName}).one_row()[0], GetRows};
+    tx, tx.exec("SELECT $1", pqxx::params{CurName}).one_field(), GetRows};
 
   // Create parallel cursor to check results
   pqxx::icursorstream C2{tx, Query, "CHECKCUR", GetRows};

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -455,7 +455,7 @@ void test_array_roundtrip()
 
   std::vector<int> const in{0, 1, 2, 3, 5};
   auto const text{
-    tx.query_value<std::string>("SELECT " + cx.quote(in) + "::integer[]")};
+    tx.query_value<std::string>("SELECT $1::integer[]", pqxx::params{in})};
   pqxx::array_parser parser{text};
   auto item{parser.get_next()};
   PQXX_CHECK_EQUAL(

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -497,8 +497,8 @@ void test_array_strings()
 
   for (auto const &input : inputs)
   {
-    auto const r{tx.exec("SELECT ARRAY[$1]", pqxx::params{input})};
-    pqxx::array_parser parser{r[0][0].as<std::string_view>()};
+    auto const f{tx.exec("SELECT ARRAY[$1]", pqxx::params{input}).one_field()};
+    pqxx::array_parser parser{f.as<std::string_view>()};
     auto [start_juncture, start_value]{parser.get_next()};
     pqxx::ignore_unused(start_value);
     PQXX_CHECK_EQUAL(

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -12,7 +12,8 @@ pqxx::binarystring
 make_binarystring(pqxx::transaction_base &T, std::string content)
 {
 #include "pqxx/internal/ignore-deprecated-pre.hxx"
-  return pqxx::binarystring(T.exec1("SELECT " + T.quote_raw(content))[0]);
+  return pqxx::binarystring(
+    T.exec("SELECT " + T.quote_raw(content)).one_field());
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -86,10 +86,9 @@ void test_binarystring()
     tx.quote(b), tx.quote_raw(simple), "Binary quoting is broken.");
   PQXX_CHECK_EQUAL(
     pqxx::binarystring(
-      tx.query_value<std::string>("SELECT $1", pqxx::params{b})
-    ).str(),
-    simple,
-    "Binary string is not idempotent.");
+      tx.query_value<std::string>("SELECT $1", pqxx::params{b}))
+      .str(),
+    simple, "Binary string is not idempotent.");
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 
   std::string const bytes("\x01\x23\x23\xa1\x2b\x0c\xff");

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -84,7 +84,10 @@ void test_binarystring()
   PQXX_CHECK_EQUAL(
     tx.quote(b), tx.quote_raw(simple), "Binary quoting is broken.");
   PQXX_CHECK_EQUAL(
-    pqxx::binarystring(tx.exec1("SELECT " + tx.quote(b))[0]).str(), simple,
+    pqxx::binarystring(
+      tx.query_value<std::string>("SELECT $1", pqxx::params{b})
+    ).str(),
+    simple,
     "Binary string is not idempotent.");
 #include "pqxx/internal/ignore-deprecated-post.hxx"
 

--- a/test/unit/test_composite.cxx
+++ b/test/unit/test_composite.cxx
@@ -10,11 +10,11 @@ void test_composite()
   pqxx::connection cx;
   pqxx::work tx{cx};
   tx.exec("CREATE TYPE pqxxfoo AS (a integer, b text)").no_rows();
-  auto const r{tx.exec("SELECT '(5,hello)'::pqxxfoo").one_row()};
+  auto const f{tx.exec("SELECT '(5,hello)'::pqxxfoo").one_field()};
 
   int a;
   std::string b;
-  pqxx::parse_composite(r[0].view(), a, b);
+  pqxx::parse_composite(f.view(), a, b);
 
   PQXX_CHECK_EQUAL(a, 5, "Integer composite field came back wrong.");
   PQXX_CHECK_EQUAL(b, "hello", "String composite field came back wrong.");
@@ -25,10 +25,10 @@ void test_composite_escapes()
 {
   pqxx::connection cx;
   pqxx::work tx{cx};
-  pqxx::row r;
   tx.exec("CREATE TYPE pqxxsingle AS (x text)").no_rows();
   std::string s;
 
+  pqxx::row r;
   r = tx.exec(R"--(SELECT '("a""b")'::pqxxsingle)--").one_row();
   pqxx::parse_composite(r[0].view(), s);
   PQXX_CHECK_EQUAL(
@@ -79,12 +79,12 @@ void test_composite_renders_to_string()
     "Composite was not rendered as expected.");
 
   tx.exec("CREATE TYPE pqxxcomp AS (a integer, b text, c text)").no_rows();
-  auto const r{
-    tx.exec("SELECT '" + std::string{buf} + "'::pqxxcomp").one_row()};
+  auto const f{
+    tx.exec("SELECT '" + std::string{buf} + "'::pqxxcomp").one_field()};
 
   int a;
   std::string b, c;
-  bool const nonnull{r[0].composite_to(a, b, c)};
+  bool const nonnull{f.composite_to(a, b, c)};
   PQXX_CHECK(nonnull, "Mistaken nullness.");
   PQXX_CHECK_EQUAL(a, 355, "Int came back wrong.");
   PQXX_CHECK_EQUAL(b, "foo", "Simple string came back wrong.");

--- a/test/unit/test_errorhandler.cxx
+++ b/test/unit/test_errorhandler.cxx
@@ -139,7 +139,8 @@ void test_destroying_connection_unregisters_handlers()
 class MinimalErrorHandler final : public pqxx::errorhandler
 {
 public:
-  explicit MinimalErrorHandler(pqxx::connection &cx) : pqxx::errorhandler(cx) {}
+  explicit MinimalErrorHandler(pqxx::connection &cx) : pqxx::errorhandler(cx)
+  {}
   bool operator()(char const[]) noexcept override { return true; }
 };
 

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -35,24 +35,24 @@ public:
 
 
 void test_receive(
-  pqxx::transaction_base &t, std::string const &channel,
+  pqxx::transaction_base &tx, std::string const &channel,
   char const payload[] = nullptr)
 {
-  pqxx::connection &cx(t.conn());
+  pqxx::connection &cx(tx.conn());
 
-  std::string SQL{"NOTIFY \"" + channel + "\""};
+  std::string SQL{"NOTIFY " + tx.quote_name(channel)};
   if (payload != nullptr)
-    SQL += ", " + t.quote(payload);
+    SQL += ", " + tx.quote(payload);
 
-  TestReceiver receiver{t.conn(), channel};
+  TestReceiver receiver{cx, channel};
 
   // Clear out any previously pending notifications that might otherwise
   // confuse the test.
   cx.get_notifs();
 
   // Notify, and receive.
-  t.exec(SQL);
-  t.commit();
+  tx.exec(SQL);
+  tx.commit();
 
   int notifs{0};
   for (int i{0}; (i < 10) and (notifs == 0);

--- a/test/unit/test_pipeline.cxx
+++ b/test/unit/test_pipeline.cxx
@@ -43,7 +43,8 @@ void test_pipeline()
   // The complete() also received any pending query results from the backend.
   r = pipe.retrieve(q);
   PQXX_CHECK_EQUAL(std::size(r), 1, "Wrong result from pipeline.");
-  PQXX_CHECK_EQUAL(r.one_field().as<int>(), 2, "Pipeline returned wrong data.");
+  PQXX_CHECK_EQUAL(
+    r.one_field().as<int>(), 2, "Pipeline returned wrong data.");
 
   // We can cancel while the pipe is empty, and things will still work.
   pipe.cancel();

--- a/test/unit/test_pipeline.cxx
+++ b/test/unit/test_pipeline.cxx
@@ -24,7 +24,8 @@ void test_pipeline()
   PQXX_CHECK_EQUAL(
     std::size(r), 1, "Wrong query result after flushing pipeline.");
   PQXX_CHECK_EQUAL(
-    r[0][0].as<int>(), 2, "Query returns wrong data after flushing pipeline.");
+    r.one_field().as<int>(), 2,
+    "Query returns wrong data after flushing pipeline.");
 
   // Inserting a query makes the pipeline grab transaction focus back.
   auto q{pipe.insert("SELECT 2")};
@@ -37,12 +38,12 @@ void test_pipeline()
   r = tx.exec("SELECT 4");
   PQXX_CHECK_EQUAL(std::size(r), 1, "Wrong query result after complete().");
   PQXX_CHECK_EQUAL(
-    r[0][0].as<int>(), 4, "Query returns wrong data after complete().");
+    r.one_field().as<int>(), 4, "Query returns wrong data after complete().");
 
   // The complete() also received any pending query results from the backend.
   r = pipe.retrieve(q);
   PQXX_CHECK_EQUAL(std::size(r), 1, "Wrong result from pipeline.");
-  PQXX_CHECK_EQUAL(r[0][0].as<int>(), 2, "Pipeline returned wrong data.");
+  PQXX_CHECK_EQUAL(r.one_field().as<int>(), 2, "Pipeline returned wrong data.");
 
   // We can cancel while the pipe is empty, and things will still work.
   pipe.cancel();

--- a/test/unit/test_prepared_statement.cxx
+++ b/test/unit/test_prepared_statement.cxx
@@ -95,14 +95,12 @@ void test_basic_args()
   PQXX_CHECK_EQUAL(
     std::size(r), 1, "Did not get 1 row from prepared statement.");
   PQXX_CHECK_EQUAL(std::size(r.front()), 1, "Did not get exactly one column.");
-  PQXX_CHECK_EQUAL(r[0][0].as<int>(), 7, "Got wrong result.");
+  PQXX_CHECK_EQUAL(r.one_field().as<int>(), 7, "Got wrong result.");
 
-#include "pqxx/internal/ignore-deprecated-pre.hxx"
-  auto rw{tx.exec_prepared1("EchoNum", 8)};
+  auto rw{tx.exec(pqxx::prepped{"EchoNum"}, 8).one_row()};
   PQXX_CHECK_EQUAL(
     std::size(rw), 1, "Did not get 1 column from exec_prepared1.");
   PQXX_CHECK_EQUAL(rw[0].as<int>(), 8, "Got wrong result.");
-#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 

--- a/test/unit/test_read_transaction.cxx
+++ b/test/unit/test_read_transaction.cxx
@@ -9,8 +9,7 @@ void test_read_transaction()
   pqxx::connection cx;
   pqxx::read_transaction tx{cx};
   PQXX_CHECK_EQUAL(
-    tx.query_value<int>("SELECT 1"), 1,
-    "Bad result from read transaction.");
+    tx.query_value<int>("SELECT 1"), 1, "Bad result from read transaction.");
 
   PQXX_CHECK_THROWS(
     tx.exec("CREATE TABLE should_not_exist(x integer)"), pqxx::sql_error,

--- a/test/unit/test_read_transaction.cxx
+++ b/test/unit/test_read_transaction.cxx
@@ -9,7 +9,7 @@ void test_read_transaction()
   pqxx::connection cx;
   pqxx::read_transaction tx{cx};
   PQXX_CHECK_EQUAL(
-    tx.exec("SELECT 1")[0][0].as<int>(), 1,
+    tx.query_value<int>("SELECT 1"), 1,
     "Bad result from read transaction.");
 
   PQXX_CHECK_THROWS(

--- a/test/unit/test_stream_from.cxx
+++ b/test/unit/test_stream_from.cxx
@@ -246,8 +246,10 @@ void test_stream_from_does_escaping()
   std::string const input{"a\t\n\n\n \\b\nc"};
   pqxx::connection cx;
   pqxx::work tx{cx};
-  tx.exec0("CREATE TEMP TABLE badstr (str text)");
-  tx.exec0("INSERT INTO badstr (str) VALUES (" + tx.quote(input) + ")");
+  tx.exec("CREATE TEMP TABLE badstr (str text)").no_rows();
+  tx.exec(
+    "INSERT INTO badstr (str) VALUES ($1)", pqxx::params{input}
+  ).no_rows();
   auto reader{pqxx::stream_from::table(tx, {"badstr"})};
   std::tuple<std::string> out;
   reader >> out;

--- a/test/unit/test_stream_from.cxx
+++ b/test/unit/test_stream_from.cxx
@@ -216,16 +216,20 @@ void test_stream_from()
     "txt4    TEXT NULL,"
     "bin5    BYTEA NOT NULL"
     ")");
-  tx.exec_params(
-    "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)", 910, nullptr,
-    nullptr, nullptr, "\\N", bytea{});
-  tx.exec_params(
-    "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)", 1234, "now",
-    4321, ipv4{8, 8, 8, 8}, "hello\n \tworld", bytea{'\x00', '\x01', '\x02'});
-  tx.exec_params(
-    "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)", 5678,
-    "2018-11-17 21:23:00", nullptr, nullptr, "\u3053\u3093\u306b\u3061\u308f",
-    bytea{'f', 'o', 'o', ' ', 'b', 'a', 'r', '\0'});
+  tx.exec(
+    "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)",
+    pqxx::params{910, nullptr, nullptr, nullptr, "\\N", bytea{}});
+  tx.exec(
+    "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)",
+    pqxx::params{
+      1234, "now", 4321, ipv4{8, 8, 8, 8}, "hello\n \tworld",
+      bytea{'\x00', '\x01', '\x02'}});
+  tx.exec(
+    "INSERT INTO stream_from_test VALUES ($1,$2,$3,$4,$5,$6)",
+    pqxx::params{
+      5678, "2018-11-17 21:23:00", nullptr, nullptr,
+      "\u3053\u3093\u306b\u3061\u308f",
+      bytea{'f', 'o', 'o', ' ', 'b', 'a', 'r', '\0'}});
   tx.commit();
 
   test_nonoptionals(cx);

--- a/test/unit/test_stream_from.cxx
+++ b/test/unit/test_stream_from.cxx
@@ -247,9 +247,8 @@ void test_stream_from_does_escaping()
   pqxx::connection cx;
   pqxx::work tx{cx};
   tx.exec("CREATE TEMP TABLE badstr (str text)").no_rows();
-  tx.exec(
-    "INSERT INTO badstr (str) VALUES ($1)", pqxx::params{input}
-  ).no_rows();
+  tx.exec("INSERT INTO badstr (str) VALUES ($1)", pqxx::params{input})
+    .no_rows();
   auto reader{pqxx::stream_from::table(tx, {"badstr"})};
   std::tuple<std::string> out;
   reader >> out;


### PR DESCRIPTION
Simply drop some documentation for deprecated items that needed careful rewrites.