### PR TITLE
Accept `pqxx::binary` concept in more places.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,7 +17,8 @@
  - Assume compiler supports concepts.
  - Assume compiler supports integral conversions in `charconv`.
  - Assume compiler supports spans, ranges, and `cmp_less` etc.
- - Assume compiler supports `std::remove_cvref_t`.
+ - Assume compiler supports `std::remove_cvref_t` etc.
+ - Assume compiler supports `std::filesystem::path`.
  - Assume compiler supports `[[likely]]` & `[[unlikely]]`.
  - Assume compiler supports `ssize()`.
  - Assume compiler supports ISO-646 without needing `<ciso646>` header.

--- a/cmake/pqxx_cxx_feature_checks.cmake
+++ b/cmake/pqxx_cxx_feature_checks.cmake
@@ -24,10 +24,6 @@ try_compile(
     SOURCES ${PROJECT_SOURCE_DIR}/config-tests/PQXX_HAVE_MULTIDIM.cxx
 )
 try_compile(
-    PQXX_HAVE_PATH ${PROJECT_BINARY_DIR}
-    SOURCES ${PROJECT_SOURCE_DIR}/config-tests/PQXX_HAVE_PATH.cxx
-)
-try_compile(
     PQXX_HAVE_POLL ${PROJECT_BINARY_DIR}
     SOURCES ${PROJECT_SOURCE_DIR}/config-tests/PQXX_HAVE_POLL.cxx
 )

--- a/config-tests/PQXX_HAVE_PATH.cxx
+++ b/config-tests/PQXX_HAVE_PATH.cxx
@@ -1,9 +1,0 @@
-// Check for working std::filesystem support.
-#include <filesystem>
-
-
-int main()
-{
-  // Apparently some versions of MinGW lack this comparison operator.
-  return std::filesystem::path{} != std::filesystem::path{};
-}

--- a/config-tests/no_need_fslib.cxx
+++ b/config-tests/no_need_fslib.cxx
@@ -1,21 +1,13 @@
 // Check whether we need to link to the stdc++fs library.
 //
-// We assume that the presence of the <filesystem> header means that we have
-// support for the basics of std::filesystem.  This check will succeed if
-// either there is no <filesystem> header, or there is one and it works without
-// any special options.  If the link fails, we assume that -lstdc++fs will fix
-// it for us.
+// This check will succeed if std::filesystem::path works without any special
+// options.  If the link fails, we assume that -lstdc++fs will fix it for us.
 
+#include <filesystem>
 #include <iostream>
-
-#if __has_include(<filesystem>)
-#  include <filesystem>
-#endif
 
 
 int main()
 {
-#if __has_include(<filesystem>)
   std::cout << std::filesystem::path{"foo.bar"}.c_str() << '\n';
-#endif
 }

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
+	config.sub install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/configitems
+++ b/configitems
@@ -10,7 +10,6 @@ PQXX_HAVE_CXA_DEMANGLE	internal	compiler
 PQXX_HAVE_GCC_PURE	public	compiler
 PQXX_HAVE_GCC_VISIBILITY	public	compiler
 PQXX_HAVE_MULTIDIM	public	compiler
-PQXX_HAVE_PATH	public	compiler
 PQXX_HAVE_POLL       internal        compiler
 PQXX_HAVE_SLEEP_FOR	internal	compiler
 PQXX_HAVE_SOURCE_LOCATION	public	compiler

--- a/configure
+++ b/configure
@@ -17839,27 +17839,15 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 //
 
-// We assume that the presence of the <filesystem> header means that we have
+// This check will succeed if std::filesystem::path works without any special
 
-// support for the basics of std::filesystem.  This check will succeed if
-
-// either there is no <filesystem> header, or there is one and it works without
-
-// any special options.  If the link fails, we assume that -lstdc++fs will fix
-
-// it for us.
+// options.  If the link fails, we assume that -lstdc++fs will fix it for us.
 
 
+
+#include <filesystem>
 
 #include <iostream>
-
-
-
-#if __has_include(<filesystem>)
-
-#  include <filesystem>
-
-#endif
 
 
 
@@ -17869,11 +17857,7 @@ int main()
 
 {
 
-#if __has_include(<filesystem>)
-
   std::cout << std::filesystem::path{"foo.bar"}.c_str() << '\n';
-
-#endif
 
 }
 
@@ -18361,27 +18345,15 @@ do
 
 //
 
-// We assume that the presence of the <filesystem> header means that we have
+// This check will succeed if std::filesystem::path works without any special
 
