### PR TITLE
Use `__cpp_has_attribute()` (#928).

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 7.10.1
  - Remove `-fanalyzer` option again; gcc is still broken.
  - Oops, no, minimum CMake version is not 3.28, but 3.12!
+ - Fix buffer overrun in converting array with nulls to string. (#922)
+ - Fix warnings on compilers that accept `[[assume]]` with a warning. (#928)
 7.10.0
  - Deprecate `errorhandler`; replace with lambda-friendly "notice handlers."
  - Deprecate `notification_receiver`; replace with "notification handlers"

--- a/config-tests/PQXX_HAVE_ASSUME.cxx
+++ b/config-tests/PQXX_HAVE_ASSUME.cxx
@@ -2,4 +2,11 @@
 #  error "No support for [[assume]] attribute."
 #endif
 
-void foo() {}
+#include <iostream>
+
+
+void foo(int i)
+{
+  [[assume(i > 0)]];
+  std::cout << i << '\n';
+}

--- a/config-tests/PQXX_HAVE_ASSUME.cxx
+++ b/config-tests/PQXX_HAVE_ASSUME.cxx
@@ -1,5 +1,5 @@
-int main(int argc, char **argv)
-{
-  [[assume(argv != nullptr)]];
-  return argc - 1;
-}
+#if !__has_cpp_attribute(assume)
+#  error "No support for [[assume]] attribute."
+#endif
+
+void foo() {}

--- a/config-tests/PQXX_HAVE_LIKELY.cxx
+++ b/config-tests/PQXX_HAVE_LIKELY.cxx
@@ -1,16 +1,8 @@
 // Test for C++20 [[likely]] and [[unlikely]] attributes.
 // C++20: Assume support.
 
-int main(int argc, char **)
-{
-#if __cplusplus < 202002L
-  deliberately_fail(because, older, C++, standard);
+#if !__has_cpp_attribute(likely)
+#  error "No support for [[likely]] / [[unlikely]] attributes."
 #endif
 
-  int x = 0;
-  if (argc == 1) [[likely]]
-    x = 0;
-  else
-    x = 1;
-  return x;
-}
+void foo() {}

--- a/config-tests/PQXX_HAVE_LIKELY.cxx
+++ b/config-tests/PQXX_HAVE_LIKELY.cxx
@@ -5,4 +5,10 @@
 #  error "No support for [[likely]] / [[unlikely]] attributes."
 #endif
 
-void foo() {}
+int foo(int i)
+{
+  if (i > 0) [[likely]]
+    return 100;
+  else
+    return 0;
+}

--- a/configure
+++ b/configure
@@ -17605,7 +17605,15 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 
 
-void foo() {}
+int foo(int i)
+
+{
+
+  if (i > 0) [[likely]] return 100;
+
+  else return 0;
+
+}
 
 
 _ACEOF

--- a/configure
+++ b/configure
@@ -17237,13 +17237,17 @@ printf %s "checking PQXX_HAVE_ASSUME... " >&6; }
 PQXX_HAVE_ASSUME=yes
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-int main(int argc, char **argv)
+#if !__has_cpp_attribute(assume)
+
+#  error "No support for [[assume]] attribute."
+
+#endif
+
+
+
+void foo()
 
 {
-
-  [[assume(argv != nullptr)]];
-
-  return argc - 1;
 
 }
 
@@ -17583,29 +17587,17 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 
 
-int main(int argc, char **)
+#if ! __has_cpp_attribute(likely)
 
-{
-
-#if __cplusplus < 202002L
-
-  deliberately_fail(because, older, C++, standard);
+#  error "No support for [[likely]] / [[unlikely]] attributes."
 
 #endif
 
 
 
-  int x = 0;
+void foo()
 
-  if (argc == 1) [[likely]]
-
-    x = 0;
-
-  else
-
-    x = 1;
-
-  return x;
+{
 
 }
 

--- a/configure
+++ b/configure
@@ -17245,9 +17245,19 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 
 
-void foo()
+#include <iostream>
+
+
+
+
+
+void foo(int i)
 
 {
+
+  [[assume(i > 0)]];
+
+  std::cout << i << '\n';
 
 }
 
@@ -17587,7 +17597,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 
 
-#if ! __has_cpp_attribute(likely)
+#if !__has_cpp_attribute(likely)
 
 #  error "No support for [[likely]] / [[unlikely]] attributes."
 
@@ -17595,11 +17605,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 
 
-void foo()
-
-{
-
-}
+void foo() {}
 
 
 _ACEOF


### PR DESCRIPTION
This changes the feature checks fo attributes `[[assume]]`, `[[likely]]`, and `[[unlikely]]` to rely on the C++20 standard means of testing for attributes.

I may want to systematise this into a separate mechanism, so that there will be just a list of attrbutes that the configure process needs to check for.