### PR TITLE
String conversion to `string_view`.  More binary types.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
  - C++20 is now the oldest C++ version that libpqxx supports.
  - "String conversion" to `std::string_view` is now supported. (#694)
  - **Beware lifetime** when "converting" a string to `std::string_view`!
+ - Conversion from string to `char const *` is no longer allowed.
  - Binary data can be any `std::contiguous_range` of `std::byte`. (#925)
  - Retired `binarystring` and its headers.  Use `blob` instead.
  - Retired `connection_base` type alias.  Use `connection`.

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 8.0.0
  - C++20 is now the oldest C++ version that libpqxx supports.
+ - "String conversion" to `std::string_view` is now supported. (#694)
+ - **Beware lifetime** when "converting" a string to `std::string_view`!
+ - Binary data can be any `std::contiguous_range` of `std::byte`. (#925)
  - Retired `binarystring` and its headers.  Use `blob` instead.
  - Retired `connection_base` type alias.  Use `connection`.
  - Retired `pqxx::encrypt_password()`.  Use the ones in `pqxx::connection`.

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
+	config.sub install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -344,44 +344,13 @@ template<> inline bool field::to<char const *>(char const *&obj) const
 }
 
 
-template<> inline bool field::to<std::string_view>(std::string_view &obj) const
-{
-  bool const null{is_null()};
-  if (not null)
-    obj = view();
-  return not null;
-}
-
-
-template<>
-inline bool field::to<std::string_view>(
-  std::string_view &obj, std::string_view const &default_value) const
-{
-  bool const null{is_null()};
-  if (null)
-    obj = default_value;
-  else
-    obj = view();
-  return not null;
-}
-
-
-template<> inline std::string_view field::as<std::string_view>() const
-{
-  if (is_null())
-    internal::throw_null_conversion(type_name<std::string_view>);
-  return view();
-}
-
-
-template<>
-inline std::string_view
-field::as<std::string_view>(std::string_view const &default_value) const
-{
-  return is_null() ? default_value : view();
-}
-
-
+/// Specialization: `to(zview &)`.
+/** This conversion is not generally available, since the general conversion
+ * would not know whether there was indeed a terminating zero at the end of
+ * the string.  (It could check, but it would have no way of knowing that a
+ * zero occurring after the string in memory was actually part of the same
+ * allocation.)
+ */
 template<> inline bool field::to<zview>(zview &obj) const
 {
   bool const null{is_null()};

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -673,7 +673,6 @@ template<> struct string_traits<std::string_view>
     return generic_to_buf(begin, end, value);
   }
 
-  /// Don't convert to this type; it has nowhere to store its contents.
   static std::string_view from_string(std::string_view value) { return value; }
 };
 

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -120,8 +120,8 @@ template<std::floating_point T> struct float_string_traits
 
   static PQXX_LIBEXPORT T from_string(std::string_view text);
 
-  static PQXX_LIBEXPORT
-  pqxx::zview to_buf(char *begin, char *end, T const &value);
+  static PQXX_LIBEXPORT pqxx::zview
+  to_buf(char *begin, char *end, T const &value);
 
   static PQXX_LIBEXPORT char *into_buf(char *begin, char *end, T const &value);
 
@@ -225,7 +225,8 @@ template<>
 struct string_traits<double> : pqxx::internal::float_string_traits<double>
 {};
 template<>
-struct string_traits<long double> : pqxx::internal::float_string_traits<long double>
+struct string_traits<long double>
+        : pqxx::internal::float_string_traits<long double>
 {};
 
 
@@ -670,10 +671,7 @@ template<> struct string_traits<std::string_view>
   }
 
   /// Don't convert to this type; it has nowhere to store its contents.
-  static std::string_view from_string(std::string_view value)
-  {
-    return value;
-  }
+  static std::string_view from_string(std::string_view value) { return value; }
 };
 
 