-// support for the basics of std::filesystem.  This check will succeed if
-
-// either there is no <filesystem> header, or there is one and it works without
-
-// any special options.  If the link fails, we assume that -lstdc++fs will fix
-
-// it for us.
+// options.  If the link fails, we assume that -lstdc++fs will fix it for us.
 
 
+
+#include <filesystem>
 
 #include <iostream>
-
-
-
-#if __has_include(<filesystem>)
-
-#  include <filesystem>
-
-#endif
 
 
 
@@ -18391,11 +18363,7 @@ int main()
 
 {
 
-#if __has_include(<filesystem>)
-
   std::cout << std::filesystem::path{"foo.bar"}.c_str() << '\n';
-
-#endif
 
 }
 

--- a/configure
+++ b/configure
@@ -17500,42 +17500,6 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PQXX_HAVE_MULTIDIM" >&5
 printf "%s\n" "$PQXX_HAVE_MULTIDIM" >&6; }
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking PQXX_HAVE_PATH" >&5
-printf %s "checking PQXX_HAVE_PATH... " >&6; }
-PQXX_HAVE_PATH=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-// Check for working std::filesystem support.
-
-#include <filesystem>
-
-
-
-
-
-int main()
-
-{
-
-  // Apparently some versions of MinGW lack this comparison operator.
-
-  return std::filesystem::path{} != std::filesystem::path{};
-
-}
-
-
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"
-then :
-
-printf "%s\n" "#define PQXX_HAVE_PATH 1" >>confdefs.h
-
-else $as_nop
-  PQXX_HAVE_PATH=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PQXX_HAVE_PATH" >&5
-printf "%s\n" "$PQXX_HAVE_PATH" >&6; }
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking PQXX_HAVE_POLL" >&5
 printf %s "checking PQXX_HAVE_POLL... " >&6; }
 PQXX_HAVE_POLL=yes

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -201,7 +201,6 @@ public:
     append_from_buf(tx, binary_cast(data), id);
   }
 
-  // XXX: Standardise on std::filesystem::path, not zview.
   /// Read client-side file and store it server-side as a binary large object.
   [[nodiscard]] static oid from_file(dbtransaction &, zview path);
 

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -201,6 +201,7 @@ public:
     append_from_buf(tx, binary_cast(data), id);
   }
 
+  // XXX: Standardise on std::filesystem::path, not zview.
   /// Read client-side file and store it server-side as a binary large object.
   [[nodiscard]] static oid from_file(dbtransaction &, zview path);
 

--- a/include/pqxx/config.h.in
+++ b/include/pqxx/config.h.in
@@ -76,9 +76,6 @@
 #undef PQXX_HAVE_MULTIDIM
 
 /* Define if this feature is available. */
-#undef PQXX_HAVE_PATH
-
-/* Define if this feature is available. */
 #undef PQXX_HAVE_POLL
 
 /* Define if this feature is available. */

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -997,6 +997,14 @@ public:
   [[nodiscard]] std::string quote(bytes_view bytes) const;
 
   // TODO: Make "into buffer" variant to eliminate a string allocation.
+  /// Escape and quote binary data for use as a BYTEA value in SQL statement.
+  template<binary DATA>
+  [[nodiscard]] std::string quote(DATA data) const
+  {
+    return esc_raw(binary_cast(data));
+  }
+
+  // TODO: Make "into buffer" variant to eliminate a string allocation.
   /// Escape string for literal LIKE match.
   /** Use this when part of an SQL "LIKE" pattern should match only as a
    * literal string, not as a pattern, even if it contains "%" or "_"

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -939,6 +939,7 @@ public:
   }
 
   /// Escape and quote a string of binary data.
+  /** You can also just use @ref quote with binary data. */
   std::string quote_raw(bytes_view) const;
 
   /// Escape and quote a string of binary data.
@@ -991,18 +992,6 @@ public:
    */
   template<typename T>
   [[nodiscard]] inline std::string quote(T const &t) const;
-
-  // TODO: Make "into buffer" variant to eliminate a string allocation.
-  /// Escape and quote binary data for use as a BYTEA value in SQL statement.
-  [[nodiscard]] std::string quote(bytes_view bytes) const;
-
-  // TODO: Make "into buffer" variant to eliminate a string allocation.
-  /// Escape and quote binary data for use as a BYTEA value in SQL statement.
-  template<binary DATA>
-  [[nodiscard]] std::string quote(DATA data) const
-  {
-    return esc_raw(binary_cast(data));
-  }
 
   // TODO: Make "into buffer" variant to eliminate a string allocation.
   /// Escape string for literal LIKE match.
