### PR TITLE
Enable some gcc/clang runtime checks.

### DIFF
--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
+	config.sub install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/configure
+++ b/configure
@@ -17103,6 +17103,7 @@ then
 		# "Eternal" (FLW) g++ options.  These have been around for
 		# ages, and both g++ and clang++ support them.  Don't bother
 		# checking for support; just add them to the compiler options.
+		# TODO: Add -D_GLIBCXX_CONCEPT_CHECKS in 8.0.
 		add_compiler_opts \
 			-fstrict-enums \
 			-Werror \
@@ -17181,6 +17182,10 @@ then
 	then
 		add_compiler_opts_if_ok \
 			-D_FORTIFY_SOURCE=2 \
+			-D_GLIBCXX_ASSERTIONS \
+			-D_GLIBCXX_DEBUG \
+			-D_GLIBCXX_DEBUG_PEDANTIC \
+			-D_GLIBCXX_SANITIZE_VECTOR \
 			-fsanitize=address \
 			-fsanitize-address-use-after-scope \
 			-fsanitize=alignment \

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,7 @@ then
 		# "Eternal" (FLW) g++ options.  These have been around for
 		# ages, and both g++ and clang++ support them.  Don't bother
 		# checking for support; just add them to the compiler options.
+		# TODO: Add -D_GLIBCXX_CONCEPT_CHECKS in 8.0.
 		add_compiler_opts \
 			-fstrict-enums \
 			-Werror \
@@ -203,6 +204,10 @@ then
 	then
 		add_compiler_opts_if_ok \
 			-D_FORTIFY_SOURCE=2 \
+			-D_GLIBCXX_ASSERTIONS \
+			-D_GLIBCXX_DEBUG \
+			-D_GLIBCXX_DEBUG_PEDANTIC \
+			-D_GLIBCXX_SANITIZE_VECTOR \
 			-fsanitize=address \
 			-fsanitize-address-use-after-scope \
 			-fsanitize=alignment \

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -12,15 +12,6 @@
 
 #include "test_helpers.hxx"
 
-namespace
-{
-inline std::string deref_field(pqxx::field const &f)
-{
-  return f.c_str();
-}
-} // namespace
-
-
 namespace pqxx::test
 {
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
@@ -101,7 +92,9 @@ void expected_exception(std::string const &message)
 
 std::string list_row(row Obj)
 {
-  return separated_list(", ", std::begin(Obj), std::end(Obj), deref_field);
+  return separated_list(
+    ", ", std::begin(Obj), std::end(Obj),
+    [](pqxx::field const &f) { return f.view(); });
 }
 
 

--- a/test/unit/test_result_iteration.cxx
+++ b/test/unit/test_result_iteration.cxx
@@ -1,3 +1,5 @@
+#include <iterator>
+
 #include <pqxx/stream_to>
 #include <pqxx/transaction>
 

--- a/test/unit/test_result_iteration.cxx
+++ b/test/unit/test_result_iteration.cxx
@@ -12,7 +12,9 @@ void test_result_iteration()
   pqxx::connection cx;
   pqxx::work tx{cx};
   pqxx::result r{tx.exec("SELECT generate_series(1, 3)")};
+#if defined(PQXX_HAVE_CONCEPTS)
   static_assert(std::forward_iterator<decltype(r.begin())>);
+#endif
 
   PQXX_CHECK(std::end(r) != std::begin(r), "Broken begin/end.");
   PQXX_CHECK(std::rend(r) != std::rbegin(r), "Broken rbegin/rend.");

--- a/test/unit/test_result_iteration.cxx
+++ b/test/unit/test_result_iteration.cxx
@@ -10,6 +10,7 @@ void test_result_iteration()
   pqxx::connection cx;
   pqxx::work tx{cx};
   pqxx::result r{tx.exec("SELECT generate_series(1, 3)")};
+  static_assert(std::forward_iterator<decltype(r.begin())>);
 
   PQXX_CHECK(std::end(r) != std::begin(r), "Broken begin/end.");
   PQXX_CHECK(std::rend(r) != std::rbegin(r), "Broken rbegin/rend.");

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -8,8 +8,8 @@ void test_row()
 {
   pqxx::connection cx;
   pqxx::work tx{cx};
-  pqxx::result rows{tx.exec("SELECT 1, 2, 3")};
-  pqxx::row r{rows[0]};
+  pqxx::row r{tx.exec("SELECT 1, 2, 3").one_row()};
+  static_assert(std::forward_iterator<decltype(r.begin())>);
   PQXX_CHECK_EQUAL(std::size(r), 3, "Unexpected row size.");
   PQXX_CHECK_EQUAL(r.at(0).as<int>(), 1, "Wrong value at index 0.");
   PQXX_CHECK(std::begin(r) != std::end(r), "Broken row iteration.");

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -1,3 +1,5 @@
+#include <iterator>
+
 #include <pqxx/transaction>
 
 #include "../test_helpers.hxx"

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -11,7 +11,9 @@ void test_row()
   pqxx::connection cx;
   pqxx::work tx{cx};
   pqxx::row r{tx.exec("SELECT 1, 2, 3").one_row()};
+#if defined(PQXX_HAVE_CONCEPTS)
   static_assert(std::forward_iterator<decltype(r.begin())>);
+#endif
   PQXX_CHECK_EQUAL(std::size(r), 3, "Unexpected row size.");
   PQXX_CHECK_EQUAL(r.at(0).as<int>(), 1, "Wrong value at index 0.");
   PQXX_CHECK(std::begin(r) != std::end(r), "Broken row iteration.");


### PR DESCRIPTION
This includes a bounds check on all array-index operators.

See [GNU libstdc++ documentation](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html) for the meanings of these macros.