@@ -1055,7 +1053,8 @@ public:
 
 namespace pqxx
 {
-template<nonbinary_range T> struct nullness<T> : no_null<T> {};
+template<nonbinary_range T> struct nullness<T> : no_null<T>
+{};
 
 
 template<nonbinary_range T>
@@ -1064,16 +1063,14 @@ struct string_traits<T> : internal::array_string_traits<T>
 
 
 /// We don't know how to pass array params in binary format, so pass as text.
-template<nonbinary_range T>
-inline constexpr format param_format(T const &)
+template<nonbinary_range T> inline constexpr format param_format(T const &)
 {
   return format::text;
 }
 
 
 /// A contiguous range of `std::byte` is a binary string; other ranges are not.
-template<binary T>
-inline constexpr format param_format(T const &)
+template<binary T> inline constexpr format param_format(T const &)
 {
   return format::binary;
 }

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -483,7 +483,10 @@ template<> struct string_traits<char const *>
   static constexpr bool converts_to_string{true};
   static constexpr bool converts_from_string{true};
 
-  /// @warning The string's lifetime depends on the original.
+  /// @warning The string's lifetime depends on the original!
+  /** When the original string that you're converting becmoes invalid in any
+   * way, so does the pointer that you get from this.
+   */
   static char const *from_string(std::string_view text) { return text.data(); }
 
   static zview to_buf(char *begin, char *end, char const *const &value)
@@ -708,7 +711,7 @@ template<> struct string_traits<zview>
   }
 
   /// Don't convert to this type.  There may not be a terminating zero.
-  /** There is no validway to figure out here whether there is a terminating
+  /** There is no valid way to figure out here whether there is a terminating
    * zero.  Even if there is one, that may just be the first byte of an
    * entirely separately allocated piece of memory.
    */

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -106,8 +106,10 @@ public:
   /// Append a non-null binary parameter.
   void append(bytes &&) &;
 
+  /// Append all parameters in `value`.
   void append(params const &value) &;
 
+  /// Append all parameters in `value`.
   void append(params &&value) &;
 
   /// Append a non-null parameter, converting it to its string

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -198,6 +198,11 @@ template<typename TYPE> struct string_traits
    * for a value of this type.
    *
    * @warning A null value has no string representation.  Do not parse a null.
+   *
+   * @warning If you convert a string to `std::string_view`, you're basically
+   * just getting a pointer into the original buffer.  So, the `string_view`
+   * will become invalid when the original string's lifetime ends, or gets
+   * overwritten.  Do not access the `string_view` you got after that!
    */
   [[nodiscard]] static inline TYPE from_string(std::string_view text);
 
@@ -590,19 +595,6 @@ inline zview generic_to_buf(char *begin, char *end, TYPE const &value)
   else
     return {begin, traits::into_buf(begin, end, value) - begin - 1};
 }
-
-
-/// Concept: Binary string, akin to @c std::string for binary data.
-/** Any type that satisfies this concept can represent an SQL BYTEA value.
- *
- * A @c binary has a @c begin(), @c end(), @c size(), and @data().  Each byte
- * is a @c std::byte, and they must all be laid out contiguously in memory so
- * we can reference them by a pointer.
- */
-template<typename TYPE>
-concept binary =
-  std::ranges::contiguous_range<TYPE> and
-  std::is_same_v<std::remove_cvref_t<value_type<TYPE>>, std::byte>;
 //@}
 } // namespace pqxx
 

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -102,6 +102,27 @@ concept potential_binary =
   std::ranges::contiguous_range<DATA> and (sizeof(value_type<DATA>) == 1);
 
 
+/// Concept: Binary string, akin to @c std::string for binary data.
+/** Any type that satisfies this concept can represent an SQL BYTEA value.
+ *
+ * A @c binary has a @c begin(), @c end(), @c size(), and @data().  Each byte
+ * is a @c std::byte, and they must all be laid out contiguously in memory so
+ * we can reference them by a pointer.
+ */
+template<typename T>
+concept binary =
+  std::ranges::contiguous_range<T> and
+  std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte>;
+
+
+/// A series of something that's not bytes.
+template<typename T>
+concept nonbinary_range =
+  std::ranges::range<T> and
+  not std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte> and
+  not std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, char>;
+
+
 /// Marker for @ref stream_from constructors: "stream from table."
 /** @deprecated Use @ref stream_from::table() instead.
  */
@@ -113,6 +134,22 @@ struct from_table_t
  */
 struct from_query_t
 {};
-
 } // namespace pqxx
+
+
+namespace pqxx::internal
+{
+/// Concept: one of the "char" types.
+template<typename T>
+concept char_type =
+  std::same_as<std::remove_cv_t<T>, char> or
+  std::same_as<std::remove_cv_t<T>, signed char> or
+  std::same_as<std::remove_cv_t<T>, unsigned char>;
+
+
+/// Concept: an integral number type.
+/** Unlike `std::integral`, this does not include the `char` types.
+ */
+template<typename T> concept integer = std::integral<T> and not char_type<T>;
+} // namespace pqxx::internal
 #endif

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -112,15 +112,18 @@ concept potential_binary =
 template<typename T>
 concept binary =
   std::ranges::contiguous_range<T> and
