### PR TITLE
Make `listen()` follow `connection` moves.

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -118,6 +118,7 @@ pqxx::encrypt_password(char const user[], char const password[])
 pqxx::connection::connection(connection &&rhs) :
         m_conn{rhs.m_conn},
 	m_notice_waiters{std::move(rhs.m_notice_waiters)},
+	m_notification_handlers{std::move(rhs.m_notification_handlers)},
 	m_unique_id{rhs.m_unique_id}
 {
   rhs.check_movable();
@@ -251,11 +252,13 @@ pqxx::connection &pqxx::connection::operator=(connection &&rhs)
   check_overwritable();
   rhs.check_movable();
 
+  // Close our old connection, if any.
   close();
 
   m_conn = std::exchange(rhs.m_conn, nullptr);
   m_unique_id = rhs.m_unique_id;
   m_notice_waiters = std::move(rhs.m_notice_waiters);
+  m_notification_handlers = std::move(rhs.m_notification_handlers);
 
   return *this;
 }

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -420,6 +420,22 @@ void test_notifications_do_not_come_in_until_commit()
 }
 
 
+void test_notification_handlers_follow_connection_move()
+{
+  auto const chan{"pqxx-chan3782"};
+  pqxx::connection cx1;
+  pqxx::connection *got{nullptr};
+  cx1.listen(chan, [&got](pqxx::notification n){ got = &n.conn; });
+  pqxx::connection cx2{std::move(cx1)};
+  pqxx::work tx{cx2};
+  tx.notify(chan);
+  tx.commit();
+  cx2.await_notification(3);
+  PQXX_CHECK(got != nullptr, "Did not get notified.");
+  PQXX_CHECK(got == &cx2, "Notification got the wrong connection.");
+}
+
+
 PQXX_REGISTER_TEST(test_notification_classic);
 PQXX_REGISTER_TEST(test_notification_to_self_arrives_after_commit);
 PQXX_REGISTER_TEST(test_notification_has_payload);
@@ -436,4 +452,5 @@ PQXX_REGISTER_TEST(test_notification_goes_to_right_handler);
 PQXX_REGISTER_TEST(test_listen_on_same_channel_overwrites);
 PQXX_REGISTER_TEST(test_empty_notification_handler_disables);
 PQXX_REGISTER_TEST(test_notifications_do_not_come_in_until_commit);
+PQXX_REGISTER_TEST(test_notification_handlers_follow_connection_move);
 } // namespace

--- a/test/unit/test_notification.cxx
+++ b/test/unit/test_notification.cxx
@@ -427,12 +427,14 @@ void test_notification_handlers_follow_connection_move()
   pqxx::connection *got{nullptr};
   cx1.listen(chan, [&got](pqxx::notification n){ got = &n.conn; });
   pqxx::connection cx2{std::move(cx1)};
-  pqxx::work tx{cx2};
+  pqxx::connection cx3;
+  cx3 = std::move(cx2);
+  pqxx::work tx{cx3};
   tx.notify(chan);
   tx.commit();
-  cx2.await_notification(3);
+  cx3.await_notification(3);
   PQXX_CHECK(got != nullptr, "Did not get notified.");
-  PQXX_CHECK(got == &cx2, "Notification got the wrong connection.");
+  PQXX_CHECK(got == &cx3, "Notification got the wrong connection.");
 }
 
 


### PR DESCRIPTION
When move-constructing or move-assigning a connection, have any notification handlers go along as well.