@@ -1391,13 +1380,21 @@ private:
 
 template<typename T> inline std::string connection::quote(T const &t) const
 {
-  // TODO: Can we leave the quotes out if unquoted_safe?
   if (is_null(t))
   {
+    // It's easy to forget, but we can't support nulls in string conversion
+    // itself, because the "NULL" may end up inside quotes or something.
+    // We can only handle nulls at this slightly higher level in the call tree,
+    // where there is awareness of the quoting.
     return "NULL";
+  }
+  else if constexpr (binary<T>)
+  {
+    return quote_raw(t);
   }
   else
   {
+    // TODO: Can we leave the quotes out if unquoted_safe?
     auto const text{to_string(t)};
 
     // Okay, there's an easy way to do this and there's a hard way.  The easy

--- a/include/pqxx/doc/binary-data.md
+++ b/include/pqxx/doc/binary-data.md
@@ -9,51 +9,33 @@ Generally you'll want to use `BYTEA` for reasonably-sized values, and large
 objects for very large values.
 
 That's the database side.  On the C++ side, in libpqxx, all binary data must be
-either `pqxx::bytes` or `pqxx::bytes_view`, or anything else that's a block of
-contiguous `std::byte` in memory.
+some block of contiguous `std::byte` values in memory.  That could be a
+`std::vector<std::byte>`, or `std::span<std::byte>`, and so on.  However the
+_preferred_ types for binary data in libpqxx are...
+* `pqxx::bytes` for storing the data, similar to `std::string` for text.
+* `pqxx::bytes_view` for reading data stored elsewhere, similar to how you'd
+   use `std::string_view` for text.
+* `pqxx::writable_bytes_view` for writing to data stored elsewhere.
 
 So for example, if you want to write a large object, you'd create a
-`pqxx::blob` object.  And you might use that to write data in the form of
-`pqxx::bytes_view`.
-
-Your particular binary data may look different though.  You may have it in a
-`std::string`, or a `std::vector<unsigned char>`, or a pointer to `char`
-accompanied by a size (which could be signed or unsigned, and of any of a few
-different widths).  Sometimes that's your choice, or sometimes some other
-library will dictate what form it takes.
+`pqxx::blob` object.  You might use that to write data which you pass in the
+form of a `pqxx::bytes_view`.  You might then read that data back by letting
+`pqxx::blob` write the data into a `pqxx::bytes &` or a
+`pqxx::writable_bytes_view` that you give it.
 
 So long as it's _basically_ still a block of bytes though, you can use
-`pqxx::binary_cast` to construct a `pqxx::bytes_view` from it.
-
-There are two forms of `binary_cast`.  One takes a single argument that must
-support `std::data()` and `std::size()`:
+`pqxx::binary_cast` to construct a `pqxx::bytes_view` from it:
 
 ```cxx
     std::string hi{"Hello binary world"};
     my_blob.write(pqxx::binary_cast(hi);
 ```
 
-The other takes a pointer and a size:
+For convenience there's also a form of `binary_cast` that takes a pointer and
+a length.
 
 ```cxx
     char const greeting[] = "Hello binary world";
     char const *hi = greeting;
     my_blob.write(pqxx::binary_cast(hi, sizeof(greeting)));
 ```
-
-
-Caveats
--------
-
-There are some restrictions on `binary_cast` that you must be aware of.
-
-First, your data must of a type that gives us _bytes._  So: `char`,
-`unsigned char`, `signed char`, `int8_t`, `uint8_t`, or of course `std::byte`.
-You can't feed in a vector of `double`, or anything like that.
-
-Second, the data must be laid out as a contiguous block in memory.  If there's
-no `std::data()` implementation for your type, it's not suitable.
-
-Third, `binary_cast` only constructs something like a `std::string_view`.  It
-does not make a copy of your actual data.  So, make sure that your data remains
-alive and in the same place while you're using it.

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -492,7 +492,7 @@ template<> struct string_traits<char const *>
   static constexpr bool converts_to_string{true};
   static constexpr bool converts_from_string{false};
 
-  static char const *from_string(std::string_view text) =delete;
+  static char const *from_string(std::string_view text) = delete;
 
   static zview to_buf(char *begin, char *end, char const *const &value)
   {

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -82,6 +82,8 @@ public:
   /// Append a non-null string parameter.
   void append(std::string &&) &;
 
+  // XXX: Rethink the view/copy situation.
+  // XXX: Generic pqxx::binary support.
   /// Append a non-null binary parameter.
   /** The underlying data must stay valid for as long as the `params`
    * remains active.

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -517,8 +517,10 @@ template<typename TYPE>
 {
   using base_type = std::remove_cvref_t<TYPE>;
   using null_traits = nullness<base_type>;
-  if constexpr (null_traits::always_null) return true;
-  else return null_traits::is_null(value);
+  if constexpr (null_traits::always_null)
+    return true;
+  else
+    return null_traits::is_null(value);
 }
 
 

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -390,7 +390,8 @@ private:
 
   /// Write raw COPY line into @c m_buffer, based on a container of fields.
   template<typename Container>
-  std::enable_if_t<not std::is_same_v<std::remove_cv_t<typename Container::value_type>, char>>
+  std::enable_if_t<
+    not std::is_same_v<std::remove_cv_t<typename Container::value_type>, char>>
   fill_buffer(Container const &c)
   {
     // To avoid unnecessary allocations and deallocations, we run through c

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -390,7 +390,7 @@ private:
 
   /// Write raw COPY line into @c m_buffer, based on a container of fields.
   template<typename Container>
-  std::enable_if_t<not std::is_same_v<typename Container::value_type, char>>
+  std::enable_if_t<not std::is_same_v<std::remove_cv_t<typename Container::value_type>, char>>
   fill_buffer(Container const &c)
   {
     // To avoid unnecessary allocations and deallocations, we run through c

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -81,8 +81,7 @@ template<typename TYPE> using strip_t = std::remove_cvref_t<TYPE>;
  * which we may or may not end up using for this.
  */
 template<std::ranges::range CONTAINER>
-using value_type =
-  std::remove_cvref_t<decltype(*std::begin(std::declval<CONTAINER>()))>;
+using value_type = std::remove_cvref_t<std::ranges::range_value_t<CONTAINER>>;
 
 
 /// A type one byte in size.
@@ -100,7 +99,7 @@ concept char_string =
 template<typename RANGE>
 concept char_strings =
     std::ranges::range<RANGE> and
-    char_string<std::remove_volatile_t<value_type<RANGE>>>;
+    char_string<std::remove_cv_t<value_type<RANGE>>>;
 
 /// Concept: Anything we might want to treat as binary data.
 template<typename DATA>

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -94,8 +94,7 @@ concept char_sized = (sizeof(CHAR) == 1);
 template<typename STRING>
 concept char_string =
   std::ranges::contiguous_range<STRING> and
-  char_sized<value_type<STRING>> and
-  std::same_as<std::remove_reference_t<value_type<STRING>>, value_type<STRING>>;
+  std::same_as<std::remove_cv_t<value_type<STRING>>, char>;
 
 /// Concept: Anything we can iterate to get things we can read as strings.
 template<typename RANGE>
@@ -107,7 +106,7 @@ concept char_strings =
 template<typename DATA>
 concept potential_binary =
   std::ranges::contiguous_range<DATA> and
-  (sizeof(value_type<DATA>) == 1) and
+  char_sized<value_type<DATA>> and
   not std::is_reference_v<value_type<DATA>>;
 
 
@@ -135,7 +134,7 @@ concept nonbinary_range =
 
 
 /// Type alias for a view of bytes.
-using bytes_view = std::span<const std::byte>;
+using bytes_view = std::span<std::byte const>;
 
 
 /// Type alias for a view of writable bytes.

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -91,21 +91,18 @@ concept char_sized = (sizeof(CHAR) == 1);
 
 /// Concept: Any type that we can read as a string of `char`.
 template<typename STRING>
-concept char_string =
-  std::ranges::contiguous_range<STRING> and
-  std::same_as<std::remove_cv_t<value_type<STRING>>, char>;
+concept char_string = std::ranges::contiguous_range<STRING> and
+                      std::same_as<std::remove_cv_t<value_type<STRING>>, char>;
 
 /// Concept: Anything we can iterate to get things we can read as strings.
 template<typename RANGE>
-concept char_strings =
-    std::ranges::range<RANGE> and
-    char_string<std::remove_cv_t<value_type<RANGE>>>;
+concept char_strings = std::ranges::range<RANGE> and
+                       char_string<std::remove_cv_t<value_type<RANGE>>>;
 
 /// Concept: Anything we might want to treat as binary data.
 template<typename DATA>
 concept potential_binary =
-  std::ranges::contiguous_range<DATA> and
-  char_sized<value_type<DATA>> and
+  std::ranges::contiguous_range<DATA> and char_sized<value_type<DATA>> and
   not std::is_reference_v<value_type<DATA>>;
 
 
@@ -117,9 +114,8 @@ concept potential_binary =
  * we can reference them by a pointer.
  */
 template<typename T>
-concept binary =
-  std::ranges::contiguous_range<T> and
-  std::same_as<std::remove_cv_t<value_type<T>>, std::byte>;
+concept binary = std::ranges::contiguous_range<T> and
+                 std::same_as<std::remove_cv_t<value_type<T>>, std::byte>;
 
 
 /// A series of something that's not bytes.

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -85,21 +85,30 @@ using value_type =
   std::remove_cvref_t<decltype(*std::begin(std::declval<CONTAINER>()))>;
 
 
+/// A type one byte in size.
+template<typename CHAR>
+concept char_sized = (sizeof(CHAR) == 1);
+
+
 /// Concept: Any type that we can read as a string of `char`.
 template<typename STRING>
 concept char_string =
   std::ranges::contiguous_range<STRING> and
-  std::same_as<std::remove_cvref_t<value_type<STRING>>, char>;
+  char_sized<value_type<STRING>> and
+  std::same_as<std::remove_reference_t<value_type<STRING>>, value_type<STRING>>;
 
 /// Concept: Anything we can iterate to get things we can read as strings.
 template<typename RANGE>
-concept char_strings = std::ranges::range<RANGE> and
-                       char_string<std::remove_cvref_t<value_type<RANGE>>>;
+concept char_strings =
+    std::ranges::range<RANGE> and
+    char_string<std::remove_volatile_t<value_type<RANGE>>>;
 
 /// Concept: Anything we might want to treat as binary data.
 template<typename DATA>
 concept potential_binary =
-  std::ranges::contiguous_range<DATA> and (sizeof(value_type<DATA>) == 1);
+  std::ranges::contiguous_range<DATA> and
+  (sizeof(value_type<DATA>) == 1) and
+  not std::is_reference_v<value_type<DATA>>;
 
 
 /// Concept: Binary string, akin to @c std::string for binary data.
@@ -112,8 +121,7 @@ concept potential_binary =
 template<typename T>
 concept binary =
   std::ranges::contiguous_range<T> and
-  std::same_as<
-    std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte>;
+  std::same_as<std::remove_cv_t<value_type<T>>, std::byte>;
 
 
 /// A series of something that's not bytes.
@@ -124,6 +132,14 @@ concept nonbinary_range =
     std::remove_cvref_t<std::ranges::range_reference_t<T>>, std::byte> and
   not std::same_as<
     std::remove_cvref_t<std::ranges::range_reference_t<T>>, char>;
+
+
+/// Type alias for a view of bytes.
+using bytes_view = std::span<const std::byte>;
+
+
+/// Type alias for a view of writable bytes.
+using writable_bytes_view = std::span<std::byte>;
 
 
 /// Marker for @ref stream_from constructors: "stream from table."

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -321,11 +321,11 @@ using bytes = std::conditional<
  * @warning You must keep the storage holding the actual data alive for as
  * long as you might use this function's return value.
  */
-template<potential_binary TYPE>
-inline bytes_view binary_cast(TYPE const &data)
+template<potential_binary TYPE> inline bytes_view binary_cast(TYPE const &data)
 {
   using item_t = value_type<TYPE>;
-  return std::as_bytes(std::span<item_t const>{std::data(data), std::size(data)});
+  return std::as_bytes(
+    std::span<item_t const>{std::data(data), std::size(data)});
 }
 
 

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -11,6 +11,7 @@
 #ifndef PQXX_H_ZVIEW
 #define PQXX_H_ZVIEW
 
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -52,6 +53,9 @@ public:
   {}
 
   /// Explicitly promote a `string_view` to a `zview`.
+  /** @warning This is not just a type conversion.  It's the caller making a
+   * promise that the string is zero-terminated.
+   */
   explicit constexpr zview(std::string_view other) noexcept :
           std::string_view{other}
   {}
@@ -90,6 +94,11 @@ public:
   template<size_t size>
   constexpr zview(char const (&literal)[size]) : zview(literal, size - 1)
   {}
+
+#if !defined(WIN32)
+  /// Construct a `zview` from a `std::filesystem::path`.
+  zview(std::filesystem::path p) : zview(p.c_str()) {}
+#endif // WIN32
 
   /// Either a null pointer, or a zero-terminated text buffer.
   [[nodiscard]] constexpr char const *c_str() const & noexcept

--- a/pqxx_cxx_feature_checks.ac
+++ b/pqxx_cxx_feature_checks.ac
@@ -59,16 +59,6 @@ AC_COMPILE_IFELSE(
         [Define if this feature is available.]),
     PQXX_HAVE_MULTIDIM=no)
 AC_MSG_RESULT($PQXX_HAVE_MULTIDIM)
-AC_MSG_CHECKING([PQXX_HAVE_PATH])
-PQXX_HAVE_PATH=yes
-AC_COMPILE_IFELSE(
-    [read_test(PQXX_HAVE_PATH.cxx)],
-    AC_DEFINE(
-        [PQXX_HAVE_PATH],
-        1,
-        [Define if this feature is available.]),
-    PQXX_HAVE_PATH=no)
-AC_MSG_RESULT($PQXX_HAVE_PATH)
 AC_MSG_CHECKING([PQXX_HAVE_POLL])
 PQXX_HAVE_POLL=yes
 AC_COMPILE_IFELSE(

--- a/requirements.json
+++ b/requirements.json
@@ -5,5 +5,5 @@
     "postgresql": "12.0",
     "gcc": "9",
     "clang": "12",
-    "msvc": "2019"
+    "msvc": "2022"
 }

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -979,12 +979,6 @@ std::string pqxx::connection::quote_raw(bytes_view bytes) const
 }
 
 
-std::string pqxx::connection::quote(bytes_view b) const
-{
-  return internal::concat("'", esc_raw(b), "'::bytea");
-}
-
-
 std::string pqxx::connection::quote_name(std::string_view identifier) const
 {
   std::unique_ptr<char, void (*)(void const *)> const buf{

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -116,6 +116,7 @@ runner_SOURCES = \
   unit/test_transaction_focus.cxx \
   unit/test_transactor.cxx \
   unit/test_type_name.cxx \
+  unit/test_util.cxx \
   unit/test_zview.cxx \
   runner.cxx
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -166,7 +166,8 @@ am_runner_OBJECTS = test00.$(OBJEXT) test01.$(OBJEXT) test02.$(OBJEXT) \
 	unit/test_transaction_base.$(OBJEXT) \
 	unit/test_transaction_focus.$(OBJEXT) \
 	unit/test_transactor.$(OBJEXT) unit/test_type_name.$(OBJEXT) \
-	unit/test_zview.$(OBJEXT) runner.$(OBJEXT)
+	unit/test_util.$(OBJEXT) unit/test_zview.$(OBJEXT) \
+	runner.$(OBJEXT)
 runner_OBJECTS = $(am_runner_OBJECTS)
 runner_DEPENDENCIES = $(top_builddir)/src/libpqxx.la
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -242,7 +243,8 @@ am__depfiles_remade = ./$(DEPDIR)/runner.Po ./$(DEPDIR)/test00.Po \
 	unit/$(DEPDIR)/test_transaction_base.Po \
 	unit/$(DEPDIR)/test_transaction_focus.Po \
 	unit/$(DEPDIR)/test_transactor.Po \
-	unit/$(DEPDIR)/test_type_name.Po unit/$(DEPDIR)/test_zview.Po
+	unit/$(DEPDIR)/test_type_name.Po unit/$(DEPDIR)/test_util.Po \
+	unit/$(DEPDIR)/test_zview.Po
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -541,6 +543,7 @@ runner_SOURCES = \
   unit/test_transaction_focus.cxx \
   unit/test_transactor.cxx \
   unit/test_type_name.cxx \
+  unit/test_util.cxx \
   unit/test_zview.cxx \
   runner.cxx
 
@@ -677,6 +680,8 @@ unit/test_transactor.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
 unit/test_type_name.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
+unit/test_util.$(OBJEXT): unit/$(am__dirstamp) \
+	unit/$(DEPDIR)/$(am__dirstamp)
 unit/test_zview.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
 
@@ -771,6 +776,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_transaction_focus.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_transactor.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_type_name.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_util.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_zview.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
@@ -1112,6 +1118,7 @@ distclean: distclean-am
 	-rm -f unit/$(DEPDIR)/test_transaction_focus.Po
 	-rm -f unit/$(DEPDIR)/test_transactor.Po
 	-rm -f unit/$(DEPDIR)/test_type_name.Po
+	-rm -f unit/$(DEPDIR)/test_util.Po
 	-rm -f unit/$(DEPDIR)/test_zview.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
@@ -1238,6 +1245,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f unit/$(DEPDIR)/test_transaction_focus.Po
 	-rm -f unit/$(DEPDIR)/test_transactor.Po
 	-rm -f unit/$(DEPDIR)/test_type_name.Po
+	-rm -f unit/$(DEPDIR)/test_util.Po
 	-rm -f unit/$(DEPDIR)/test_zview.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -172,7 +172,8 @@ int main(int argc, char const *argv[])
 {
   // TODO: Accept multiple names.
   std::string_view test_name;
-  if (argc > 1) test_name = argv[1];
+  if (argc > 1)
+    test_name = argv[1];
 
   auto const num_tests{std::size(*all_test_names)};
   std::map<std::string_view, pqxx::test::testfunc> all_tests;
@@ -200,8 +201,7 @@ int main(int argc, char const *argv[])
       catch (pqxx::test::test_failure const &e)
       {
         std::cerr << "Test failure in " << e.file() << " line "
-                  << pqxx::to_string(e.line()) << ": " << e.what()
-                  << '\n';
+                  << pqxx::to_string(e.line()) << ": " << e.what() << '\n';
       }
       catch (std::bad_alloc const &)
       {

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <filesystem>
 
 #include <pqxx/blob>
 #include <pqxx/transaction>
@@ -587,10 +588,7 @@ void test_blob_close_leaves_blob_unusable()
 
 void test_blob_accepts_std_filesystem_path()
 {
-#if defined(PQXX_HAVE_PATH) && !defined(_WIN32)
-  // A bug in gcc 8's ~std::filesystem::path() causes a run-time crash.
-#  if !defined(__GNUC__) || (__GNUC__ > 8)
-
+#if !defined(_WIN32)
   char const temp_file[] = "blob-test-filesystem-path.tmp";
   pqxx::bytes const data{std::byte{'4'}, std::byte{'2'}};
 
@@ -603,9 +601,7 @@ void test_blob_accepts_std_filesystem_path()
   auto id{pqxx::blob::from_file(tx, path)};
   pqxx::blob::to_buf(tx, id, buf, 10);
   PQXX_CHECK_EQUAL(buf, data, "Wrong data from blob::from_file().");
-
-#  endif
-#endif
+#endif // WIN32
 }
 
 

--- a/test/unit/test_blob.cxx
+++ b/test/unit/test_blob.cxx
@@ -177,7 +177,8 @@ void test_blob_read_reads_data()
 
 void test_blob_read_reads_generic_data()
 {
-  std::array<std::byte, 3> const data{std::byte{'a'}, std::byte{'b'}, std::byte{'c'}};
+  std::array<std::byte, 3> const data{
+    std::byte{'a'}, std::byte{'b'}, std::byte{'c'}};
 
   pqxx::connection cx;
   pqxx::work tx{cx};
@@ -448,7 +449,9 @@ void test_blob_generic_append_from_buf_appends()
   pqxx::blob::append_from_buf(tx, data, id);
   pqxx::bytes buf;
   pqxx::blob::to_buf(tx, id, buf, 10);
-  PQXX_CHECK_EQUAL(std::size(buf), 2 * std::size(data), "Generic append_from_buf() created unexpected length.");
+  PQXX_CHECK_EQUAL(
+    std::size(buf), 2 * std::size(data),
+    "Generic append_from_buf() created unexpected length.");
 }
 
 

--- a/test/unit/test_escape.cxx
+++ b/test/unit/test_escape.cxx
@@ -80,8 +80,11 @@ void test_quote(pqxx::connection &cx, pqxx::transaction_base &t)
   }
 
   std::vector<std::byte> const bin{std::byte{0x33}, std::byte{0x4a}};
-  PQXX_CHECK_EQUAL(t.quote(bin), "'\\x334a'::bytea", "Unexpected binary quoting output.");
-  PQXX_CHECK_EQUAL(t.quote(std::span<std::byte const>{bin}), "'\\x334a'::bytea", "Binary span quotes differently from vector.");
+  PQXX_CHECK_EQUAL(
+    t.quote(bin), "'\\x334a'::bytea", "Unexpected binary quoting output.");
+  PQXX_CHECK_EQUAL(
+    t.quote(std::span<std::byte const>{bin}), "'\\x334a'::bytea",
+    "Binary span quotes differently from vector.");
 }
 
 

--- a/test/unit/test_escape.cxx
+++ b/test/unit/test_escape.cxx
@@ -61,6 +61,7 @@ void test_quote(pqxx::connection &cx, pqxx::transaction_base &t)
   PQXX_CHECK_EQUAL(t.quote(0), "'0'", "Quoting zero is a problem.");
   char const *const null_ptr{nullptr};
   PQXX_CHECK_EQUAL(t.quote(null_ptr), "NULL", "Not quoting NULL correctly.");
+  PQXX_CHECK_EQUAL(t.quote(nullptr), "NULL", "Not quoting nullptr correctly.");
   PQXX_CHECK_EQUAL(
     t.quote(std::string{"'"}), "''''", "Escaping quotes goes wrong.");
 
@@ -77,6 +78,10 @@ void test_quote(pqxx::connection &cx, pqxx::transaction_base &t)
     PQXX_CHECK_EQUAL(
       r, test_strings[i], "Selecting quoted string does not come back equal.");
   }
+
+  std::vector<std::byte> const bin{std::byte{0x33}, std::byte{0x4a}};
+  PQXX_CHECK_EQUAL(t.quote(bin), "'\\x334a'::bytea", "Unexpected binary quoting output.");
+  PQXX_CHECK_EQUAL(t.quote(std::span<std::byte const>{bin}), "'\\x334a'::bytea", "Binary span quotes differently from vector.");
 }
 
 

--- a/test/unit/test_util.cxx
+++ b/test/unit/test_util.cxx
@@ -1,0 +1,44 @@
+#include <cassert>
+
+#include <pqxx/types>
+#include <pqxx/util>
+
+#include "../test_helpers.hxx"
+
+namespace
+{
+template<typename T> void test_for(T const &val)
+{
+  auto const name{pqxx::type_name<T>};
+  auto const sz{std::size(val)};
+
+  std::span<std::byte const> out{pqxx::binary_cast(val)};
+
+  PQXX_CHECK_EQUAL(
+    std::size(out), sz,
+    "Got bad size on binary_cast<" + name + "().");
+
+  for (std::size_t i{0}; i < sz; ++i)
+    PQXX_CHECK_EQUAL(
+      static_cast<unsigned>(out[i]),
+      static_cast<unsigned>(val[i]),
+      "Mismatch in " + name + " byte " + pqxx::to_string(i) + ".");
+}
+
+
+void test_binary_cast()
+{
+  std::byte const bytes_c_array[]{
+    std::byte{0x22}, std::byte{0x23}, std::byte{0x24}
+  };
+  test_for(bytes_c_array);
+  test_for("Hello world");
+
+  test_for(std::vector<char>{'n', 'o', 'p', 'q'});
+  test_for(std::vector<unsigned char>{'n', 'o', 'p', 'q'});
+  test_for(std::vector<signed char>{'n', 'o', 'p', 'q'});
+}
+
+
+PQXX_REGISTER_TEST(test_binary_cast);
+} // namespace

--- a/test/unit/test_util.cxx
+++ b/test/unit/test_util.cxx
@@ -15,13 +15,11 @@ template<typename T> void test_for(T const &val)
   std::span<std::byte const> out{pqxx::binary_cast(val)};
 
   PQXX_CHECK_EQUAL(
-    std::size(out), sz,
-    "Got bad size on binary_cast<" + name + "().");
+    std::size(out), sz, "Got bad size on binary_cast<" + name + "().");
 
   for (std::size_t i{0}; i < sz; ++i)
     PQXX_CHECK_EQUAL(
-      static_cast<unsigned>(out[i]),
-      static_cast<unsigned>(val[i]),
+      static_cast<unsigned>(out[i]), static_cast<unsigned>(val[i]),
       "Mismatch in " + name + " byte " + pqxx::to_string(i) + ".");
 }
 
