### PR TITLE
Enable warnings for missed NRVO opportunities.

### DIFF
--- a/configure
+++ b/configure
@@ -17171,6 +17171,7 @@ then
 			-Warray-bounds=2 \
 			-Wduplicated-branches \
 			-Wduplicated-cond \
+			-Wnrvo \
 			-Wsuggest-attribute=noreturn \
 			-Wsuggest-override \
 			-Wtrampolines

--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ then
 			-Warray-bounds=2 \
 			-Wduplicated-branches \
 			-Wduplicated-cond \
+			-Wnrvo \
 			-Wsuggest-attribute=noreturn \
 			-Wsuggest-override \
 			-Wtrampolines


### PR DESCRIPTION
The compilers on my system don't seem to support this yet, but I want to know how it works out: enable warnings for missed oppurtinities to get the Named Return Value Optimization in gcc & clang.