-  std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte>;
+  std::same_as<
+    std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte>;
 
 
 /// A series of something that's not bytes.
 template<typename T>
 concept nonbinary_range =
   std::ranges::range<T> and
-  not std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte> and
-  not std::same_as<std::remove_cvref_t<std::ranges::range_reference_t<T>>, char>;
+  not std::same_as<
+    std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte> and
+  not std::same_as<
+    std::remove_cvref_t<std::ranges::range_reference_t<T>>, char>;
 
 
 /// Marker for @ref stream_from constructors: "stream from table."
@@ -141,15 +144,15 @@ namespace pqxx::internal
 {
 /// Concept: one of the "char" types.
 template<typename T>
-concept char_type =
-  std::same_as<std::remove_cv_t<T>, char> or
-  std::same_as<std::remove_cv_t<T>, signed char> or
-  std::same_as<std::remove_cv_t<T>, unsigned char>;
+concept char_type = std::same_as<std::remove_cv_t<T>, char> or
+                    std::same_as<std::remove_cv_t<T>, signed char> or
+                    std::same_as<std::remove_cv_t<T>, unsigned char>;
 
 
 /// Concept: an integral number type.
 /** Unlike `std::integral`, this does not include the `char` types.
  */
-template<typename T> concept integer = std::integral<T> and not char_type<T>;
+template<typename T>
+concept integer = std::integral<T> and not char_type<T>;
 } // namespace pqxx::internal
 #endif

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -334,7 +334,7 @@ using bytes_view = std::conditional<
  * @warning You must keep the storage holding the actual data alive for as
  * long as you might use this function's return value.
  */
-template<potential_binary TYPE> bytes_view binary_cast(TYPE const &data)
+template<potential_binary TYPE> inline bytes_view binary_cast(TYPE const &data)
 {
   static_assert(sizeof(value_type<TYPE>) == 1);
   // C++20: Use std::as_bytes.
@@ -453,7 +453,7 @@ inline constexpr std::size_t size_unesc_bin(std::size_t escaped_bytes) noexcept
 }
 
 
-// TODO: Use actual binary type for "data".
+// XXX: Maybe pass a span so we can check length?
 /// Hex-escape binary data into a buffer.
 /** The buffer must be able to accommodate
  * `size_esc_bin(std::size(binary_data))` bytes, and the function will write
@@ -461,6 +461,19 @@ inline constexpr std::size_t size_unesc_bin(std::size_t escaped_bytes) noexcept
  * zero.
  */
 void PQXX_LIBEXPORT esc_bin(bytes_view binary_data, char buffer[]) noexcept;
+
+
+/// Hex-escape binary data into a buffer.
+/** The buffer must be able to accommodate
+ * `size_esc_bin(std::size(binary_data))` bytes, and the function will write
+ * exactly that number of bytes into the buffer.  This includes a trailing
+ * zero.
+ */
+template<binary T>
+inline void esc_bin(T &&binary_data, char buffer[]) noexcept
+{
+  esc_bin(binary_cast(binary_data), buffer);
+}
 
 
 /// Hex-escape binary data into a std::string.

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -469,8 +469,7 @@ void PQXX_LIBEXPORT esc_bin(bytes_view binary_data, char buffer[]) noexcept;
  * exactly that number of bytes into the buffer.  This includes a trailing
  * zero.
  */
-template<binary T>
-inline void esc_bin(T &&binary_data, char buffer[]) noexcept
+template<binary T> inline void esc_bin(T &&binary_data, char buffer[]) noexcept
 {
   esc_bin(binary_cast(binary_data), buffer);
 }

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -144,11 +144,11 @@ inline char *wrap_to_chars(char *begin, char *end, T const &value)
 } // namespace
 
 