@@ -29,8 +27,7 @@ template<typename T> void test_for(T const &val)
 void test_binary_cast()
 {
   std::byte const bytes_c_array[]{
-    std::byte{0x22}, std::byte{0x23}, std::byte{0x24}
-  };
+    std::byte{0x22}, std::byte{0x23}, std::byte{0x24}};
   test_for(bytes_c_array);
   test_for("Hello world");
 

--- a/test/unit/test_zview.cxx
+++ b/test/unit/test_zview.cxx
@@ -1,3 +1,5 @@
+#include <ranges>
+
 #include <pqxx/zview>
 
 #include "../test_helpers.hxx"
@@ -5,6 +7,14 @@
 
 namespace
 {
+void test_zview_is_a_range()
+{
+  static_assert(std::ranges::range<pqxx::zview>);
+  static_assert(std::ranges::borrowed_range<pqxx::zview>);
+  static_assert(std::ranges::contiguous_range<pqxx::zview>);
+}
+
+
 void test_zview_literal()
 {
   using pqxx::operator"" _zv;
@@ -40,6 +50,7 @@ void test_zview_converts_to_string()
 }
 
 
+PQXX_REGISTER_TEST(test_zview_is_a_range);
 PQXX_REGISTER_TEST(test_zview_literal);
 PQXX_REGISTER_TEST(test_zview_converts_to_string);
 } // namespace


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/925

Extends a bunch more functions that accept `pqxx::bytes_view` with variants which accept any type that satisfies the `pqxx::binary` concept.

Also, change the `pqxx::bytes_view` type alies from being a `std::basic_string_view<std::byte>` (which doesn't actually have to work according to the standard!) to being a `std::span<std::byte>`.  This seems to be broadly compatible with existing code.  For completeness I'm adding a `pqxx::writable_bytes_view` as well.

Along the way I'm assuming support for C++17's `std::filesystem::path`, and adding a conversion to `pqxx::zview`.  With that, `pqxx::blob` no longer needs explicit support for `std::filesystem::path` filenames; it just accepts `pqxx::zview` and passing a `std::filesystem::path` will just work.  It avoids some ambiguities.