### PR TITLE
Silence `clang-tidy` warnings.

### DIFF
--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub install-sh ltmain.sh missing mkinstalldirs
+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/src/binarystring.cxx
+++ b/src/binarystring.cxx
@@ -36,6 +36,7 @@ std::shared_ptr<unsigned char>
   PQXX_COLD copy_to_buffer(void const *data, std::size_t len)
 {
   std::shared_ptr<unsigned char> ptr{
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,hicpp-no-malloc)
     static_cast<unsigned char *>(malloc(len + 1)), std::free};
   if (not ptr)
     throw std::bad_alloc{};

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -44,6 +44,7 @@ void pqxx::internal::clear_result(pq::PGresult const *data) noexcept
   // This acts as a destructor, though implemented as a regular function so we
   // can pass it into a smart pointer.  That's why I think it's kind of fair
   // to treat the PGresult as const.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   PQclear(const_cast<pq::PGresult *>(data));
 }
 
@@ -362,6 +363,7 @@ char const *pqxx::result::cmd_status() const noexcept
   // PQcmdStatus() can't take a PGresult const * because it returns a non-const
   // pointer into the PGresult's data, and that can't be changed without
   // breaking compatibility.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   return PQcmdStatus(const_cast<internal::pq::PGresult *>(m_data.get()));
 }
 
@@ -383,12 +385,13 @@ pqxx::oid pqxx::result::inserted_oid() const
 
 pqxx::result::size_type pqxx::result::affected_rows() const
 {
-  // PQcmdTuples() can't take a PGresult const * because it returns a non-const
-  // pointer into the PGresult's data, and that can't be changed without
-  // breaking compatibility.
-  auto const rows_str{
+  // PQcmdTuples() can't take a "PGresult const *" because it returns a
+  // non-const pointer into the PGresult's data, and that can't be changed
+  // without breaking compatibility.
+  std::string_view const rows_str{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     PQcmdTuples(const_cast<internal::pq::PGresult *>(m_data.get()))};
-  return (rows_str[0] == '\0') ? 0 : size_type(atoi(rows_str));
+  return from_string<size_type>(rows_str);
 }
 
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -237,7 +237,7 @@ std::string demangle_type_name(char const raw[])
   // When __cxa_demangle fails, it's guaranteed to return null.
   std::unique_ptr<char, void (*)(char *)> const demangled{
     abi::__cxa_demangle(raw, nullptr, nullptr, &status),
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, hicpp-no-malloc)
+    // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
     [](char *x) { std::free(x); }};
 #else
   std::unique_ptr<char> demangled{};

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -151,6 +151,7 @@ wrap_to_chars(char *begin, char *end, T const &value)
 namespace pqxx::internal
 {
 template<typename T>
+// NOLINTNEXTLINE(readability-non-const-parameter)
 zview integral_traits<T>::to_buf(char *begin, char *end, T const &value)
 {
   static_assert(std::is_integral_v<T>);
@@ -236,6 +237,7 @@ std::string demangle_type_name(char const raw[])
   // When __cxa_demangle fails, it's guaranteed to return null.
   std::unique_ptr<char, void (*)(char *)> const demangled{
     abi::__cxa_demangle(raw, nullptr, nullptr, &status),
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, hicpp-no-malloc)
     [](char *x) { std::free(x); }};
 #else
   std::unique_ptr<char> demangled{};

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -110,8 +110,7 @@ constexpr std::array<char, 16u> hex_digits{
 /// Translate a number (must be between 0 and 16 exclusive) to a hex digit.
 constexpr char hex_digit(int c) noexcept
 {
-  assert(c >= 0 and c < pqxx::internal::ssize(hex_digits));
-  return hex_digits[static_cast<unsigned int>(c)];
+  return hex_digits.at(static_cast<unsigned int>(c));
 }
 
 
@@ -207,6 +206,7 @@ void pqfreemem(void const *ptr) noexcept
 {
   // Why is it OK to const_cast here?  Because this is the C equivalent to a
   // destructor.  Those apply to const objects as well as non-const ones.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   PQfreemem(const_cast<void *>(ptr));
 }
 } // namespace pqxx::internal::pq


### PR DESCRIPTION
These warnings fell into 3 categories:
1. Useful warnings — many, but already fixed.
2. _Scènes à faire_ — nothing to be done but suppress them.
3. Painful advice — implemented here, accepting a small performance cost.

One `std::free()` in `strconv.cxx` triggered _three_ clang-tidy warnings — more than could fit on one healthy line.  I didn't want blanket suppression, but as a compromise, it turned out that wildcards worked.  (Perhaps I could have gotten by with a backslash-escaped newline in that comment, but that's just gruesome.)  Blanket suppression of warning signs is of course a bad thing.

But for now... clean yet thorough lint check!