### PR TITLE
Bugfix: (sparse) arrays' size_buffer() - not accounting for separator for NULL values

### DIFF
--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -1120,9 +1120,9 @@ public:
                      // Budget for each element includes a terminating zero.
                      // We won't actually be wanting those, but don't subtract
                      // that one byte: we want room for a separator instead.
-                     // However, std::size(s_null) doesn't account for a
-                     // separator, so add one to make s_null pay for its own
-                     // separator.
+                     // However, std::size(s_null) doesn't account for the
+                     // terminating zero, so add one to make s_null pay for its
+                     // own separator.
                      return acc + (pqxx::is_null(elt) ?
                                      (std::size(s_null) + 1) :
                                      elt_traits::size_buffer(elt));
@@ -1133,10 +1133,9 @@ public:
                    [](std::size_t acc, elt_type const &elt) {
                      // Opening and closing quotes, plus worst-case escaping,
                      // and the one byte for the trailing zero becomes room
-                     // for a separator.
-                     // std::size(s_null) doesn't account for a
-                     // separator, so add one to make s_null pay for its own
-                     // separator.
+                     // for a separator. However, std::size(s_null) doesn't
+                     // account for the terminating zero, so add one to make
+                     // s_null pay for its own separator.
                      std::size_t const elt_size{
                        pqxx::is_null(elt) ? (std::size(s_null) + 1) :
                                             elt_traits::size_buffer(elt)};

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -1120,8 +1120,11 @@ public:
                      // Budget for each element includes a terminating zero.
                      // We won't actually be wanting those, but don't subtract
                      // that one byte: we want room for a separator instead.
+                     // However, std::size(s_null) doesn't account for a
+                     // separator, so add one to make s_null pay for its own
+                     // separator.
                      return acc + (pqxx::is_null(elt) ?
-                                     std::size(s_null) :
+                                     (std::size(s_null) + 1) :
                                      elt_traits::size_buffer(elt));
                    });
     else
@@ -1131,8 +1134,11 @@ public:
                      // Opening and closing quotes, plus worst-case escaping,
                      // and the one byte for the trailing zero becomes room
                      // for a separator.
+                     // std::size(s_null) doesn't account for a
+                     // separator, so add one to make s_null pay for its own
+                     // separator.
                      std::size_t const elt_size{
-                       pqxx::is_null(elt) ? std::size(s_null) :
+                       pqxx::is_null(elt) ? (std::size(s_null) + 1) :
                                             elt_traits::size_buffer(elt)};
                      return acc + 2 * elt_size + 2;
                    });

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -436,6 +436,31 @@ void test_array_generate_empty_strings()
     "Array of 12 empty strings came out wrong.");
 }
 
+void test_sparse_arrays()
+{
+  // Reproduce # : NULL not paying for its separator in an array
+
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string(std::vector<std::optional<int>>{
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt}),
+    "{NULL,NULL,NULL,NULL}",
+    "Array of optional<int> filled with std::nullopt came out wrong");
+
+  std::vector<std::optional<int>> sparseVectorOfOptionalInts(13, std::nullopt);
+  sparseVectorOfOptionalInts.push_back(42);
+
+  std::array<std::optional<int>, 14> sparseArray{std::nullopt, std::nullopt,
+                                                 std::nullopt, std::nullopt,
+                                                 std::nullopt, std::nullopt,
+                                                 std::nullopt, std::nullopt,
+                                                 std::nullopt, std::nullopt,
+                                                 std::nullopt, std::nullopt,
+                                                 std::nullopt, 42};
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string(sparseArray),
+    "{NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,42}",
+    "A sparsely filled array of optional<int> came out wrong");
+}
 
 void test_array_generate()
 {
@@ -445,6 +470,7 @@ void test_array_generate()
   test_generate_multiple_items();
   test_generate_nested_array();
   test_generate_escaped_strings();
+  test_sparse_arrays();
 }
 
 

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -447,9 +447,6 @@ void test_sparse_arrays()
     "{NULL,NULL,NULL,NULL}",
     "Array of optional<int> filled with std::nullopt came out wrong");
 
-  std::vector<std::optional<int>> sparseVectorOfOptionalInts(13, std::nullopt);
-  sparseVectorOfOptionalInts.push_back(42);
-
   std::array<std::optional<int>, 14> sparseArray{std::nullopt, std::nullopt,
                                                  std::nullopt, std::nullopt,
                                                  std::nullopt, std::nullopt,

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -438,7 +438,8 @@ void test_array_generate_empty_strings()
 
 void test_sparse_arrays()
 {
-  // Reproduce # : NULL not paying for its separator in an array
+  // Reproduce #922 : NULL not paying for its separator in an array, causing
+  // problems in sparse arrays
 
   PQXX_CHECK_EQUAL(
     pqxx::to_string(std::vector<std::optional<int>>{

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -442,8 +442,7 @@ void test_sparse_arrays()
   // problems in sparse arrays.
 
   // If NULL didn't pay for its separator, the size allocated for an array-like
-  // object filled with null-like values would be too small when array size is
-  // >= 4.
+  // object filled with null-like values would be too small.
 
   auto arrayOfNulls = std::vector<std::optional<int>>(4, std::nullopt);
   std::string arrayOfNullsStr = "{NULL,NULL,NULL,NULL}";

--- a/test/unit/test_array.cxx
+++ b/test/unit/test_array.cxx
@@ -449,8 +449,8 @@ void test_sparse_arrays()
 
   PQXX_CHECK(
     pqxx::size_buffer(arrayOfNulls) >= arrayOfNullsStr.size(),
-    "Size allocated for an array of optional<int> filled with nulls was too "
-    "small.");
+    "Buffer size allocated for an array of optional<int> filled with nulls "
+    "was too small.");
 
   PQXX_CHECK_EQUAL(
     pqxx::to_string(arrayOfNulls), arrayOfNullsStr,
@@ -471,8 +471,8 @@ void test_sparse_arrays()
 
   PQXX_CHECK(
     pqxx::size_buffer(sparseArray) >= sparseArrayStr.size(),
-    "Size allocated for a sparsely-filled array of optional<int> was too "
-    "small.");
+    "Buffer size allocated for a sparsely-filled array of optional<int> was "
+    "too small.");
 
   PQXX_CHECK_EQUAL(
     pqxx::to_string(sparseArray), sparseArrayStr,


### PR DESCRIPTION
This is a fix for https://github.com/jtv/libpqxx/issues/922 

@jtv This change passes the tests and fixes my app's crash, but I dont know the codebase well-enough to tell if there are any unintended side-effects from this - PTAL. 


Thanks! 