### PR TITLE
Oops, minimum CMake is 3.12, not 3.28.

### DIFF
--- a/BUILDING-cmake.md
+++ b/BUILDING-cmake.md
@@ -57,7 +57,7 @@ your code will link with libpqxx.  For example, if your project is named
 So a simple working `CMakeLists.txt` might be:
 
 ```cmake
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.12)
 project(ausom)
 set(CMAKE_CXX_STANDARD 20)
 add_executable(ausom src/ausom.cxx)
@@ -93,7 +93,7 @@ your code will link with libpqxx.  For example, if your project is named
 So a simple working `CMakeLists.txt` might be:
 
 ```cmake
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.12)
 project(ausom)
 set(CMAKE_CXX_STANDARD 20)
 add_executable(ausom src/ausom.cxx)

--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@
 7.10.0
  - Deprecate `errorhandler`; replace with lambda-friendly "notice handlers."
  - Deprecate `notification_receiver`; replace with "notification handlers"
- - Bump minimum CMake version to 3.28. (#874)
+ - Bump minimum CMake version to 3.12. (#851, #874)
  - Fixed error message on clashing transaction focuses. (#879)
  - Don't call`/bin/true`; macOS doesn't have it.  Just call `true`. (#885)
  - Deprecate `exec_prepared()`; just use `exec()` with a `pqxx::prepped`.

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 7.10.1
  - Remove `-fanalyzer` option again; gcc is still broken.
+ - Oops, no, minimum CMake version is not 3.28, but 3.12!
 7.10.0
  - Deprecate `errorhandler`; replace with lambda-friendly "notice handlers."
  - Deprecate `notification_receiver`; replace with "notification handlers"


### PR DESCRIPTION
Fixes: #916.

Don't know how that typo got in there.  There was a lot of hullabaloo over CMake changes back in #851, which led to the version bump.