-namespace pqxx::internal
+namespace pqxx
 {
-template<std::integral T>
+template<pqxx::internal::integer T>
 // NOLINTNEXTLINE(readability-non-const-parameter)
-zview integral_traits<T>::to_buf(char *begin, char *end, T const &value)
+zview string_traits<T>::to_buf(char *begin, char *end, T const &value)
 {
   static_assert(std::is_integral_v<T>);
   auto const space{end - begin},
@@ -174,23 +174,23 @@ zview integral_traits<T>::to_buf(char *begin, char *end, T const &value)
 }
 
 
-template zview integral_traits<short>::to_buf(char *, char *, short const &);
-template zview integral_traits<unsigned short>::to_buf(
+template zview string_traits<short>::to_buf(char *, char *, short const &);
+template zview string_traits<unsigned short>::to_buf(
   char *, char *, unsigned short const &);
-template zview integral_traits<int>::to_buf(char *, char *, int const &);
+template zview string_traits<int>::to_buf(char *, char *, int const &);
 template zview
-integral_traits<unsigned>::to_buf(char *, char *, unsigned const &);
-template zview integral_traits<long>::to_buf(char *, char *, long const &);
+string_traits<unsigned>::to_buf(char *, char *, unsigned const &);
+template zview string_traits<long>::to_buf(char *, char *, long const &);
 template zview
-integral_traits<unsigned long>::to_buf(char *, char *, unsigned long const &);
+string_traits<unsigned long>::to_buf(char *, char *, unsigned long const &);
 template zview
-integral_traits<long long>::to_buf(char *, char *, long long const &);
-template zview integral_traits<unsigned long long>::to_buf(
+string_traits<long long>::to_buf(char *, char *, long long const &);
+template zview string_traits<unsigned long long>::to_buf(
   char *, char *, unsigned long long const &);
 
 
-template<std::integral T>
-char *integral_traits<T>::into_buf(char *begin, char *end, T const &value)
+template<pqxx::internal::integer T>
+char *string_traits<T>::into_buf(char *begin, char *end, T const &value)
 {
   // This is exactly what to_chars is good at.  Trust standard library
   // implementers to optimise better than we can.
@@ -198,20 +198,20 @@ char *integral_traits<T>::into_buf(char *begin, char *end, T const &value)
 }
 
 
-template char *integral_traits<short>::into_buf(char *, char *, short const &);
-template char *integral_traits<unsigned short>::into_buf(
+template char *string_traits<short>::into_buf(char *, char *, short const &);
+template char *string_traits<unsigned short>::into_buf(
   char *, char *, unsigned short const &);
-template char *integral_traits<int>::into_buf(char *, char *, int const &);
+template char *string_traits<int>::into_buf(char *, char *, int const &);
 template char *
-integral_traits<unsigned>::into_buf(char *, char *, unsigned const &);
-template char *integral_traits<long>::into_buf(char *, char *, long const &);
-template char *integral_traits<unsigned long>::into_buf(
+string_traits<unsigned>::into_buf(char *, char *, unsigned const &);
+template char *string_traits<long>::into_buf(char *, char *, long const &);
+template char *string_traits<unsigned long>::into_buf(
   char *, char *, unsigned long const &);
 template char *
-integral_traits<long long>::into_buf(char *, char *, long long const &);
-template char *integral_traits<unsigned long long>::into_buf(
+string_traits<long long>::into_buf(char *, char *, long long const &);
+template char *string_traits<unsigned long long>::into_buf(
   char *, char *, unsigned long long const &);
-} // namespace pqxx::internal
+} // namespace pqxx
 
 
 namespace pqxx::internal
@@ -420,11 +420,11 @@ inline T PQXX_COLD from_string_awful_float(std::string_view text)
 #endif // !PQXX_HAVE_CHARCONV_FLOAT
 
 
-namespace pqxx::internal
+namespace pqxx
 {
 /// Floating-point to_buf implemented in terms of to_string.
 template<std::floating_point T>
-zview float_traits<T>::to_buf(char *begin, char *end, T const &value)
+zview string_traits<T>::to_buf(char *begin, char *end, T const &value)
 {
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
   {
@@ -456,14 +456,14 @@ zview float_traits<T>::to_buf(char *begin, char *end, T const &value)
 }
 
 
-template zview float_traits<float>::to_buf(char *, char *, float const &);
-template zview float_traits<double>::to_buf(char *, char *, double const &);
+template zview string_traits<float>::to_buf(char *, char *, float const &);
+template zview string_traits<double>::to_buf(char *, char *, double const &);
 template zview
-float_traits<long double>::to_buf(char *, char *, long double const &);
+string_traits<long double>::to_buf(char *, char *, long double const &);
 
 
 template<std::floating_point T>
-char *float_traits<T>::into_buf(char *begin, char *end, T const &value)
+char *string_traits<T>::into_buf(char *begin, char *end, T const &value)
 {
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
   return wrap_to_chars(begin, end, value);
@@ -473,10 +473,10 @@ char *float_traits<T>::into_buf(char *begin, char *end, T const &value)
 }
 
 
-template char *float_traits<float>::into_buf(char *, char *, float const &);
-template char *float_traits<double>::into_buf(char *, char *, double const &);
+template char *string_traits<float>::into_buf(char *, char *, float const &);
+template char *string_traits<double>::into_buf(char *, char *, double const &);
 template char *
-float_traits<long double>::into_buf(char *, char *, long double const &);
+string_traits<long double>::into_buf(char *, char *, long double const &);
 
 
 #if !defined(PQXX_HAVE_CHARCONV_FLOAT)
@@ -489,18 +489,21 @@ to_dumb_stringstream(dumb_stringstream<F> &s, F value)
   return s.str();
 }
 #endif
+} // namespace pqxx
 
 
+namespace pqxx::internal
+{
 /// Floating-point implementations for @c pqxx::to_string().
 template<typename T> std::string to_string_float(T value)
 {
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
   {
-    static constexpr auto space{float_traits<T>::size_buffer(value)};
+    static constexpr auto space{string_traits<T>::size_buffer(value)};
     std::string buf;
     buf.resize(space);
     std::string_view const view{
-      float_traits<T>::to_buf(std::data(buf), std::data(buf) + space, value)};
+      string_traits<T>::to_buf(std::data(buf), std::data(buf) + space, value)};
     buf.resize(static_cast<std::size_t>(std::end(view) - std::begin(view)));
     return buf;
   }
@@ -525,29 +528,29 @@ template<typename T> std::string to_string_float(T value)
 } // namespace pqxx::internal
 
 
-namespace pqxx::internal
+namespace pqxx
 {
-template<std::integral T>
-T integral_traits<T>::from_string(std::string_view text)
+template<pqxx::internal::integer T>
+T string_traits<T>::from_string(std::string_view text)
 {
   return from_string_arithmetic<T>(text);
 }
 
-template short integral_traits<short>::from_string(std::string_view);
+template short string_traits<short>::from_string(std::string_view);
 template unsigned short
-  integral_traits<unsigned short>::from_string(std::string_view);
-template int integral_traits<int>::from_string(std::string_view);
-template unsigned integral_traits<unsigned>::from_string(std::string_view);
-template long integral_traits<long>::from_string(std::string_view);
+  string_traits<unsigned short>::from_string(std::string_view);
+template int string_traits<int>::from_string(std::string_view);
+template unsigned string_traits<unsigned>::from_string(std::string_view);
+template long string_traits<long>::from_string(std::string_view);
 template unsigned long
-  integral_traits<unsigned long>::from_string(std::string_view);
-template long long integral_traits<long long>::from_string(std::string_view);
+  string_traits<unsigned long>::from_string(std::string_view);
+template long long string_traits<long long>::from_string(std::string_view);
 template unsigned long long
-  integral_traits<unsigned long long>::from_string(std::string_view);
+  string_traits<unsigned long long>::from_string(std::string_view);
 
 
 template<std::floating_point T>
-T float_traits<T>::from_string(std::string_view text)
+T string_traits<T>::from_string(std::string_view text)
 {
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
   return from_string_arithmetic<T>(text);
@@ -557,11 +560,14 @@ T float_traits<T>::from_string(std::string_view text)
 }
 
 
-template float float_traits<float>::from_string(std::string_view);
-template double float_traits<double>::from_string(std::string_view);
-template long double float_traits<long double>::from_string(std::string_view);
+template float string_traits<float>::from_string(std::string_view);
+template double string_traits<double>::from_string(std::string_view);
+template long double string_traits<long double>::from_string(std::string_view);
+} // namespace pqxx
 
 
+namespace pqxx::internal
+{
 template std::string to_string_float(float);
 template std::string to_string_float(double);
 template std::string to_string_float(long double);

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -146,9 +146,11 @@ inline char *wrap_to_chars(char *begin, char *end, T const &value)
 
 namespace pqxx
 {
-template<pqxx::internal::integer T> inline
-// NOLINTNEXTLINE(readability-non-const-parameter)
-zview string_traits<T>::to_buf(char *begin, char *end, T const &value)
+template<pqxx::internal::integer T>
+inline
+  // NOLINTNEXTLINE(readability-non-const-parameter)
+  zview
+  string_traits<T>::to_buf(char *begin, char *end, T const &value)
 {
   static_assert(std::is_integral_v<T>);
   auto const space{end - begin},
@@ -174,8 +176,8 @@ zview string_traits<T>::to_buf(char *begin, char *end, T const &value)
 }
 
 
-template<pqxx::internal::integer T> inline
-char *string_traits<T>::into_buf(char *begin, char *end, T const &value)
+template<pqxx::internal::integer T>
+inline char *string_traits<T>::into_buf(char *begin, char *end, T const &value)
 {
   // This is exactly what to_chars is good at.  Trust standard library
   // implementers to optimise better than we can.
@@ -406,7 +408,7 @@ to_dumb_stringstream(dumb_stringstream<F> &s, F value)
   return s.str();
 }
 #endif
-} // namespace pqxx
+} // namespace
 
 
 namespace pqxx::internal
@@ -448,9 +450,9 @@ template<std::floating_point T>
 T float_string_traits<T>::from_string(std::string_view text)
 {
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
-    return from_string_arithmetic<T>(text);
+  return from_string_arithmetic<T>(text);
 #else
-    return from_string_awful_float<T>(text);
+  return from_string_awful_float<T>(text);
 #endif
 }
 

--- a/test/unit/test_string_conversion.cxx
+++ b/test/unit/test_string_conversion.cxx
@@ -209,17 +209,16 @@ void test_string_view_conversion()
 void test_binary_converts_to_string()
 {
   PQXX_CHECK_EQUAL(
-    pqxx::to_string(std::array<std::byte, 3>{std::byte{0x41}, std::byte{0x42}, std::byte{0x43}}),
-    "\\x414243",
-    "Bad conversino from std::array<std::byte, n> to string.");
+    pqxx::to_string(std::array<std::byte, 3>{
+      std::byte{0x41}, std::byte{0x42}, std::byte{0x43}}),
+    "\\x414243", "Bad conversino from std::array<std::byte, n> to string.");
 
   std::array<std::byte, 1> x{std::byte{0x78}};
   PQXX_CHECK_EQUAL(std::size(x), 1u, "This vector is not what I thought.");
   std::span<std::byte> span{x};
   PQXX_CHECK_EQUAL(std::size(span), 1u, "Strangely different span.");
   PQXX_CHECK_EQUAL(
-    pqxx::to_string(span),
-    "\\x78",
+    pqxx::to_string(span), "\\x78",
     "Bad conversion from std::span<std::byte> to string.");
 }
 

--- a/test/unit/test_string_conversion.cxx
+++ b/test/unit/test_string_conversion.cxx
@@ -206,9 +206,28 @@ void test_string_view_conversion()
 }
 
 
+void test_binary_converts_to_string()
+{
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string(std::array<std::byte, 3>{std::byte{0x41}, std::byte{0x42}, std::byte{0x43}}),
+    "\\x414243",
+    "Bad conversino from std::array<std::byte, n> to string.");
+
+  std::array<std::byte, 1> x{std::byte{0x78}};
+  PQXX_CHECK_EQUAL(std::size(x), 1u, "This vector is not what I thought.");
+  std::span<std::byte> span{x};
+  PQXX_CHECK_EQUAL(std::size(span), 1u, "Strangely different span.");
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string(span),
+    "\\x78",
+    "Bad conversion from std::span<std::byte> to string.");
+}
+
+
 PQXX_REGISTER_TEST(test_string_conversion);
 PQXX_REGISTER_TEST(test_convert_variant_to_string);
 PQXX_REGISTER_TEST(test_integer_conversion);
 PQXX_REGISTER_TEST(test_convert_null);
 PQXX_REGISTER_TEST(test_string_view_conversion);
+PQXX_REGISTER_TEST(test_binary_converts_to_string);
 } // namespace


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/694
Fixes: https://github.com/jtv/libpqxx/issues/827

Making much broader use of concepts.  String conversions now accept any contiguous range of `std::byte` as binary data.  Traits specialisations for integer and floating-point types are simpler now.  And you can now just convert from string to `std::string_view` (or `char const *`), so long as you don't access it after the original string's lifetime ends.