### PR TITLE
Drop assertion in workaround for `std::unreachable`.

### DIFF
--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -47,9 +47,9 @@ namespace pqxx
 // C++23: Retire wrapper.
 // PQXX_UNREACHABLE: equivalent to `std::unreachable()` if available.
 #if !defined(__cpp_lib_unreachable)
-#  define PQXX_UNREACHABLE assert(false)
+#  define PQXX_UNREACHABLE while (false)
 #elif !__cpp_lib_unreachable
-#  define PQXX_UNREACHABLE assert(false)
+#  define PQXX_UNREACHABLE while (false)
 #else
 #  define PQXX_UNREACHABLE std::unreachable()
 #endif


### PR DESCRIPTION
In environments where `std::unreachable` is not available, we previously _asserted_ that the code was not reached.  Which I guess was useful in the early days for exposing any mixups, but doesn't really set the same expectations as `std::unreachable` itself.

So, drop that assertion.  This also gets rid of a bunch of warnings from my static checker about "this could be a `static_assert`."