### PR TITLE
Skip building tests by default when included in other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 option(BUILD_DOC "Build documentation" OFF)
 
-if(NOT SKIP_BUILD_TEST)
+if(NOT SKIP_BUILD_TEST AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     option(BUILD_TEST "Build all test cases" ON)
 endif()
 


### PR DESCRIPTION
Hi, I think it'd be nice to skip building tests by default when libpqxx is included in other projects. For instance, with [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html):

```cmake
include(FetchContent)

FetchContent_Declare(libpqxx GIT_REPOSITORY https://github.com/jtv/libpqxx.git GIT_TAG 7.10.0)
FetchContent_MakeAvailable(libpqxx)

target_link_libraries(app PRIVATE libpqxx::pqxx)
```

Currently, projects need to set:

```cmake
set(SKIP_BUILD_TEST ON)
```

[nlohmann/json](https://github.com/nlohmann/json) is one project that does this.