### PR TITLE
#930: Fix memory sanitizer error, and sundry others.

### DIFF
--- a/configure
+++ b/configure
@@ -17609,9 +17609,13 @@ int foo(int i)
 
 {
 
-  if (i > 0) [[likely]] return 100;
+  if (i > 0) [[likely]]
 
-  else return 0;
+    return 100;
+
+  else
+
+    return 0;
 
 }
 


### PR DESCRIPTION
I still don't have all of them solved though.  For some reason a lookup in a `std::map` also counts as using uninitialized memory.

Took the opportunity to rewrite a few other small things.