### PR TITLE
Drop `test/unit` from Doxyfile.

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -103,7 +103,7 @@ RECURSIVE = YES
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH = ../test ../test/unit
+EXAMPLE_PATH = ../test
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and


### PR DESCRIPTION
Now that the test directories have been unified, we no longer need to run Doxygen on `test/unit/`.