### PR TITLE
Fix string conversion for nulls in arrays.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@
  - Deprecate `exec1()` etc.  Use `result::expect_rows()` etc.
  - Fix error-reporting crash in non-blocking connection constructor. (#894)
  - Fix buffer overrun when converting array containing nulls to string. (#906)
+ - Fix nullness check for `std::optional` containing a nullable value. (#907)
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
  - Deprecate `exec_prepared()`; just use `exec()` with a `pqxx::prepped`.
  - Deprecate `exec1()` etc.  Use `result::expect_rows()` etc.
  - Fix error-reporting crash in non-blocking connection constructor. (#894)
+ - Fix buffer overrun when converting array containing nulls to string. (#906)
 7.9.2
  - Fix CMake documentation install. (#848)
  - More CMake build fix. (#869)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -1011,6 +1011,7 @@ template<> inline constexpr format param_format(bytes_view const &)
 
 namespace pqxx::internal
 {
+// C++20: Use input_range (except string or range of std::byte).
 /// String traits for SQL arrays.
 template<typename Container> struct array_string_traits
 {
@@ -1097,11 +1098,13 @@ public:
       return 3 + std::accumulate(
                    std::begin(value), std::end(value), std::size_t{},
                    [](std::size_t acc, elt_type const &elt) {
+		     // Budget for each element includes a terminating zero.
+		     // We won't actually be wanting those, but don't subtract
+		     // that one byte: we want room for a separator instead.
                      return acc +
                             (pqxx::is_null(elt) ?
                                std::size(s_null) :
-                               elt_traits::size_buffer(elt)) -
-                            1;
+                               elt_traits::size_buffer(elt));
                    });
     else
       return 3 + std::accumulate(

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -1098,13 +1098,12 @@ public:
       return 3 + std::accumulate(
                    std::begin(value), std::end(value), std::size_t{},
                    [](std::size_t acc, elt_type const &elt) {
-		     // Budget for each element includes a terminating zero.
-		     // We won't actually be wanting those, but don't subtract
-		     // that one byte: we want room for a separator instead.
-                     return acc +
-                            (pqxx::is_null(elt) ?
-                               std::size(s_null) :
-                               elt_traits::size_buffer(elt));
+                     // Budget for each element includes a terminating zero.
+                     // We won't actually be wanting those, but don't subtract
+                     // that one byte: we want room for a separator instead.
+                     return acc + (pqxx::is_null(elt) ?
+                                     std::size(s_null) :
+                                     elt_traits::size_buffer(elt));
                    });
     else
       return 3 + std::accumulate(

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -303,10 +303,10 @@ template<typename T> struct string_traits<std::optional<T>>
 
   static zview to_buf(char *begin, char *end, std::optional<T> const &value)
   {
-    if (value.has_value())
-      return string_traits<T>::to_buf(begin, end, *value);
-    else
+    if (pqxx::is_null(value))
       return {};
+    else
+      return string_traits<T>::to_buf(begin, end, *value);
   }
 
   static std::optional<T> from_string(std::string_view text)
@@ -317,7 +317,10 @@ template<typename T> struct string_traits<std::optional<T>>
 
   static std::size_t size_buffer(std::optional<T> const &value) noexcept
   {
-    return pqxx::size_buffer(value.value());
+    if (pqxx::is_null(value))
+      return std::size("NULL");
+    else
+      return pqxx::size_buffer(value.value());
   }
 };
 
@@ -332,7 +335,7 @@ template<typename... T> struct nullness<std::variant<T...>>
   static constexpr bool always_null = (nullness<T>::always_null and ...);
   static constexpr bool is_null(std::variant<T...> const &value) noexcept
   {
-    return std::visit(
+    return value.valueless_by_exception() or std::visit(
       [](auto const &i) noexcept {
         return nullness<strip_t<decltype(i)>>::is_null(i);
       },
@@ -371,8 +374,11 @@ template<typename... T> struct string_traits<std::variant<T...>>
   }
   static std::size_t size_buffer(std::variant<T...> const &value) noexcept
   {
-    return std::visit(
-      [](auto const &i) noexcept { return pqxx::size_buffer(i); }, value);
+    if (pqxx::is_null(value))
+      return std::size("NULL");
+    else
+      return std::visit(
+        [](auto const &i) noexcept { return pqxx::size_buffer(i); }, value);
   }
 
   /** There's no from_string for std::variant.  We could have one with a rule
@@ -511,7 +517,8 @@ template<> struct string_traits<char const *>
 
   static std::size_t size_buffer(char const *const &value) noexcept
   {
-    return std::strlen(value) + 1;
+    if (pqxx::is_null(value)) return std::size("NULL");
+    else return std::strlen(value) + 1;
   }
 };
 
@@ -544,7 +551,8 @@ template<> struct string_traits<char *>
   }
   static std::size_t size_buffer(char *const &value) noexcept
   {
-    return string_traits<char const *>::size_buffer(value);
+    if (pqxx::is_null(value)) return std::size("NULL");
+    else return string_traits<char const *>::size_buffer(value);
   }
 
   /// Don't allow conversion to this type since it breaks const-safety.
@@ -808,7 +816,10 @@ struct string_traits<std::unique_ptr<T, Args...>>
   static std::size_t
   size_buffer(std::unique_ptr<T, Args...> const &value) noexcept
   {
-    return pqxx::size_buffer(*value.get());
+    if (pqxx::is_null(value))
+      return std::size("NULL");
+    else
+      return pqxx::size_buffer(*value.get());
   }
 };
 
@@ -860,7 +871,8 @@ template<typename T> struct string_traits<std::shared_ptr<T>>
   }
   static std::size_t size_buffer(std::shared_ptr<T> const &value) noexcept
   {
-    return pqxx::size_buffer(*value);
+    if (pqxx::is_null(value)) return std::size("NULL");
+    else return pqxx::size_buffer(*value);
   }
 };
 
@@ -1011,7 +1023,7 @@ template<> inline constexpr format param_format(bytes_view const &)
 
 namespace pqxx::internal
 {
-// C++20: Use input_range (except string or range of std::byte).
+// C++20: Use concepts to identify arrays.
 /// String traits for SQL arrays.
 template<typename Container> struct array_string_traits
 {
@@ -1110,7 +1122,8 @@ public:
                    std::begin(value), std::end(value), std::size_t{},
                    [](std::size_t acc, elt_type const &elt) {
                      // Opening and closing quotes, plus worst-case escaping,
-                     // but don't count the trailing zeroes.
+                     // and the one byte for the trailing zero becomes room
+		     // for a separator.
                      std::size_t const elt_size{
                        pqxx::is_null(elt) ? std::size(s_null) :
                                             elt_traits::size_buffer(elt)};

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -318,7 +318,7 @@ template<typename T> struct string_traits<std::optional<T>>
   static std::size_t size_buffer(std::optional<T> const &value) noexcept
   {
     if (pqxx::is_null(value))
-      return std::size("NULL");
+      return 0;
     else
       return pqxx::size_buffer(value.value());
   }
@@ -375,7 +375,7 @@ template<typename... T> struct string_traits<std::variant<T...>>
   static std::size_t size_buffer(std::variant<T...> const &value) noexcept
   {
     if (pqxx::is_null(value))
-      return std::size("NULL");
+      return 0;
     else
       return std::visit(
         [](auto const &i) noexcept { return pqxx::size_buffer(i); }, value);
@@ -517,7 +517,7 @@ template<> struct string_traits<char const *>
 
   static std::size_t size_buffer(char const *const &value) noexcept
   {
-    if (pqxx::is_null(value)) return std::size("NULL");
+    if (pqxx::is_null(value)) return 0;
     else return std::strlen(value) + 1;
   }
 };
@@ -551,7 +551,7 @@ template<> struct string_traits<char *>
   }
   static std::size_t size_buffer(char *const &value) noexcept
   {
-    if (pqxx::is_null(value)) return std::size("NULL");
+    if (pqxx::is_null(value)) return 0;
     else return string_traits<char const *>::size_buffer(value);
   }
 
@@ -817,7 +817,7 @@ struct string_traits<std::unique_ptr<T, Args...>>
   size_buffer(std::unique_ptr<T, Args...> const &value) noexcept
   {
     if (pqxx::is_null(value))
-      return std::size("NULL");
+      return 0;
     else
       return pqxx::size_buffer(*value.get());
   }
@@ -871,7 +871,7 @@ template<typename T> struct string_traits<std::shared_ptr<T>>
   }
   static std::size_t size_buffer(std::shared_ptr<T> const &value) noexcept
   {
-    if (pqxx::is_null(value)) return std::size("NULL");
+    if (pqxx::is_null(value)) return 0;
     else return pqxx::size_buffer(*value);
   }
 };

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -214,7 +214,7 @@ template<typename TYPE> struct string_traits
   [[nodiscard]] static inline std::size_t
   size_buffer(TYPE const &value) noexcept;
 
-  // TODO: Move is_unquoted_string into the traits after all?
+  // TODO: Move is_unquoted_safe into the traits after all?
 };
 
 

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -147,7 +147,8 @@ template<typename TYPE> struct no_null
  * and from_string support.
  *
  * String conversions are not meant to work for nulls.  Check for null before
- * converting a value of @c TYPE to a string, or vice versa.
+ * converting a value of @c TYPE to a string, or vice versa, and handle them
+ * separately.
  */
 template<typename TYPE> struct string_traits
 {

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -480,8 +480,8 @@ namespace
 {
 constexpr bool valid_infinity_string(std::string_view text) noexcept
 {
-  return text == "infinity" or text == "Infinity" or
-         text == "INFINITY" or text == "inf";
+  return text == "inf" or text == "infinity" or text == "INFINITY" or
+         text == "Infinity";
 }
 
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -50,13 +50,6 @@ constexpr bool have_thread_local{
 #endif
 
 
-/// String comparison between string_view.
-constexpr inline bool equal(std::string_view lhs, std::string_view rhs)
-{
-  return lhs.compare(rhs) == 0;
-}
-
-
 /// The lowest possible value of integral type T.
 template<typename T> constexpr T bottom{std::numeric_limits<T>::min()};
 
@@ -487,8 +480,8 @@ namespace
 {
 constexpr bool valid_infinity_string(std::string_view text) noexcept
 {
-  return equal("infinity", text) or equal("Infinity", text) or
-         equal("INFINITY", text) or equal("inf", text);
+  return text == "infinity" or text == "Infinity" or
+         text == "INFINITY" or text == "inf";
 }
 
 
@@ -768,12 +761,12 @@ bool pqxx::string_traits<bool>::from_string(std::string_view text)
     break;
 
   case std::size("true"sv):
-    if (equal(text, "true") or equal(text, "TRUE"))
+    if (text == "true" or text == "TRUE")
       result = true;
     break;
 
   case std::size("false"sv):
-    if (equal(text, "false") or equal(text, "FALSE"))
+    if (text == "false" or text == "FALSE")
       result = false;
     break;
 

--- a/test/unit/test_binarystring.cxx
+++ b/test/unit/test_binarystring.cxx
@@ -177,10 +177,10 @@ void test_binarystring_array_stream()
 
   constexpr char bytes1[]{"a\tb\0c"}, bytes2[]{"1\0.2"};
   std::string_view const data1{bytes1}, data2{bytes2};
-#include "pqxx/internal/ignore-deprecated-pre.hxx"
+#  include "pqxx/internal/ignore-deprecated-pre.hxx"
   pqxx::binarystring bin1{data1}, bin2{data2};
   std::vector<pqxx::binarystring> const vec{bin1, bin2};
-#include "pqxx/internal/ignore-deprecated-post.hxx"
+#  include "pqxx/internal/ignore-deprecated-post.hxx"
 
   auto to{pqxx::stream_to::table(tx, {"pqxxbinstream"})};
   to.write_values(0, vec);


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/906

The budget calculation for the conversion from array-like types to SQL strings did not take null values into account.  (In a distant past, SQL arrays could not contain null values.)  The actual string conversion did generate a null, but the budget calculation simply tried to generate a number — which could be less than what was needed to insert the SQL `NULL` keyword.

Next, the budgeting function for `std::optional` failed to account for the possibility of the `std::optional` containing a value, but the value being a null.

Also the buffer budget calculation for arrays of unquoted-safe types was slightly too tight.  I think I've had to fix this for unsafe types in the past.

(I'm also removing an internal wrapper function for comparing `std::string_view` values for equality.  That type supports the equality operator nowadays.)