### PR TITLE
Simpler, more modern API for listen/notify.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 7.10.0
  - Deprecate `errorhandler`; replace with lambda-friendly "notice handlers."
+ - Deprecate `notification_receiver`; replace with "notification handlers"
  - Bump minimum CMake version to 3.28. (#874)
  - Fixed error message on clashing transaction focuses. (#879)
  - Don't call`/bin/true`; macOS doesn't have it.  Just call `true`. (#885)

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub install-sh ltmain.sh missing mkinstalldirs
+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/configure
+++ b/configure
@@ -17160,7 +17160,6 @@ then
 			-Wattribute-alias=2 \
 			-Wlogical-op \
 			-Wmismatched-tags \
-			-Wnoexcept \
 			-Wredundant-tags \
 			-Wrestrict \
 			-Wstringop-overflow \

--- a/configure
+++ b/configure
@@ -18690,7 +18690,7 @@ if test "$found_fslib" != "yes"
 then
 	as_fn_error $? "
 There seems to be <filesystem> support, but I could not figure out now to make
-it work.  You'll have to add set your own build options for this.
+it work.  You'll have to set your own build options for this.
 	" "$LINENO" 5
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $result_msg" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -182,7 +182,6 @@ then
 			-Wattribute-alias=2 \
 			-Wlogical-op \
 			-Wmismatched-tags \
-			-Wnoexcept \
 			-Wredundant-tags \
 			-Wrestrict \
 			-Wstringop-overflow \

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
-# XXX: Pin versions.
+# TODO: Pin versions.
+# TODO: Do we even still need this file?
 dia
 sphinx-rtd-theme
 myst-parser

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -633,7 +633,7 @@ public:
    * a notification for every client listening on a channel, except yourself.
    * If you sent out the notification yourself in the same session, then the
    * handler will receive a process ID that's identical to the one that your
-   * connection's @ref backend_pid() returns. 
+   * connection's @ref backendpid() returns. 
    */
   using notification_handler = std::function<void(zview, int, zview)>;
 

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -669,7 +669,7 @@ public:
    *
    * @return Number of notifications processed.
    */
-  int await_notification(std::time_t seconds, long microseconds);
+  int await_notification(std::time_t seconds, long microseconds = 0);
 
   /// A handler callback for incoming notifications on a given channel.
   /** Your callback must accept a @ref notification object.  This object can

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <ctime>
+#include <functional>
 #include <initializer_list>
 #include <list>
 #include <map>
@@ -246,9 +247,9 @@ public:
 
   /// Move constructor.
   /** Moving a connection is not allowed if it has an open transaction, or has
-   * error handlers or notification receivers registered on it.  In those
-   * situations, other objects may hold references to the old object which
-   * would become invalid and might produce hard-to-diagnose bugs.
+   * error handlers or is listening for notifications.  In those situations,
+   * other objects may hold references to the old object which would become
+   * invalid and might produce hard-to-diagnose bugs.
    */
   connection(connection &&rhs);
 
@@ -283,9 +284,10 @@ public:
     {}
   }
 
+  // TODO: Once we drop notification_receiver/errorhandler, move is easier.
   /// Move assignment.
-  /** Neither connection can have an open transaction, or registered
-   * notification receivers.
+  /** Neither connection can have an open transaction, `errorhandler`, or
+   * `notification_receiver`.
    */
   connection &operator=(connection &&rhs);
 
@@ -341,7 +343,7 @@ public:
   /// Process ID for backend process, or 0 if inactive.
   [[nodiscard]] int PQXX_PURE backendpid() const & noexcept;
 
-  /// Socket currently used for connection, or -1 for none.  Use with care!
+  /// Socket currently used for connection, or -1 for none.
   /** Query the current socket number.  This is intended for event loops based
    * on functions such as select() or poll(), where you're waiting for any of
    * multiple file descriptors to become ready for communication.
@@ -477,34 +479,122 @@ public:
 
   /**
    * @name Notifications and Receivers
+   *
+   * This is PostgreSQL-specific extension that goes beyond standard SQL.  It's
+   * a communications mechanism between clients on a database, akin to a
+   * transactional message bus.
+   *
+   * A notification happens on a _channel,_ identified by a name.  You can set
+   * a connection to _listen_ for notifications on the channel, using the
+   * connection's @ref listen() function.  (Internally this will issue a
+   * `LISTEN` SQL command).  Any client on the database can send a
+   * notification on that channel by executing a `NOTIFY` SQL command.  The
+   * transaction classes implement a convenience function for this, called
+   * @ref transaction_base::notify().
+   *
+   * Notifications can carry an optional _payload_ string.  This is free-form
+   * text which carries additional information to the receiver.
+   *
+   * @warning There are a few pitfalls with the channel names: case sensitivity
+   * and encodings.  They are not too hard to avoid, but the safest thing to do
+   * is use only lower-case ASCII names.
+   *
+   *
+   * ### Case sensitivity
+   *
+   * Channel names are _case-sensitive._  By default, however, PostgreSQL does
+   * convert the channel name in a `NOTIFY` or `LISTEN` command to lower-case,
+   * to give the impression that it is _not_ case-sensitive while keeping the
+   * performance cost low.
+   *
+   * Thus, a `LISTEN Hello` will pick up a notification from `NOTIFY Hello` but
+   * also one from `NOTIFY hello`, because the database converts `Hello` into
+   * `hello` going in either direction.
+   *
+   * You can prevent this conversion by putting the name in double quotes, as
+   * @ref quote_name() does.  This is what libpqxx's notification functions do.
+   * If you use libpqxx to lisen on `Hello` but raw SQL to notify `Hello`, the
+   * notification will not arrive because the notification actually uses the
+   * string `hello` instead.
+   *
+   * Confused?  Safest thing to do is to use only lower-case letters in the
+   * channel names!
+   *
+   *
+   * ### Transactions
+   *
+   * Both listening and notifying are _transactional_ in the backend: they
+   * only take effect once the back-end transaction in which you do them is
+   * committed.
+   *
+   * For an outgoing notification, this means that the transaction holds on to
+   * the outgoing message until you commit.  (A @ref nontransaction does not
+   * start a backend transaction, so if that's the transaction type you're
+   * using, the message does go out immediately.)
+   *
+   * For listening to incoming notifications, it gets a bit more complicated.
+   * To avoid complicating its internal bookkeeping, libpqxx only lets you 
+   * start listening while no transaction is open.
+   *
+   * No notifications will come in while you're in a transaction... again
+   * unless it's a @ref nontransaction of course, because that does not open a
+   * transaction on the backend.
+   *
+   *
+   * ### Exceptions
+   *
+   * If your handler throws an exception, that will simply propagate up the
+   * call chain to wherever you were when you received it.
+   *
+   * This is differnt from the old `notification_receiver` mechanism which
+   * logged exceptions but did not propagate them.
+   *
+   *
+   * ### Encoding
+   *
+   * When a client sends a notification, it does so in its client encoding.  If
+   * necessary, the back-end converts them to its internal encoding.  And then
+   * when a client receives the notification, the database converts it to the
+   * receiver's client encoding.
+   *
+   * Simple enough, right?
+   *
+   * However if you should _change_ your connection's client encoding after you
+   * start listening on a channel, then any notifications you receive may have
+   * different channel names than the ones for which you are listening.
+   *
+   * If this could be a problem in your scenario, stick to names in pure
+   * ASCII.  Those will look the same in all the encodings postgres supports.
    */
   //@{
   /// Check for pending notifications and take appropriate action.
   /** This does not block.  To wait for incoming notifications, either call
-   * await_notification() (it calls this function); or wait for incoming data
-   * on the connection's socket (i.e. wait to read), and then call this
+   * @ref await_notification() (it calls this function); or wait for incoming
+   * data on the connection's socket (i.e. wait to read), and then call this
    * function repeatedly until it returns zero.  After that, there are no more
-   * pending notifications so you may want to wait again.
+   * pending notifications so you may want to wait again, or move on and do
+   * other work.
    *
    * If any notifications are pending when you call this function, it
-   * processes them by finding any receivers that match the notification string
-   * and invoking those.  If no receivers match, there is nothing to invoke but
-   * we do consider the notification processed.
+   * processes them by checking for a matching notification handler, and if it
+   * finds one, invoking it.  If there is no matching handler, nothing happens.
    *
-   * If any of the client-registered receivers throws an exception, the
-   * function will report it using the connection's notice handler.  It does
-   * not re-throw the exceptions.
+   * If your notifcation handler throws an exception, `get_notifs()` will just
+   * propagate it back to you.  (This is different from the old
+   * `notification_receiver` mechanism, which would merely log them.)
    *
    * @return Number of notifications processed.
    */
   int get_notifs();
 
   /// Wait for a notification to come in.
-  /** There are other events that will also terminate the wait, such as the
-   * backend failing.  It will also wake up periodically.
+  /** There are other events that will also cancel the wait, such as the
+   * backend failing.  Also, _the function will wake up by itself from time to
+   * time._  Your code must be ready to handle this; don't assume after waking
+   * up that there will always be a pending notifiation.
    *
-   * If a notification comes in, the call will process it, along with any other
-   * notifications that may have been pending.
+   * If a notification comes in, the call to this function will process it,
+   * along with any other notifications that may have been pending.
    *
    * To wait for notifications into your own event loop instead, wait until
    * there is incoming data on the connection's socket to be read, then call
@@ -515,8 +605,8 @@ public:
   int await_notification();
 
   /// Wait for a notification to come in, or for given timeout to pass.
-  /** There are other events that will also terminate the wait, such as the
-   * backend failing, or timeout expiring.
+  /** There are other events that will also cancel the wait, such as the
+   * backend failing, some kinds of signal coming in, or timeout expiring.
    *
    * If a notification comes in, the call will process it, along with any other
    * notifications that may have been pending.
@@ -525,9 +615,49 @@ public:
    * there is incoming data on the connection's socket to be read, then call
    * @ref get_notifs repeatedly until it returns zero.
    *
-   * @return Number of notifications processed
+   * If your notifcation handler throws an exception, `get_notifs()` will just
+   * propagate it back to you.  (This is different from the old
+   * `notification_receiver` mechanism, which would merely log them.)
+   *
+   * @return Number of notifications processed.
    */
   int await_notification(std::time_t seconds, long microseconds);
+
+  /// A handler callback for notifications.
+  /** A notification handler takes 3 arguments: the _channel name_ to which
+   * the notification was sent; the process ID of the backend that sent the
+   * notification; and an optional "payload" text.  If there was no payload,
+   * you will receive an empty string there.
+   *
+   * Why the backend process ID?  Because sometimes you may want to send out
+   * a notification for every client listening on a channel, except yourself.
+   * If you sent out the notification yourself in the same session, then the
+   * handler will receive a process ID that's identical to the one that your
+   * connection's @ref backend_pid() returns. 
+   */
+  using notification_handler = std::function<void(zview, int, zview)>;
+
+  /// Attach a handler to a notification channel.
+  /** Issues a `LISTEN` SQL command for channel `name`, and stores `handler`
+   * as the callback for when a notification comes in on that channel.
+   *
+   * The handler is a `std::function` (see @ref notification_handler), but you
+   * can simply pass in a lambda with the right parameters.  Your handler
+   * probably needs to interact with your application's data; the simple way to
+   * get that working is to pass a lambda with a closure referencing the data
+   * items you need.
+   *
+   * If the handler is empty (the default), then that stops the connection
+   * listening on the channel.  It cancels your subscription, so to speak.
+   * You can do that as many times as you like, even when you never started
+   * listening to that channel in the first place.
+   *
+   * A connection can only have one handler per channel, so if you register two
+   * different handlers on the same channel, then the second overwrites the
+   * first.
+   */
+  void listen(std::string_view name, notification_handler handler = {});
+
   //@}
 
   /**
@@ -772,7 +902,7 @@ public:
 #endif
 
   // TODO: Make "into buffer" variant to eliminate a string allocation.
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    *
@@ -892,7 +1022,7 @@ public:
     return esc(std::string_view{text, maxlen});
   }
 
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
@@ -904,7 +1034,7 @@ public:
 #include "pqxx/internal/ignore-deprecated-post.hxx"
   }
 
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
@@ -964,7 +1094,6 @@ public:
    */
   void set_notice_handler(std::function<void(zview)> handler)
   {
-// XXX: Express noexcept on handler in code, somehow.
     m_notice_waiters->notice_handler = std::move(handler);
   }
 
@@ -1159,6 +1288,16 @@ private:
     std::multimap<std::string, pqxx::notification_receiver *>;
   /// Notification receivers.
   receiver_list m_receivers;
+
+  /// Notification handlers.
+  /** These are the functions we call when notifications come in.  Each
+   * corresponds to a `LISTEN` we have executed.
+   *
+   * The map does not contain any `std::function` which are empty.  If the
+   * caller registers an empty function, that simply cancels any subscription
+   * to that channel.
+   */
+  std::map<std::string, notification_handler> m_notification_handlers;
 
   /// Unique number to use as suffix for identifiers (see adorn_name()).
   int m_unique_id = 0;

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -1283,6 +1283,7 @@ private:
   /// 9.0: Replace with just notice handler.
   std::shared_ptr<pqxx::internal::notice_waiters> m_notice_waiters;
 
+  // TODO: Remove these when we retire notification_receiver.
   // TODO: Can we make these movable?
   using receiver_list =
     std::multimap<std::string, pqxx::notification_receiver *>;

--- a/include/pqxx/notification.hxx
+++ b/include/pqxx/notification.hxx
@@ -61,10 +61,13 @@ public:
    * @param cx Connnection to operate on.
    * @param channel Name of the notification to listen for.
    */
+  [[deprecated("Use pqxx::connection::listen() instead.")]]
   notification_receiver(connection &cx, std::string_view channel);
   /// Register the receiver with a connection.
+  [[deprecated("Use pqxx::connection::listen() instead.")]]
   notification_receiver(notification_receiver const &) = delete;
   /// Register the receiver with a connection.
+  [[deprecated("Use pqxx::connection::listen() instead.")]]
   notification_receiver &operator=(notification_receiver const &) = delete;
   /// Deregister the receiver.
   virtual ~notification_receiver();

--- a/include/pqxx/notification.hxx
+++ b/include/pqxx/notification.hxx
@@ -75,7 +75,6 @@ public:
   /// The channel that this receiver listens on.
   [[nodiscard]] std::string const &channel() const & { return m_channel; }
 
-  // TODO: Change API to take payload as zview instead of string ref.
   /// Overridable: action to invoke when notification arrives.
   /**
    * @param payload An optional string that may have been passed to the NOTIFY

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -213,7 +213,7 @@ public:
     return conn().esc_raw(std::forward<ARGS>(args)...);
   }
 
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
@@ -225,13 +225,13 @@ public:
 #include "pqxx/internal/ignore-deprecated-post.hxx"
   }
 
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
   [[nodiscard]] bytes unesc_bin(zview text) { return conn().unesc_bin(text); }
 
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
@@ -243,7 +243,7 @@ public:
 #include "pqxx/internal/ignore-deprecated-post.hxx"
   }
 
-  /// Unescape binary data, e.g. from a table field or notification payload.
+  /// Unescape binary data, e.g. from a `bytea` field.
   /** Takes a binary string as escaped by PostgreSQL, and returns a restored
    * copy of the original binary data.
    */
@@ -892,6 +892,28 @@ public:
   {
     exec(query, parms).for_each(std::forward<CALLABLE>(func));
   }
+
+  /// Send a notification.
+  /** Convenience shorthand for executing a "NOTIFY" command.  Most of the
+   * logic for handling _incoming_ notifications is in @ref pqxx::connection
+   * (particularly @ref pqxx::connection::listen), but _outgoing_
+   * notifications happen here.
+   *
+   * Unless this transaction is a nontransaction, the actual notification only
+   * goes out once the outer transaction is committed.
+   */
+  void notify(std::string_view name);
+
+  /// Send a notification.
+  /** Convenience shorthand for executing a "NOTIFY" command.  Most of the
+   * logic for handling _incoming_ notifications is in @ref pqxx::connection
+   * (particularly @ref pqxx::connection::listen), but _outgoing_
+   * notifications happen here.
+   *
+   * Unless this transaction is a nontransaction, the actual notification only
+   * goes out once the outer transaction is committed.
+   */
+  void notify(std::string_view name, std::string_view payload);
   //@}
 
   /// Execute a prepared statement, with optional arguments.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -901,19 +901,15 @@ public:
    *
    * Unless this transaction is a nontransaction, the actual notification only
    * goes out once the outer transaction is committed.
-   */
-  void notify(std::string_view name);
-
-  /// Send a notification.
-  /** Convenience shorthand for executing a "NOTIFY" command.  Most of the
-   * logic for handling _incoming_ notifications is in @ref pqxx::connection
-   * (particularly @ref pqxx::connection::listen), but _outgoing_
-   * notifications happen here.
    *
-   * Unless this transaction is a nontransaction, the actual notification only
-   * goes out once the outer transaction is committed.
+   * @param channel Name of the "channel" on which clients will need to be
+   * listening in order to receive this notification.
+   *
+   * @param payload Optional argument string which any listeners will also
+   * receive.  If you leave this out, they will receive an empty string as the
+   * payload.
    */
-  void notify(std::string_view name, std::string_view payload);
+  void notify(std::string_view channel, std::string_view payload = {});
   //@}
 
   /// Execute a prepared statement, with optional arguments.

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -655,10 +655,7 @@ int pqxx::connection::get_notifs()
 
     auto const handler{m_notification_handlers.find(N->relname)};
     if (handler != std::end(m_notification_handlers))
-    {
-      ++notifs;
       (handler->second)(name, N->be_pid, N->extra);
-    }
 
     N.reset();
   }

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -420,14 +420,14 @@ void PQXX_COLD pqxx::connection::add_receiver(pqxx::notification_receiver *n)
 
 
 void pqxx::connection::listen(
-    std::string_view name, notification_handler handler)
+    std::string_view channel, notification_handler handler)
 {
   if (m_trans != nullptr)
     throw usage_error{pqxx::internal::concat(
-      "Attempting to listen for notifications on '", name,
+      "Attempting to listen for notifications on '", channel,
       "' while transaction is active.")};
 
-  std::string str_name{name};
+  std::string str_name{channel};
 
   auto const
     pos{m_notification_handlers.lower_bound(str_name)},
@@ -436,7 +436,7 @@ void pqxx::connection::listen(
   if (handler)
   {
     // Setting a handler.
-    if ((pos != handlers_end) and (pos->first == name))
+    if ((pos != handlers_end) and (pos->first == channel))
     {
       // Overwrite existing handler.
       m_notification_handlers.insert_or_assign(
@@ -445,8 +445,8 @@ void pqxx::connection::listen(
     else
     {
       // We had no handler installed for this name.  Start listening.
-      exec(pqxx::internal::concat("LISTEN ", quote_name(name))).no_rows();
-      m_notification_handlers.emplace_hint(pos, name, std::move(handler));
+      exec(pqxx::internal::concat("LISTEN ", quote_name(channel))).no_rows();
+      m_notification_handlers.emplace_hint(pos, channel, std::move(handler));
     }
   }
   else
@@ -456,7 +456,7 @@ void pqxx::connection::listen(
     if (pos != handlers_end)
     {
       // Yes, we had a handler for this name.  Remove it.
-      exec(pqxx::internal::concat("UNLISTEN ", quote_name(name))).no_rows();
+      exec(pqxx::internal::concat("UNLISTEN ", quote_name(channel))).no_rows();
       m_notification_handlers.erase(pos);
     }
   }

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -619,9 +619,9 @@ int pqxx::connection::get_notifs()
   {
     notifs++;
 
-    std::string const name{N->relname};
+    std::string const channel{N->relname};
 
-    auto const Hit{m_receivers.equal_range(name)};
+    auto const Hit{m_receivers.equal_range(channel)};
     if (Hit.second != Hit.first)
     {
       std::string const payload{N->extra};
@@ -654,8 +654,9 @@ int pqxx::connection::get_notifs()
     }
 
     auto const handler{m_notification_handlers.find(N->relname)};
+    // C++20: Use "dot notation" to initialise struct fields.
     if (handler != std::end(m_notification_handlers))
-      (handler->second)(name, N->be_pid, N->extra);
+      (handler->second)(notification{*this, channel, N->extra, N->be_pid});
 
     N.reset();
   }

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -357,7 +357,9 @@ std::string pqxx::result::status_error() const
 
 char const *pqxx::result::cmd_status() const noexcept
 {
-  // TODO: PQcmdStatus() could totally take a pointer to const.
+  // PQcmdStatus() can't take a PGresult const * because it returns a non-const
+  // pointer into the PGresult's data, and that can't be changed without
+  // breaking compatibility.
   return PQcmdStatus(const_cast<internal::pq::PGresult *>(m_data.get()));
 }
 
@@ -379,7 +381,9 @@ pqxx::oid pqxx::result::inserted_oid() const
 
 pqxx::result::size_type pqxx::result::affected_rows() const
 {
-  // TODO: PQcmdTuples() could take a pointer to const.
+  // PQcmdTuples() can't take a PGresult const * because it returns a non-const
+  // pointer into the PGresult's data, and that can't be changed without
+  // breaking compatibility.
   auto const rows_str{
     PQcmdTuples(const_cast<internal::pq::PGresult *>(m_data.get()))};
   return (rows_str[0] == '\0') ? 0 : size_type(atoi(rows_str));

--- a/src/transaction.cxx
+++ b/src/transaction.cxx
@@ -71,7 +71,7 @@ void pqxx::internal::basic_transaction::do_commit()
     process_notice(internal::concat(e.what(), "\n"));
 
     std::string msg{internal::concat(
-      "WARNING: Commit of transaction '", name(),
+      "WARNING: Commit status of transaction '", name(),
       "' is unknown. "
       "There is no way to tell whether the transaction succeeded "
       "or was aborted except to check manually.\n")};

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -302,6 +302,22 @@ pqxx::result pqxx::transaction_base::internal_exec_params(
 }
 
 
+void pqxx::transaction_base::notify(std::string_view name)
+{
+  exec(pqxx::internal::concat("NOTIFY ", quote_name(name))).no_rows();
+}
+
+
+void pqxx::transaction_base::notify(
+  std::string_view name, std::string_view payload)
+{
+  exec(pqxx::internal::concat(
+    "NOTIFY ", quote_name(name), ", $1"),
+    params{payload}
+  ).no_rows();
+}
+
+
 void pqxx::transaction_base::set_variable(
   std::string_view var, std::string_view value)
 {

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -302,18 +302,13 @@ pqxx::result pqxx::transaction_base::internal_exec_params(
 }
 
 
-void pqxx::transaction_base::notify(std::string_view name)
-{
-  exec(pqxx::internal::concat("NOTIFY ", quote_name(name))).no_rows();
-}
-
-
 void pqxx::transaction_base::notify(
-  std::string_view name, std::string_view payload)
+  std::string_view channel, std::string_view payload)
 {
-  exec(
-    pqxx::internal::concat("NOTIFY ", quote_name(name), ", ", quote(payload))
-  ).no_rows();
+  // For some reason, NOTIFY does not work as a parameterised statement,
+  // even just for the payload (which is supposed to be a normal string).
+  // Luckily, pg_notify() does.
+  exec("SELECT pg_notify($1, $2)", params{channel, payload}).one_row();
 }
 
 

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -311,9 +311,8 @@ void pqxx::transaction_base::notify(std::string_view name)
 void pqxx::transaction_base::notify(
   std::string_view name, std::string_view payload)
 {
-  exec(pqxx::internal::concat(
-    "NOTIFY ", quote_name(name), ", $1"),
-    params{payload}
+  exec(
+    pqxx::internal::concat("NOTIFY ", quote_name(name), ", ", quote(payload))
   ).no_rows();
 }
 

--- a/test/test04.cxx
+++ b/test/test04.cxx
@@ -25,8 +25,8 @@ void test_004()
   int backend_pid{0};
   cx.listen(
     channel,
-    [&backend_pid](pqxx::zview, int pid, pqxx::zview) noexcept
-    { backend_pid = pid; });
+    [&backend_pid](pqxx::notification n) noexcept
+    { backend_pid = n.backend_pid; });
 
   // Trigger our notification receiver.
   pqxx::perform([&cx, &channel] {

--- a/test/test04.cxx
+++ b/test/test04.cxx
@@ -28,7 +28,7 @@ void test_004()
     [&backend_pid](pqxx::zview, int pid, pqxx::zview){ backend_pid = pid; });
 
   // Trigger our notification receiver.
-  perform([&cx, &channel] {
+  pqxx::perform([&cx, &channel] {
     pqxx::work tx(cx);
     tx.notify(channel);
     tx.commit();

--- a/test/test04.cxx
+++ b/test/test04.cxx
@@ -25,7 +25,8 @@ void test_004()
   int backend_pid{0};
   cx.listen(
     channel,
-    [&backend_pid](pqxx::zview, int pid, pqxx::zview){ backend_pid = pid; });
+    [&backend_pid](pqxx::zview, int pid, pqxx::zview) noexcept
+    { backend_pid = pid; });
 
   // Trigger our notification receiver.
   pqxx::perform([&cx, &channel] {

--- a/test/test78.cxx
+++ b/test/test78.cxx
@@ -18,7 +18,9 @@ void test_078()
   bool done{false};
 
   std::string const channel{"my listener"};
-  cx.listen(channel, [&done](pqxx::zview, int, pqxx::zview){ done = true; });
+  cx.listen(
+    channel,
+    [&done](pqxx::zview, int, pqxx::zview) noexcept { done = true; });
 
   pqxx::perform([&cx, &channel] {
     pqxx::nontransaction tx{cx};

--- a/test/test78.cxx
+++ b/test/test78.cxx
@@ -2,8 +2,7 @@
 #include <cstring>
 #include <iostream>
 
-#include <pqxx/notification>
-#include <pqxx/transaction>
+#include <pqxx/nontransaction>
 #include <pqxx/transactor>
 
 #include "test_helpers.hxx"
@@ -13,46 +12,22 @@
 // notification name with unusal characters, and without polling.
 namespace
 {
-// Sample implementation of notification receiver.
-class TestListener : public pqxx::notification_receiver
-{
-  bool m_done;
-
-public:
-  explicit TestListener(pqxx::connection &cx, std::string const &Name) :
-          pqxx::notification_receiver(cx, Name), m_done(false)
-  {}
-
-  void operator()(std::string const &, int be_pid) override
-  {
-    m_done = true;
-    PQXX_CHECK_EQUAL(
-      be_pid, conn().backendpid(),
-      "Got notification from wrong backend process.");
-
-    std::cout << "Received notification: " << channel() << " pid=" << be_pid
-              << std::endl;
-  }
-
-  bool done() const { return m_done; }
-};
-
-
 void test_078()
 {
   pqxx::connection cx;
+  bool done{false};
 
-  std::string const NotifName{"my listener"};
-  TestListener L{cx, NotifName};
+  std::string const channel{"my listener"};
+  cx.listen(channel, [&done](pqxx::zview, int, pqxx::zview){ done = true; });
 
-  pqxx::perform([&cx, &L] {
-    pqxx::work tx{cx};
-    tx.exec("NOTIFY " + tx.quote_name(L.channel())).no_rows();
+  pqxx::perform([&cx, &channel] {
+    pqxx::nontransaction tx{cx};
+    tx.notify(channel);
     tx.commit();
   });
 
   int notifs{0};
-  for (int i{0}; (i < 20) and not L.done(); ++i)
+  for (int i{0}; (i < 20) and not done; ++i)
   {
     PQXX_CHECK_EQUAL(notifs, 0, "Got unexpected notifications.");
     std::cout << ".";
@@ -60,7 +35,7 @@ void test_078()
   }
   std::cout << std::endl;
 
-  PQXX_CHECK(L.done(), "No notification received.");
+  PQXX_CHECK(done, "No notification received.");
   PQXX_CHECK_EQUAL(notifs, 1, "Got unexpected number of notifications.");
 }
 } // namespace

--- a/test/test78.cxx
+++ b/test/test78.cxx
@@ -18,9 +18,7 @@ void test_078()
   bool done{false};
 
   std::string const channel{"my listener"};
-  cx.listen(
-    channel,
-    [&done](pqxx::zview, int, pqxx::zview) noexcept { done = true; });
+  cx.listen(channel, [&done](pqxx::notification) noexcept { done = true; });
 
   pqxx::perform([&cx, &channel] {
     pqxx::nontransaction tx{cx};

--- a/test/test79.cxx
+++ b/test/test79.cxx
@@ -20,8 +20,8 @@ void test_079()
 
   cx.listen(
     channel,
-    [&backend_pid](pqxx::zview, int pid, pqxx::zview) noexcept
-    { backend_pid = pid; });
+    [&backend_pid](pqxx::notification n) noexcept
+    { backend_pid = n.backend_pid; });
 
   // First see if the timeout really works: we're not expecting any notifs
   int notifs{cx.await_notification(0, 1)};

--- a/test/test79.cxx
+++ b/test/test79.cxx
@@ -2,7 +2,6 @@
 #include <cstring>
 #include <iostream>
 
-#include <pqxx/notification>
 #include <pqxx/transaction>
 #include <pqxx/transactor>
 
@@ -12,48 +11,28 @@
 // Example program for libpqxx.  Test waiting for notification with timeout.
 namespace
 {
-// Sample implementation of notification receiver.
-class TestListener final : public pqxx::notification_receiver
-{
-  bool m_done;
-
-public:
-  explicit TestListener(pqxx::connection &cx, std::string const &Name) :
-          pqxx::notification_receiver(cx, Name), m_done(false)
-  {}
-
-  void operator()(std::string const &, int be_pid) override
-  {
-    m_done = true;
-    PQXX_CHECK_EQUAL(
-      be_pid, conn().backendpid(), "Notification came from wrong backend.");
-
-    std::cout << "Received notification: " << channel() << " pid=" << be_pid
-              << std::endl;
-  }
-
-  bool done() const { return m_done; }
-};
-
-
 void test_079()
 {
   pqxx::connection cx;
 
-  std::string const NotifName{"mylistener"};
-  TestListener L(cx, NotifName);
+  std::string const channel{"mylistener"};
+  int backend_pid{0};
+
+  cx.listen(
+    channel,
+    [&backend_pid](pqxx::zview, int pid, pqxx::zview){ backend_pid = pid; });
 
   // First see if the timeout really works: we're not expecting any notifs
   int notifs{cx.await_notification(0, 1)};
   PQXX_CHECK_EQUAL(notifs, 0, "Got unexpected notification.");
 
-  pqxx::perform([&cx, &L] {
+  pqxx::perform([&cx, &channel] {
     pqxx::work tx{cx};
-    tx.exec("NOTIFY " + L.channel()).no_rows();
+    tx.notify(channel);
     tx.commit();
   });
 
-  for (int i{0}; (i < 20) and not L.done(); ++i)
+  for (int i{0}; (i < 20) and (backend_pid == 0); ++i)
   {
     PQXX_CHECK_EQUAL(notifs, 0, "Got notifications, but no handler called.");
     std::cout << ".";
@@ -61,7 +40,7 @@ void test_079()
   }
   std::cout << std::endl;
 
-  PQXX_CHECK(L.done(), "No notifications received.");
+  PQXX_CHECK_EQUAL(backend_pid, cx.backendpid(), "Wrong backend.");
   PQXX_CHECK_EQUAL(notifs, 1, "Got unexpected notifications.");
 }
 } // namespace

--- a/test/test79.cxx
+++ b/test/test79.cxx
@@ -20,7 +20,8 @@ void test_079()
 
   cx.listen(
     channel,
-    [&backend_pid](pqxx::zview, int pid, pqxx::zview){ backend_pid = pid; });
+    [&backend_pid](pqxx::zview, int pid, pqxx::zview) noexcept
+    { backend_pid = pid; });
 
   // First see if the timeout really works: we're not expecting any notifs
   int notifs{cx.await_notification(0, 1)};

--- a/test/test87.cxx
+++ b/test/test87.cxx
@@ -11,7 +11,6 @@
 
 #include <pqxx/internal/header-post.hxx>
 
-#include <pqxx/notification>
 #include <pqxx/transaction>
 #include <pqxx/transactor>
 

--- a/test/test87.cxx
+++ b/test/test87.cxx
@@ -32,7 +32,8 @@ void test_087()
 
   cx.listen(
     channel,
-    [&backend_pid](pqxx::zview, int pid, pqxx::zview){ backend_pid = pid; });
+    [&backend_pid](pqxx::zview, int pid, pqxx::zview) noexcept
+    { backend_pid = pid; });
 
   pqxx::perform([&cx, &channel] {
     pqxx::work tx{cx};

--- a/test/test87.cxx
+++ b/test/test87.cxx
@@ -32,8 +32,8 @@ void test_087()
 
   cx.listen(
     channel,
-    [&backend_pid](pqxx::zview, int pid, pqxx::zview) noexcept
-    { backend_pid = pid; });
+    [&backend_pid](pqxx::notification n) noexcept
+    { backend_pid = n.backend_pid; });
 
   pqxx::perform([&cx, &channel] {
     pqxx::work tx{cx};

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -35,7 +35,7 @@ public:
 };
 
 
-void test_receive(
+void test_receive_classic(
   pqxx::transaction_base &tx, std::string const &channel,
   char const payload[] = nullptr)
 {
@@ -69,20 +69,102 @@ void test_receive(
 }
 
 
-void test_notification()
+void test_notification_classic()
 {
   pqxx::connection cx;
   TestReceiver receiver(cx, "mychannel");
   PQXX_CHECK_EQUAL(receiver.channel(), "mychannel", "Bad channel.");
 
   pqxx::work tx{cx};
-  test_receive(tx, "channel1");
+  test_receive_classic(tx, "channel1");
 
   pqxx::nontransaction u(cx);
-  test_receive(u, "channel2", "payload");
+  test_receive_classic(u, "channel2", "payload");
 }
 #include <pqxx/internal/ignore-deprecated-post.hxx>
 
 
-PQXX_REGISTER_TEST(test_notification);
+void test_notification_to_self_arrives_after_commit()
+{
+  pqxx::connection cx;
+
+  auto const channel{"pqxx_test_channel"};
+  int notifications{0};
+  pqxx::connection *conn;
+  std::string incoming, payload;
+  int pid{0};
+
+  cx.listen(
+    channel,
+    [&notifications, &conn, &incoming, &payload, &pid](pqxx::notification n){
+      ++notifications;
+      conn = &n.conn;
+      incoming = n.channel;
+      pid = n.backend_pid;
+      payload = n.payload;
+    });
+
+  cx.get_notifs();
+
+  // No notifications so far.
+  PQXX_CHECK_EQUAL(notifications, 0, "Unexpected notification.");
+
+  pqxx::work tx{cx};
+  tx.notify(channel);
+  int received{cx.await_notification(0, 300)};
+
+  // Notification has not been delivered yet, since transaction has not yet
+  // been committed.
+  PQXX_CHECK_EQUAL(received, 0, "Notification went out before commit.");
+  PQXX_CHECK_EQUAL(notifications, 0, "Received uncounted notification.");
+
+  tx.commit();
+
+  received = cx.await_notification(3);
+  PQXX_CHECK_EQUAL(received, 1, "Did not receive 1 notification from self.");
+  PQXX_CHECK_EQUAL(notifications, 1, "Miscounted notifcations.");
+  PQXX_CHECK(conn == &cx, "Wrong connection on notification from self.");
+  PQXX_CHECK_EQUAL(
+    pid, cx.backendpid(), "Notification from self came from wrong connection.");
+  PQXX_CHECK_EQUAL(incoming, channel, "Notification is on wrong channel.");
+  PQXX_CHECK_EQUAL(payload, "", "Unexpected payload.");
+}
+
+
+void test_notification_has_payload()
+{
+  pqxx::connection cx;
+
+  auto const channel{"pqxx-ichan"}, payload{"two dozen eggs"};
+  int notifications{0};
+  std::string received;
+
+  cx.listen(
+    channel,
+    [&notifications, &received](pqxx::notification n) {
+      ++notifications;
+      received = n.payload;
+    });
+
+  pqxx::work tx{cx};
+  tx.notify(channel, payload);
+  tx.commit();
+
+  cx.await_notification(3);
+
+  PQXX_CHECK_EQUAL(notifications, 1, "Expeccted 1 self-notification.");
+  PQXX_CHECK_EQUAL(received, payload, "Unexpected payload.");
+}
+
+// XXX: different kinds of callable, including different signatures.
+// XXX: nontransaction.
+// XXX: subtransaction.
+// XXX: refuses to listen() while in a transaction.
+// XXX: send across connections.
+// XXX: Choosing (just) the right one out of multiple handlers.
+
+
+PQXX_REGISTER_TEST(test_notification_classic);
+PQXX_REGISTER_TEST(test_notification_to_self_arrives_after_commit);
+PQXX_REGISTER_TEST(test_notification_has_payload);
 } // namespace

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -13,6 +13,7 @@
 
 namespace
 {
+#include <pqxx/internal/ignore-deprecated-pre.hxx>
 class TestReceiver final : public pqxx::notification_receiver
 {
 public:
@@ -80,6 +81,7 @@ void test_notification()
   pqxx::nontransaction u(cx);
   test_receive(u, "channel2", "payload");
 }
+#include <pqxx/internal/ignore-deprecated-post.hxx>
 
 
 PQXX_REGISTER_TEST(test_notification);


### PR DESCRIPTION
No more inheritance, no more virtual functions, no more mandatory base class — just pass in a lambda or any other matching callable.

Only one handler per channel — makes the channel name the key, and you can disable a handler simply by overwriting it.

No more hassle with case-insensitive channel names.  We'll just quote them consistently.

No more logging of exceptions, to a notice-processing callback which probably just ignores the message.  Exceptions during handling now just propagate up the call chain.