### PR TITLE
Pass `std::source_location` into libpqxx functions.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@
  - Conversion from string to `char const *` is no longer allowed.
  - Binary data can be any `std::contiguous_range` of `std::byte`. (#925)
  - Generic `quote()` takes `always_null` into account.
+ - The libpqxx exceptions now have a `std::source_location`.
+ - More getters on `pqxx::connection` are now `noexcept`.
  - Retired `binarystring` and its headers.  Use `blob` instead.
  - Retired `connection_base` type alias.  Use `connection`.
  - Retired `pqxx::encrypt_password()`.  Use the ones in `pqxx::connection`.
@@ -21,6 +23,7 @@
  - Assume compiler supports `std::filesystem::path`.
  - Assume compiler supports `[[likely]]` & `[[unlikely]]`.
  - Assume compiler supports `ssize()`.
+ - Assume compiler supports `std::source_location`.
  - Assume compiler supports ISO-646 without needing `<ciso646>` header.
 7.10.1
  - Fix string conversion buffer budget for arrays containing nulls. (#921)

--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@
  - Binary data can be any `std::contiguous_range` of `std::byte`. (#925)
  - Generic `quote()` takes `always_null` into account.
  - The libpqxx exceptions now have a `std::source_location`.
- - More getters on `pqxx::connection` are now `noexcept`.
+ - More getters are now `noexcept`.
  - Retired `binarystring` and its headers.  Use `blob` instead.
  - Retired `connection_base` type alias.  Use `connection`.
  - Retired `pqxx::encrypt_password()`.  Use the ones in `pqxx::connection`.

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub install-sh ltmain.sh missing mkinstalldirs
+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -65,9 +65,7 @@ public:
    * @throws pqxx::unexpected_null if the array contains a null value, and the
    * `ELEMENT` type does not support null values.
    */
-  array(
-    std::string_view data, connection const &cx,
-    PQXX_LOC loc = PQXX_LOC::current()) :
+  array(std::string_view data, connection const &cx, sl loc = sl::current()) :
           array{data, pqxx::internal::enc_group(cx.encoding_id(), loc), loc}
   {}
 
@@ -171,7 +169,7 @@ private:
    * walking through the entire array sequentially, and identifying all the
    * character boundaries.  The main parsing routine detects that one.
    */
-  void check_dims(std::string_view data, PQXX_LOC loc = PQXX_LOC::current())
+  void check_dims(std::string_view data, sl loc = sl::current())
   {
     auto sz{std::size(data)};
     if (sz < DIMENSIONS * 2)
@@ -215,8 +213,7 @@ private:
   // Couldn't make this work through a call gate, thanks to the templating.
   friend class ::pqxx::field;
 
-  array(
-    std::string_view data, pqxx::internal::encoding_group enc, PQXX_LOC loc)
+  array(std::string_view data, pqxx::internal::encoding_group enc, sl loc)
   {
     using group = pqxx::internal::encoding_group;
     switch (enc)
@@ -243,7 +240,7 @@ private:
    * complicated point, and return the offset where parsing should continue.
    */
   std::size_t
-  parse_field_end(std::string_view data, std::size_t here, PQXX_LOC loc) const
+  parse_field_end(std::string_view data, std::size_t here, sl loc) const
   {
     auto const sz{std::size(data)};
     if (here < sz)
@@ -294,7 +291,7 @@ private:
   }
 
   template<pqxx::internal::encoding_group ENC>
-  void parse(std::string_view data, PQXX_LOC loc = PQXX_LOC::current())
+  void parse(std::string_view data, sl loc = sl::current())
   {
     static_assert(DIMENSIONS > 0u, "Can't create a zero-dimensional array.");
     auto const sz{std::size(data)};
@@ -585,7 +582,7 @@ public:
    * Call this until the @ref array_parser::juncture it returns is
    * @ref juncture::done.
    */
-  std::pair<juncture, std::string> get_next(PQXX_LOC loc = PQXX_LOC::current())
+  std::pair<juncture, std::string> get_next(sl loc = sl::current())
   {
     return (this->*m_impl)(loc);
   }
@@ -603,37 +600,35 @@ private:
    * very hot loops.
    */
   using implementation =
-    std::pair<juncture, std::string> (array_parser::*)(PQXX_LOC);
+    std::pair<juncture, std::string> (array_parser::*)(sl);
 
   /// Pick the `implementation` for `enc`.
   static implementation
-  specialize_for_encoding(pqxx::internal::encoding_group enc, PQXX_LOC loc);
+  specialize_for_encoding(pqxx::internal::encoding_group enc, sl loc);
 
   /// Our implementation of `parse_array_step`, specialised for our encoding.
   implementation m_impl;
 
   /// Perform one step of array parsing.
   template<pqxx::internal::encoding_group>
-  std::pair<juncture, std::string> parse_array_step(PQXX_LOC loc);
+  std::pair<juncture, std::string> parse_array_step(sl loc);
 
   template<pqxx::internal::encoding_group>
-  std::string::size_type scan_double_quoted_string(PQXX_LOC loc) const;
+  std::string::size_type scan_double_quoted_string(sl loc) const;
   template<pqxx::internal::encoding_group>
   std::string
-  parse_double_quoted_string(std::string::size_type end, PQXX_LOC loc) const;
+  parse_double_quoted_string(std::string::size_type end, sl loc) const;
   template<pqxx::internal::encoding_group>
-  std::string::size_type scan_unquoted_string(PQXX_LOC loc) const;
+  std::string::size_type scan_unquoted_string(sl loc) const;
   template<pqxx::internal::encoding_group>
   std::string_view
-  parse_unquoted_string(std::string::size_type end, PQXX_LOC loc) const;
+  parse_unquoted_string(std::string::size_type end, sl loc) const;
 
   template<pqxx::internal::encoding_group>
-  std::string::size_type
-  scan_glyph(std::string::size_type pos, PQXX_LOC loc) const;
+  std::string::size_type scan_glyph(std::string::size_type pos, sl loc) const;
   template<pqxx::internal::encoding_group>
   std::string::size_type scan_glyph(
-    std::string::size_type pos, std::string::size_type end,
-    PQXX_LOC loc) const;
+    std::string::size_type pos, std::string::size_type end, sl loc) const;
 };
 } // namespace pqxx
 #endif

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -66,7 +66,7 @@ public:
    * `ELEMENT` type does not support null values.
    */
   array(std::string_view data, connection const &cx, sl loc = sl::current()) :
-          array{data, pqxx::internal::enc_group(cx.encoding_id(), loc), loc}
+          array{data, pqxx::internal::enc_group(cx.encoding_id(loc), loc), loc}
   {}
 
   /// How many dimensions does this array have?
@@ -291,7 +291,7 @@ private:
   }
 
   template<pqxx::internal::encoding_group ENC>
-  void parse(std::string_view data, sl loc = sl::current())
+  void parse(std::string_view data, sl loc)
   {
     static_assert(DIMENSIONS > 0u, "Can't create a zero-dimensional array.");
     auto const sz{std::size(data)};
@@ -471,7 +471,9 @@ private:
   template<typename OUTER, typename... INDEX>
   constexpr std::size_t add_index(OUTER outer, INDEX... indexes) const noexcept
   {
-    std::size_t const first{check_cast<std::size_t>(outer, "array index"sv)};
+    sl loc{sl::current()};
+    std::size_t const first{
+      check_cast<std::size_t>(outer, "array index"sv, loc)};
     if constexpr (sizeof...(indexes) == 0)
     {
       return first;
@@ -493,7 +495,9 @@ private:
   template<typename OUTER, std::integral... INDEX>
   constexpr void check_bounds(OUTER outer, INDEX... indexes) const
   {
-    std::size_t const first{check_cast<std::size_t>(outer, "array index"sv)};
+    sl loc{sl::current()};
+    std::size_t const first{
+      check_cast<std::size_t>(outer, "array index"sv, loc)};
     static_assert(sizeof...(indexes) < DIMENSIONS);
     // (Offset by 1 here because the outer dimension is not in there.)
     constexpr auto dimension{DIMENSIONS - (sizeof...(indexes) + 1)};

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -65,8 +65,8 @@ public:
    * @throws pqxx::unexpected_null if the array contains a null value, and the
    * `ELEMENT` type does not support null values.
    */
-  array(std::string_view data, connection const &cx) :
-          array{data, pqxx::internal::enc_group(cx.encoding_id())}
+  array(std::string_view data, connection const &cx, PQXX_LOC loc = PQXX_LOC::current()) :
+          array{data, pqxx::internal::enc_group(cx.encoding_id()), loc}
   {}
 
   /// How many dimensions does this array have?
@@ -84,7 +84,8 @@ public:
     return m_extents;
   }
 
-  template<typename... INDEX> ELEMENT const &at(INDEX... index) const
+  // TODO: How can we pass std::source_location here?
+  template<std::integral... INDEX> ELEMENT const &at(INDEX... index) const
   {
     static_assert(sizeof...(index) == DIMENSIONS);
     check_bounds(index...);
@@ -100,7 +101,7 @@ public:
    * better.  In older versions of C++ it will work only with
    * single-dimensional arrays.
    */
-  template<typename... INDEX> ELEMENT const &operator[](INDEX... index) const
+  template<std::integral... INDEX> ELEMENT const &operator[](INDEX... index) const
   {
     static_assert(sizeof...(index) == DIMENSIONS);
     return m_elts[locate(index...)];
@@ -167,13 +168,13 @@ private:
    * walking through the entire array sequentially, and identifying all the
    * character boundaries.  The main parsing routine detects that one.
    */
-  void check_dims(std::string_view data)
+  void check_dims(std::string_view data, PQXX_LOC loc = PQXX_LOC::current())
   {
     auto sz{std::size(data)};
     if (sz < DIMENSIONS * 2)
       throw conversion_error{pqxx::internal::concat(
         "Trying to parse a ", DIMENSIONS, "-dimensional array out of '", data,
-        "'.")};
+        "'."), loc};
 
     // Making some assumptions here:
     // * The array holds no extraneous whitespace.
@@ -185,43 +186,43 @@ private:
     // of DIMENSIONS bytes with the ASCII value for '}'.
 
     if (data[0] != '{')
-      throw conversion_error{"Malformed array: does not start with '{'."};
+      throw conversion_error{"Malformed array: does not start with '{'.", loc};
     for (std::size_t i{0}; i < DIMENSIONS; ++i)
       if (data[i] != '{')
         throw conversion_error{pqxx::internal::concat(
-          "Expecting ", DIMENSIONS, "-dimensional array, but found ", i, ".")};
+          "Expecting ", DIMENSIONS, "-dimensional array, but found ", i, "."), loc};
     if (data[DIMENSIONS] == '{')
       throw conversion_error{pqxx::internal::concat(
         "Tried to parse ", DIMENSIONS,
-        "-dimensional array from array data that has more dimensions.")};
+        "-dimensional array from array data that has more dimensions."), loc};
     for (std::size_t i{0}; i < DIMENSIONS; ++i)
       if (data[sz - 1 - i] != '}')
         throw conversion_error{
-          "Malformed array: does not end in the right number of '}'."};
+          "Malformed array: does not end in the right number of '}'.", loc};
   }
 
   // Allow fields to construct arrays passing the encoding group.
   // Couldn't make this work through a call gate, thanks to the templating.
   friend class ::pqxx::field;
 
-  array(std::string_view data, pqxx::internal::encoding_group enc)
+  array(std::string_view data, pqxx::internal::encoding_group enc, PQXX_LOC loc)
   {
     using group = pqxx::internal::encoding_group;
     switch (enc)
     {
-    case group::MONOBYTE: parse<group::MONOBYTE>(data); break;
-    case group::BIG5: parse<group::BIG5>(data); break;
-    case group::EUC_CN: parse<group::EUC_CN>(data); break;
-    case group::EUC_JP: parse<group::EUC_JP>(data); break;
-    case group::EUC_KR: parse<group::EUC_KR>(data); break;
-    case group::EUC_TW: parse<group::EUC_TW>(data); break;
-    case group::GB18030: parse<group::GB18030>(data); break;
-    case group::GBK: parse<group::GBK>(data); break;
-    case group::JOHAB: parse<group::JOHAB>(data); break;
-    case group::MULE_INTERNAL: parse<group::MULE_INTERNAL>(data); break;
-    case group::SJIS: parse<group::SJIS>(data); break;
-    case group::UHC: parse<group::UHC>(data); break;
-    case group::UTF8: parse<group::UTF8>(data); break;
+    case group::MONOBYTE: parse<group::MONOBYTE>(data, loc); break;
+    case group::BIG5: parse<group::BIG5>(data, loc); break;
+    case group::EUC_CN: parse<group::EUC_CN>(data, loc); break;
+    case group::EUC_JP: parse<group::EUC_JP>(data, loc); break;
+    case group::EUC_KR: parse<group::EUC_KR>(data, loc); break;
+    case group::EUC_TW: parse<group::EUC_TW>(data, loc); break;
+    case group::GB18030: parse<group::GB18030>(data, loc); break;
+    case group::GBK: parse<group::GBK>(data, loc); break;
+    case group::JOHAB: parse<group::JOHAB>(data, loc); break;
+    case group::MULE_INTERNAL: parse<group::MULE_INTERNAL>(data, loc); break;
+    case group::SJIS: parse<group::SJIS>(data, loc); break;
+    case group::UHC: parse<group::UHC>(data, loc); break;
+    case group::UTF8: parse<group::UTF8>(data, loc); break;
     default: PQXX_UNREACHABLE; break;
     }
   }
@@ -230,7 +231,7 @@ private:
   /** Check for a trailing separator, detect any syntax errors at this somewhat
    * complicated point, and return the offset where parsing should continue.
    */
-  std::size_t parse_field_end(std::string_view data, std::size_t here) const
+  std::size_t parse_field_end(std::string_view data, std::size_t here, PQXX_LOC loc) const
   {
     auto const sz{std::size(data)};
     if (here < sz)
@@ -239,12 +240,12 @@ private:
       case SEPARATOR:
         ++here;
         if (here >= sz)
-          throw conversion_error{"Array looks truncated."};
+          throw conversion_error{"Array looks truncated.", loc};
         switch (data[here])
         {
         case SEPARATOR:
-          throw conversion_error{"Array contains double separator."};
-        case '}': throw conversion_error{"Array contains trailing separator."};
+          throw conversion_error{"Array contains double separator.", loc};
+        case '}': throw conversion_error{"Array contains trailing separator.", loc};
         default: break;
         }
         break;
@@ -253,7 +254,7 @@ private:
         throw conversion_error{pqxx::internal::concat(
           "Unexpected character in array: ",
           static_cast<unsigned>(static_cast<unsigned char>(data[here])),
-          " where separator or closing brace expected.")};
+          " where separator or closing brace expected."), loc};
       }
     return here;
   }
@@ -278,7 +279,7 @@ private:
   }
 
   template<pqxx::internal::encoding_group ENC>
-  void parse(std::string_view data)
+  void parse(std::string_view data, PQXX_LOC loc = PQXX_LOC::current())
   {
     static_assert(DIMENSIONS > 0u, "Can't create a zero-dimensional array.");
     auto const sz{std::size(data)};
@@ -322,7 +323,7 @@ private:
           if (know_extents_from != DIMENSIONS)
             throw conversion_error{
               "Array text representation closed and reopened its outside "
-              "brace pair."};
+              "brace pair.", loc};
           assert(here == 0);
           PQXX_ASSUME(here == 0);
         }
@@ -330,7 +331,7 @@ private:
         {
           if (dim >= (DIMENSIONS - 1))
             throw conversion_error{
-              "Array seems to have inconsistent number of dimensions."};
+              "Array seems to have inconsistent number of dimensions.", loc};
           ++extents[dim];
         }
         // (Rolls over to zero if we're coming from the outer dimension.)
@@ -341,7 +342,7 @@ private:
       else if (data[here] == '}')
       {
         if (dim == outer)
-          throw conversion_error{"Array has spurious '}'."};
+          throw conversion_error{"Array has spurious '}'.", loc};
         if (dim < know_extents_from)
         {
           // We just finished parsing our first row in this dimension.
@@ -352,13 +353,13 @@ private:
         else
         {
           if (extents[dim] != m_extents[dim])
-            throw conversion_error{"Rows in array have inconsistent sizes."};
+            throw conversion_error{"Rows in array have inconsistent sizes.", loc};
         }
         // Bump back down to the next-lower dimension.  Which may be the outer
         // dimension, through underflow.
         --dim;
         ++here;
-        here = parse_field_end(data, here);
+        here = parse_field_end(data, here, loc);
       }
       else
       {
@@ -366,14 +367,14 @@ private:
         // "inner" dimension.
         if (dim != DIMENSIONS - 1)
           throw conversion_error{
-            "Malformed array: found element where sub-array was expected."};
+            "Malformed array: found element where sub-array was expected.", loc};
         assert(dim != outer);
         ++extents[dim];
         std::size_t end;
         switch (data[here])
         {
-        case '\0': throw conversion_error{"Unexpected zero byte in array."};
-        case ',': throw conversion_error{"Array contains empty field."};
+        case '\0': throw conversion_error{"Unexpected zero byte in array.", loc};
+        case ',': throw conversion_error{"Array contains empty field.", loc};
         case '"': {
           // Double-quoted string.  We parse it into a buffer before parsing
           // the resulting string as an element.  This seems wasteful: the
@@ -385,11 +386,11 @@ private:
           // So in practice, this optimisation would only apply if the only
           // special characters in the string were commas.
           end = pqxx::internal::scan_double_quoted_string<ENC>(
-            std::data(data), std::size(data), here);
+            std::data(data), std::size(data), here, loc);
           // TODO: scan_double_quoted_string() with reusable buffer.
           std::string const buf{
             pqxx::internal::parse_double_quoted_string<ENC>(
-              std::data(data), end, here)};
+              std::data(data), end, here, loc)};
           m_elts.emplace_back(from_string<ELEMENT>(buf));
         }
         break;
@@ -398,7 +399,7 @@ private:
           // escaping or encoding, so we don't need to parse it into a
           // buffer.  We can just read it as a string_view.
           end = pqxx::internal::scan_unquoted_string<ENC, SEPARATOR, '}'>(
-            std::data(data), std::size(data), here);
+            std::data(data), std::size(data), here, loc);
           std::string_view const field{
             std::string_view{std::data(data) + here, end - here}};
           if (field == "NULL")
@@ -409,7 +410,7 @@ private:
               throw unexpected_null{pqxx::internal::concat(
                 "Array contains a null ", type_name<ELEMENT>,
                 ".  Consider making it an array of std::optional<",
-                type_name<ELEMENT>, "> instead.")};
+                type_name<ELEMENT>, "> instead."), loc};
           }
           else
             m_elts.emplace_back(from_string<ELEMENT>(field));
@@ -417,12 +418,12 @@ private:
         }
         here = end;
         PQXX_ASSUME(here <= sz);
-        here = parse_field_end(data, here);
+        here = parse_field_end(data, here, loc);
       }
     }
 
     if (dim != outer)
-      throw conversion_error{"Malformed array; may be truncated."};
+      throw conversion_error{"Malformed array; may be truncated.", loc};
     assert(know_extents_from == 0);
     PQXX_ASSUME(know_extents_from == 0);
 
@@ -467,10 +468,11 @@ private:
     }
   }
 
+  // TODO: How can we pass std::source_location here?
   /// Check that indexes are within bounds.
   /** @throw pqxx::range_error if not.
    */
-  template<typename OUTER, typename... INDEX>
+  template<typename OUTER, std::integral... INDEX>
   constexpr void check_bounds(OUTER outer, INDEX... indexes) const
   {
     std::size_t const first{check_cast<std::size_t>(outer, "array index"sv)};
@@ -550,6 +552,7 @@ public:
    * remains valid.  Once all `result` objects referring to that data have been
    * destroyed, the parser will no longer refer to valid memory.
    */
+  [[deprecated("Use pqxx::array instead.")]]
   explicit array_parser(
     std::string_view input,
     internal::encoding_group = internal::encoding_group::MONOBYTE);
@@ -589,13 +592,13 @@ private:
   std::pair<juncture, std::string> parse_array_step();
 
   template<pqxx::internal::encoding_group>
-  std::string::size_type scan_double_quoted_string() const;
+  std::string::size_type scan_double_quoted_string(PQXX_LOC loc) const;
   template<pqxx::internal::encoding_group>
-  std::string parse_double_quoted_string(std::string::size_type end) const;
+  std::string parse_double_quoted_string(std::string::size_type end, PQXX_LOC loc) const;
   template<pqxx::internal::encoding_group>
-  std::string::size_type scan_unquoted_string() const;
+  std::string::size_type scan_unquoted_string(PQXX_LOC loc) const;
   template<pqxx::internal::encoding_group>
-  std::string_view parse_unquoted_string(std::string::size_type end) const;
+  std::string_view parse_unquoted_string(std::string::size_type end, PQXX_LOC loc) const;
 
   template<pqxx::internal::encoding_group>
   std::string::size_type scan_glyph(std::string::size_type pos) const;

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -49,20 +49,17 @@ public:
    * already is an object with that oid.
    */
   [[nodiscard]] static oid
-  create(dbtransaction &, oid = 0, PQXX_LOC = PQXX_LOC::current());
+  create(dbtransaction &, oid = 0, sl = sl::current());
 
   /// Delete a large object, or fail if it does not exist.
-  static void remove(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  static void remove(dbtransaction &, oid, sl = sl::current());
 
   /// Open blob for reading.  Any attempt to write to it will fail.
-  [[nodiscard]] static blob
-  open_r(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static blob open_r(dbtransaction &, oid, sl = sl::current());
   // Open blob for writing.  Any attempt to read from it will fail.
-  [[nodiscard]] static blob
-  open_w(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static blob open_w(dbtransaction &, oid, sl = sl::current());
   // Open blob for reading and/or writing.
-  [[nodiscard]] static blob
-  open_rw(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static blob open_rw(dbtransaction &, oid, sl = sl::current());
 
   /// You can default-construct a blob, but it won't do anything useful.
   /** Most operations on a default-constructed blob will throw @ref
@@ -98,8 +95,7 @@ public:
    * @warning The underlying protocol only supports reads up to 2GB at a time.
    * If you need to read more, try making repeated calls to @ref append_to_buf.
    */
-  std::size_t
-  read(bytes &buf, std::size_t size, PQXX_LOC = PQXX_LOC::current());
+  std::size_t read(bytes &buf, std::size_t size, sl = sl::current());
 
   /// Read up to `std::size(buf)` bytes from the object.
   /** Retrieves bytes from the blob, at the current position, until `buf` is
@@ -109,7 +105,7 @@ public:
    */
   template<std::size_t extent = std::dynamic_extent>
   writable_bytes_view
-  read(std::span<std::byte, extent> buf, PQXX_LOC loc = PQXX_LOC::current())
+  read(std::span<std::byte, extent> buf, sl loc = sl::current())
   {
     return buf.subspan(0, raw_read(std::data(buf), std::size(buf), loc));
   }
@@ -121,7 +117,7 @@ public:
    * Returns the filled portion of `buf`.  This may be empty.
    */
   template<binary DATA>
-  writable_bytes_view read(DATA &buf, PQXX_LOC loc = PQXX_LOC::current())
+  writable_bytes_view read(DATA &buf, sl loc = sl::current())
   {
     return {std::data(buf), raw_read(std::data(buf), std::size(buf), loc)};
   }
@@ -145,8 +141,7 @@ public:
    * time.  If you need to write more, try making repeated calls to
    * @ref append_from_buf.
    */
-  template<binary DATA>
-  void write(DATA const &data, PQXX_LOC loc = PQXX_LOC::current())
+  template<binary DATA> void write(DATA const &data, sl loc = sl::current())
   {
     return raw_write(binary_cast(data), loc);
   }
@@ -158,46 +153,41 @@ public:
    * If the blob is less than `size` bytes long, it adds enough zero bytes to
    * make it the desired length.
    */
-  void resize(std::int64_t size, PQXX_LOC = PQXX_LOC::current());
+  void resize(std::int64_t size, sl = sl::current());
 
   /// Return the current reading/writing position in the large object.
-  [[nodiscard]] std::int64_t tell(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] std::int64_t tell(sl = sl::current()) const;
 
   /// Set the current reading/writing position to an absolute offset.
   /** Returns the new file offset. */
-  std::int64_t
-  seek_abs(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
+  std::int64_t seek_abs(std::int64_t offset = 0, sl = sl::current());
   /// Move the current reading/writing position forwards by an offset.
   /** To move backwards, pass a negative offset.
    *
    * Returns the new file offset.
    */
-  std::int64_t
-  seek_rel(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
+  std::int64_t seek_rel(std::int64_t offset = 0, sl = sl::current());
   /// Set the current position to an offset relative to the end of the blob.
   /** You'll probably want an offset of zero or less.
    *
    * Returns the new file offset.
    */
-  std::int64_t
-  seek_end(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
+  std::int64_t seek_end(std::int64_t offset = 0, sl = sl::current());
 
   /// Create a binary large object containing given `data`.
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
-  static oid from_buf(
-    dbtransaction &tx, bytes_view data, oid id = 0,
-    PQXX_LOC = PQXX_LOC::current());
+  static oid
+  from_buf(dbtransaction &tx, bytes_view data, oid id = 0, sl = sl::current());
 
   /// Create a binary large object containing given `data`.
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
   template<binary DATA>
-  static oid from_buf(
-    dbtransaction &tx, DATA data, oid id = 0,
-    PQXX_LOC loc = PQXX_LOC::current())
+  static oid
+  from_buf(dbtransaction &tx, DATA data, oid id = 0, sl loc = sl::current())
   {
     return from_buf(tx, binary_cast(data), id, loc);
   }
@@ -206,29 +196,27 @@ public:
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
   static void append_from_buf(
-    dbtransaction &tx, bytes_view data, oid id,
-    PQXX_LOC = PQXX_LOC::current());
+    dbtransaction &tx, bytes_view data, oid id, sl = sl::current());
 
   /// Append `data` to binary large object.
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
   template<binary DATA>
-  static void append_from_buf(
-    dbtransaction &tx, DATA data, oid id, PQXX_LOC loc = PQXX_LOC::current())
+  static void
+  append_from_buf(dbtransaction &tx, DATA data, oid id, sl loc = sl::current())
   {
     append_from_buf(tx, binary_cast(data), id, loc);
   }
 
   /// Read client-side file and store it server-side as a binary large object.
   [[nodiscard]] static oid
-  from_file(dbtransaction &, zview path, PQXX_LOC = PQXX_LOC::current());
+  from_file(dbtransaction &, zview path, sl = sl::current());
 
   /// Read client-side file and store it server-side as a binary large object.
   /** In this version, you specify the binary large object's oid.  If that oid
    * is already in use, the operation will fail.
    */
-  static oid
-  from_file(dbtransaction &, zview path, oid, PQXX_LOC = PQXX_LOC::current());
+  static oid from_file(dbtransaction &, zview path, oid, sl = sl::current());
 
   // XXX: Can we build a generic version of this?
   /// Convenience function: Read up to `max_size` bytes from blob with `id`.
@@ -236,8 +224,7 @@ public:
    * functions, but it can save you a bit of code to do it this way.
    */
   static void to_buf(
-    dbtransaction &, oid, bytes &, std::size_t max_size,
-    PQXX_LOC = PQXX_LOC::current());
+    dbtransaction &, oid, bytes &, std::size_t max_size, sl = sl::current());
 
   // XXX: Can we build a generic version of this?
   /// Read part of the binary large object with `id`, and append it to `buf`.
@@ -249,11 +236,10 @@ public:
    */
   static std::size_t append_to_buf(
     dbtransaction &tx, oid id, std::int64_t offset, bytes &buf,
-    std::size_t append_max, PQXX_LOC = PQXX_LOC::current());
+    std::size_t append_max, sl = sl::current());
 
   /// Write a binary large object's contents to a client-side file.
-  static void
-  to_file(dbtransaction &, oid, zview path, PQXX_LOC = PQXX_LOC::current());
+  static void to_file(dbtransaction &, oid, zview path, sl = sl::current());
 
   /// Close this blob.
   /** This does not delete the blob from the database; it only terminates your
@@ -272,7 +258,7 @@ public:
 private:
   PQXX_PRIVATE blob(connection &cx, int fd) noexcept : m_conn{&cx}, m_fd{fd} {}
   static PQXX_PRIVATE blob
-  open_internal(dbtransaction &, oid, int, PQXX_LOC = PQXX_LOC::current());
+  open_internal(dbtransaction &, oid, int, sl = sl::current());
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
   raw_conn(pqxx::connection *) noexcept;
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
@@ -284,10 +270,9 @@ private:
   }
   PQXX_PRIVATE std::string errmsg() const { return errmsg(m_conn); }
   PQXX_PRIVATE std::int64_t
-  seek(std::int64_t offset, int whence, PQXX_LOC = PQXX_LOC::current());
-  std::size_t
-  raw_read(std::byte buf[], std::size_t size, PQXX_LOC = PQXX_LOC::current());
-  void raw_write(bytes_view, PQXX_LOC = PQXX_LOC::current());
+  seek(std::int64_t offset, int whence, sl = sl::current());
+  std::size_t raw_read(std::byte buf[], std::size_t size, sl = sl::current());
+  void raw_write(bytes_view, sl = sl::current());
 
   connection *m_conn = nullptr;
   int m_fd = -1;

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -257,8 +257,7 @@ public:
 
 private:
   PQXX_PRIVATE blob(connection &cx, int fd) noexcept : m_conn{&cx}, m_fd{fd} {}
-  static PQXX_PRIVATE blob
-  open_internal(dbtransaction &, oid, int, sl = sl::current());
+  static PQXX_PRIVATE blob open_internal(dbtransaction &, oid, int, sl);
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
   raw_conn(pqxx::connection *) noexcept;
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
@@ -269,10 +268,9 @@ private:
     return errmsg(&tx.conn());
   }
   PQXX_PRIVATE std::string errmsg() const { return errmsg(m_conn); }
-  PQXX_PRIVATE std::int64_t
-  seek(std::int64_t offset, int whence, sl = sl::current());
-  std::size_t raw_read(std::byte buf[], std::size_t size, sl = sl::current());
-  void raw_write(bytes_view, sl = sl::current());
+  PQXX_PRIVATE std::int64_t seek(std::int64_t offset, int whence, sl);
+  std::size_t raw_read(std::byte buf[], std::size_t size, sl);
+  void raw_write(bytes_view, sl);
 
   connection *m_conn = nullptr;
   int m_fd = -1;

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -48,17 +48,17 @@ public:
    * the new object will have that oid -- or creation will fail if there
    * already is an object with that oid.
    */
-  [[nodiscard]] static oid create(dbtransaction &, oid = 0);
+  [[nodiscard]] static oid create(dbtransaction &, oid = 0, PQXX_LOC = PQXX_LOC::current());
 
   /// Delete a large object, or fail if it does not exist.
-  static void remove(dbtransaction &, oid);
+  static void remove(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
 
   /// Open blob for reading.  Any attempt to write to it will fail.
-  [[nodiscard]] static blob open_r(dbtransaction &, oid);
+  [[nodiscard]] static blob open_r(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
   // Open blob for writing.  Any attempt to read from it will fail.
-  [[nodiscard]] static blob open_w(dbtransaction &, oid);
+  [[nodiscard]] static blob open_w(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
   // Open blob for reading and/or writing.
-  [[nodiscard]] static blob open_rw(dbtransaction &, oid);
+  [[nodiscard]] static blob open_rw(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
 
   /// You can default-construct a blob, but it won't do anything useful.
   /** Most operations on a default-constructed blob will throw @ref
@@ -94,7 +94,7 @@ public:
    * @warning The underlying protocol only supports reads up to 2GB at a time.
    * If you need to read more, try making repeated calls to @ref append_to_buf.
    */
-  std::size_t read(bytes &buf, std::size_t size);
+  std::size_t read(bytes &buf, std::size_t size, PQXX_LOC = PQXX_LOC::current());
 
   /// Read up to `std::size(buf)` bytes from the object.
   /** Retrieves bytes from the blob, at the current position, until `buf` is
@@ -103,9 +103,9 @@ public:
    * Returns the filled portion of `buf`.  This may be empty.
    */
   template<std::size_t extent = std::dynamic_extent>
-  writable_bytes_view read(std::span<std::byte, extent> buf)
+  writable_bytes_view read(std::span<std::byte, extent> buf, PQXX_LOC loc = PQXX_LOC::current())
   {
-    return buf.subspan(0, raw_read(std::data(buf), std::size(buf)));
+    return buf.subspan(0, raw_read(std::data(buf), std::size(buf), loc));
   }
 
   /// Read up to `std::size(buf)` bytes from the object.
@@ -114,9 +114,9 @@ public:
    *
    * Returns the filled portion of `buf`.  This may be empty.
    */
-  template<binary DATA> writable_bytes_view read(DATA &buf)
+  template<binary DATA> writable_bytes_view read(DATA &buf, PQXX_LOC loc = PQXX_LOC::current())
   {
-    return {std::data(buf), raw_read(std::data(buf), std::size(buf))};
+    return {std::data(buf), raw_read(std::data(buf), std::size(buf), loc)};
   }
 
   /// Write `data` to large object, at the current position.
@@ -138,9 +138,9 @@ public:
    * time.  If you need to write more, try making repeated calls to
    * @ref append_from_buf.
    */
-  template<binary DATA> void write(DATA const &data)
+  template<binary DATA> void write(DATA const &data, PQXX_LOC loc = PQXX_LOC::current())
   {
-    return raw_write(binary_cast(data));
+    return raw_write(binary_cast(data), loc);
   }
 
   /// Resize large object to `size` bytes.
@@ -150,72 +150,72 @@ public:
    * If the blob is less than `size` bytes long, it adds enough zero bytes to
    * make it the desired length.
    */
-  void resize(std::int64_t size);
+  void resize(std::int64_t size, PQXX_LOC = PQXX_LOC::current());
 
   /// Return the current reading/writing position in the large object.
-  [[nodiscard]] std::int64_t tell() const;
+  [[nodiscard]] std::int64_t tell(PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Set the current reading/writing position to an absolute offset.
   /** Returns the new file offset. */
-  std::int64_t seek_abs(std::int64_t offset = 0);
+  std::int64_t seek_abs(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
   /// Move the current reading/writing position forwards by an offset.
   /** To move backwards, pass a negative offset.
    *
    * Returns the new file offset.
    */
-  std::int64_t seek_rel(std::int64_t offset = 0);
+  std::int64_t seek_rel(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
   /// Set the current position to an offset relative to the end of the blob.
   /** You'll probably want an offset of zero or less.
    *
    * Returns the new file offset.
    */
-  std::int64_t seek_end(std::int64_t offset = 0);
+  std::int64_t seek_end(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
 
   /// Create a binary large object containing given `data`.
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
-  static oid from_buf(dbtransaction &tx, bytes_view data, oid id = 0);
+  static oid from_buf(dbtransaction &tx, bytes_view data, oid id = 0, PQXX_LOC = PQXX_LOC::current());
 
   /// Create a binary large object containing given `data`.
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
   template<binary DATA>
-  static oid from_buf(dbtransaction &tx, DATA data, oid id = 0)
+  static oid from_buf(dbtransaction &tx, DATA data, oid id = 0, PQXX_LOC loc = PQXX_LOC::current())
   {
-    return from_buf(tx, binary_cast(data), id);
+    return from_buf(tx, binary_cast(data), id, loc);
   }
 
   /// Append `data` to binary large object.
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
-  static void append_from_buf(dbtransaction &tx, bytes_view data, oid id);
+  static void append_from_buf(dbtransaction &tx, bytes_view data, oid id, PQXX_LOC = PQXX_LOC::current());
 
   /// Append `data` to binary large object.
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
   template<binary DATA>
-  static void append_from_buf(dbtransaction &tx, DATA data, oid id)
+  static void append_from_buf(dbtransaction &tx, DATA data, oid id, PQXX_LOC loc = PQXX_LOC::current())
   {
-    append_from_buf(tx, binary_cast(data), id);
+    append_from_buf(tx, binary_cast(data), id, loc);
   }
 
   /// Read client-side file and store it server-side as a binary large object.
-  [[nodiscard]] static oid from_file(dbtransaction &, zview path);
+  [[nodiscard]] static oid from_file(dbtransaction &, zview path, PQXX_LOC = PQXX_LOC::current());
 
   /// Read client-side file and store it server-side as a binary large object.
   /** In this version, you specify the binary large object's oid.  If that oid
    * is already in use, the operation will fail.
    */
-  static oid from_file(dbtransaction &, zview path, oid);
+  static oid from_file(dbtransaction &, zview path, oid, PQXX_LOC = PQXX_LOC::current());
 
   // XXX: Can we build a generic version of this?
   /// Convenience function: Read up to `max_size` bytes from blob with `id`.
   /** You could easily do this yourself using the @ref open_r and @ref read
    * functions, but it can save you a bit of code to do it this way.
    */
-  static void to_buf(dbtransaction &, oid, bytes &, std::size_t max_size);
+  static void to_buf(dbtransaction &, oid, bytes &, std::size_t max_size, PQXX_LOC = PQXX_LOC::current());
 
   // XXX: Can we build a generic version of this?
   /// Read part of the binary large object with `id`, and append it to `buf`.
@@ -227,10 +227,10 @@ public:
    */
   static std::size_t append_to_buf(
     dbtransaction &tx, oid id, std::int64_t offset, bytes &buf,
-    std::size_t append_max);
+    std::size_t append_max, PQXX_LOC = PQXX_LOC::current());
 
   /// Write a binary large object's contents to a client-side file.
-  static void to_file(dbtransaction &, oid, zview path);
+  static void to_file(dbtransaction &, oid, zview path, PQXX_LOC = PQXX_LOC::current());
 
   /// Close this blob.
   /** This does not delete the blob from the database; it only terminates your
@@ -248,7 +248,7 @@ public:
 
 private:
   PQXX_PRIVATE blob(connection &cx, int fd) noexcept : m_conn{&cx}, m_fd{fd} {}
-  static PQXX_PRIVATE blob open_internal(dbtransaction &, oid, int);
+  static PQXX_PRIVATE blob open_internal(dbtransaction &, oid, int, PQXX_LOC = PQXX_LOC::current());
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
   raw_conn(pqxx::connection *) noexcept;
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
@@ -259,9 +259,9 @@ private:
     return errmsg(&tx.conn());
   }
   PQXX_PRIVATE std::string errmsg() const { return errmsg(m_conn); }
-  PQXX_PRIVATE std::int64_t seek(std::int64_t offset, int whence);
-  std::size_t raw_read(std::byte buf[], std::size_t size);
-  void raw_write(bytes_view);
+  PQXX_PRIVATE std::int64_t seek(std::int64_t offset, int whence, PQXX_LOC = PQXX_LOC::current());
+  std::size_t raw_read(std::byte buf[], std::size_t size, PQXX_LOC = PQXX_LOC::current());
+  void raw_write(bytes_view, PQXX_LOC = PQXX_LOC::current());
 
   connection *m_conn = nullptr;
   int m_fd = -1;

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -48,17 +48,21 @@ public:
    * the new object will have that oid -- or creation will fail if there
    * already is an object with that oid.
    */
-  [[nodiscard]] static oid create(dbtransaction &, oid = 0, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static oid
+  create(dbtransaction &, oid = 0, PQXX_LOC = PQXX_LOC::current());
 
   /// Delete a large object, or fail if it does not exist.
   static void remove(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
 
   /// Open blob for reading.  Any attempt to write to it will fail.
-  [[nodiscard]] static blob open_r(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static blob
+  open_r(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
   // Open blob for writing.  Any attempt to read from it will fail.
-  [[nodiscard]] static blob open_w(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static blob
+  open_w(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
   // Open blob for reading and/or writing.
-  [[nodiscard]] static blob open_rw(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static blob
+  open_rw(dbtransaction &, oid, PQXX_LOC = PQXX_LOC::current());
 
   /// You can default-construct a blob, but it won't do anything useful.
   /** Most operations on a default-constructed blob will throw @ref
@@ -94,7 +98,8 @@ public:
    * @warning The underlying protocol only supports reads up to 2GB at a time.
    * If you need to read more, try making repeated calls to @ref append_to_buf.
    */
-  std::size_t read(bytes &buf, std::size_t size, PQXX_LOC = PQXX_LOC::current());
+  std::size_t
+  read(bytes &buf, std::size_t size, PQXX_LOC = PQXX_LOC::current());
 
   /// Read up to `std::size(buf)` bytes from the object.
   /** Retrieves bytes from the blob, at the current position, until `buf` is
@@ -103,7 +108,8 @@ public:
    * Returns the filled portion of `buf`.  This may be empty.
    */
   template<std::size_t extent = std::dynamic_extent>
-  writable_bytes_view read(std::span<std::byte, extent> buf, PQXX_LOC loc = PQXX_LOC::current())
+  writable_bytes_view
+  read(std::span<std::byte, extent> buf, PQXX_LOC loc = PQXX_LOC::current())
   {
     return buf.subspan(0, raw_read(std::data(buf), std::size(buf), loc));
   }
@@ -114,7 +120,8 @@ public:
    *
    * Returns the filled portion of `buf`.  This may be empty.
    */
-  template<binary DATA> writable_bytes_view read(DATA &buf, PQXX_LOC loc = PQXX_LOC::current())
+  template<binary DATA>
+  writable_bytes_view read(DATA &buf, PQXX_LOC loc = PQXX_LOC::current())
   {
     return {std::data(buf), raw_read(std::data(buf), std::size(buf), loc)};
   }
@@ -138,7 +145,8 @@ public:
    * time.  If you need to write more, try making repeated calls to
    * @ref append_from_buf.
    */
-  template<binary DATA> void write(DATA const &data, PQXX_LOC loc = PQXX_LOC::current())
+  template<binary DATA>
+  void write(DATA const &data, PQXX_LOC loc = PQXX_LOC::current())
   {
     return raw_write(binary_cast(data), loc);
   }
@@ -157,32 +165,39 @@ public:
 
   /// Set the current reading/writing position to an absolute offset.
   /** Returns the new file offset. */
-  std::int64_t seek_abs(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
+  std::int64_t
+  seek_abs(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
   /// Move the current reading/writing position forwards by an offset.
   /** To move backwards, pass a negative offset.
    *
    * Returns the new file offset.
    */
-  std::int64_t seek_rel(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
+  std::int64_t
+  seek_rel(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
   /// Set the current position to an offset relative to the end of the blob.
   /** You'll probably want an offset of zero or less.
    *
    * Returns the new file offset.
    */
-  std::int64_t seek_end(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
+  std::int64_t
+  seek_end(std::int64_t offset = 0, PQXX_LOC = PQXX_LOC::current());
 
   /// Create a binary large object containing given `data`.
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
-  static oid from_buf(dbtransaction &tx, bytes_view data, oid id = 0, PQXX_LOC = PQXX_LOC::current());
+  static oid from_buf(
+    dbtransaction &tx, bytes_view data, oid id = 0,
+    PQXX_LOC = PQXX_LOC::current());
 
   /// Create a binary large object containing given `data`.
   /** You may optionally specify an oid for the new object.  If you do, and an
    * object with that oid already exists, creation will fail.
    */
   template<binary DATA>
-  static oid from_buf(dbtransaction &tx, DATA data, oid id = 0, PQXX_LOC loc = PQXX_LOC::current())
+  static oid from_buf(
+    dbtransaction &tx, DATA data, oid id = 0,
+    PQXX_LOC loc = PQXX_LOC::current())
   {
     return from_buf(tx, binary_cast(data), id, loc);
   }
@@ -190,32 +205,39 @@ public:
   /// Append `data` to binary large object.
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
-  static void append_from_buf(dbtransaction &tx, bytes_view data, oid id, PQXX_LOC = PQXX_LOC::current());
+  static void append_from_buf(
+    dbtransaction &tx, bytes_view data, oid id,
+    PQXX_LOC = PQXX_LOC::current());
 
   /// Append `data` to binary large object.
   /** The underlying protocol only supports appending blocks up to 2 GB.
    */
   template<binary DATA>
-  static void append_from_buf(dbtransaction &tx, DATA data, oid id, PQXX_LOC loc = PQXX_LOC::current())
+  static void append_from_buf(
+    dbtransaction &tx, DATA data, oid id, PQXX_LOC loc = PQXX_LOC::current())
   {
     append_from_buf(tx, binary_cast(data), id, loc);
   }
 
   /// Read client-side file and store it server-side as a binary large object.
-  [[nodiscard]] static oid from_file(dbtransaction &, zview path, PQXX_LOC = PQXX_LOC::current());
+  [[nodiscard]] static oid
+  from_file(dbtransaction &, zview path, PQXX_LOC = PQXX_LOC::current());
 
   /// Read client-side file and store it server-side as a binary large object.
   /** In this version, you specify the binary large object's oid.  If that oid
    * is already in use, the operation will fail.
    */
-  static oid from_file(dbtransaction &, zview path, oid, PQXX_LOC = PQXX_LOC::current());
+  static oid
+  from_file(dbtransaction &, zview path, oid, PQXX_LOC = PQXX_LOC::current());
 
   // XXX: Can we build a generic version of this?
   /// Convenience function: Read up to `max_size` bytes from blob with `id`.
   /** You could easily do this yourself using the @ref open_r and @ref read
    * functions, but it can save you a bit of code to do it this way.
    */
-  static void to_buf(dbtransaction &, oid, bytes &, std::size_t max_size, PQXX_LOC = PQXX_LOC::current());
+  static void to_buf(
+    dbtransaction &, oid, bytes &, std::size_t max_size,
+    PQXX_LOC = PQXX_LOC::current());
 
   // XXX: Can we build a generic version of this?
   /// Read part of the binary large object with `id`, and append it to `buf`.
@@ -230,7 +252,8 @@ public:
     std::size_t append_max, PQXX_LOC = PQXX_LOC::current());
 
   /// Write a binary large object's contents to a client-side file.
-  static void to_file(dbtransaction &, oid, zview path, PQXX_LOC = PQXX_LOC::current());
+  static void
+  to_file(dbtransaction &, oid, zview path, PQXX_LOC = PQXX_LOC::current());
 
   /// Close this blob.
   /** This does not delete the blob from the database; it only terminates your
@@ -248,7 +271,8 @@ public:
 
 private:
   PQXX_PRIVATE blob(connection &cx, int fd) noexcept : m_conn{&cx}, m_fd{fd} {}
-  static PQXX_PRIVATE blob open_internal(dbtransaction &, oid, int, PQXX_LOC = PQXX_LOC::current());
+  static PQXX_PRIVATE blob
+  open_internal(dbtransaction &, oid, int, PQXX_LOC = PQXX_LOC::current());
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
   raw_conn(pqxx::connection *) noexcept;
   static PQXX_PRIVATE pqxx::internal::pq::PGconn *
@@ -259,8 +283,10 @@ private:
     return errmsg(&tx.conn());
   }
   PQXX_PRIVATE std::string errmsg() const { return errmsg(m_conn); }
-  PQXX_PRIVATE std::int64_t seek(std::int64_t offset, int whence, PQXX_LOC = PQXX_LOC::current());
-  std::size_t raw_read(std::byte buf[], std::size_t size, PQXX_LOC = PQXX_LOC::current());
+  PQXX_PRIVATE std::int64_t
+  seek(std::int64_t offset, int whence, PQXX_LOC = PQXX_LOC::current());
+  std::size_t
+  raw_read(std::byte buf[], std::size_t size, PQXX_LOC = PQXX_LOC::current());
   void raw_write(bytes_view, PQXX_LOC = PQXX_LOC::current());
 
   connection *m_conn = nullptr;

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -44,7 +44,8 @@ inline void parse_composite(
   auto const data{std::data(text)};
   auto const size{std::size(text)};
   if (size == 0)
-    throw conversion_error{"Cannot parse composite value from empty string.", loc};
+    throw conversion_error{
+      "Cannot parse composite value from empty string.", loc};
 
   std::size_t here{0}, next{scan(data, size, here)};
   if (next != 1 or data[here] != '(')
@@ -60,12 +61,16 @@ inline void parse_composite(
      index, text, here, fields, num_fields - 1, loc),
    ...);
   if (here != std::size(text))
-    throw conversion_error{internal::concat(
-      "Composite value did not end at the closing parenthesis: '", text,
-      "'."), loc};
+    throw conversion_error{
+      internal::concat(
+        "Composite value did not end at the closing parenthesis: '", text,
+        "'."),
+      loc};
   if (text[here - 1] != ')')
-    throw conversion_error{internal::concat(
-      "Composite value did not end in parenthesis: '", text, "'"), loc};
+    throw conversion_error{
+      internal::concat(
+        "Composite value did not end in parenthesis: '", text, "'"),
+      loc};
 }
 
 

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -38,7 +38,7 @@ inline void parse_composite(
 {
   static_assert(sizeof...(fields) > 0);
   // TODO: Turn this into a parameter.
-  auto const loc{PQXX_LOC::current()};
+  auto const loc{sl::current()};
 
   auto const scan{pqxx::internal::get_glyph_scanner(enc, loc)};
   auto const data{std::data(text)};
@@ -132,7 +132,7 @@ composite_size_buffer(T const &...fields) noexcept
 template<typename... T>
 inline char *composite_into_buf(char *begin, char *end, T const &...fields)
 {
-  auto loc{PQXX_LOC::current()};
+  auto loc{sl::current()};
   if (std::size_t(end - begin) < composite_size_buffer(fields...))
     throw conversion_error{
       "Buffer space may not be enough to represent composite value.", loc};

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -40,14 +40,14 @@ inline void parse_composite(
   // TODO: Turn this into a parameter.
   auto const loc{PQXX_LOC::current()};
 
-  auto const scan{pqxx::internal::get_glyph_scanner(enc)};
+  auto const scan{pqxx::internal::get_glyph_scanner(enc, loc)};
   auto const data{std::data(text)};
   auto const size{std::size(text)};
   if (size == 0)
     throw conversion_error{
       "Cannot parse composite value from empty string.", loc};
 
-  std::size_t here{0}, next{scan(data, size, here)};
+  std::size_t here{0}, next{scan(data, size, here, loc)};
   if (next != 1 or data[here] != '(')
     throw conversion_error{
       internal::concat("Invalid composite value string: ", text), loc};

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -11,6 +11,7 @@
 
 namespace pqxx
 {
+// TODO: How can we pass std::source_location here?
 /// Parse a string representation of a value of a composite type.
 /** @warning This code is still experimental.  Use with care.
  *
@@ -36,36 +37,39 @@ inline void parse_composite(
   pqxx::internal::encoding_group enc, std::string_view text, T &...fields)
 {
   static_assert(sizeof...(fields) > 0);
+  // TODO: Turn this into a parameter.
+  auto const loc{PQXX_LOC::current()};
 
   auto const scan{pqxx::internal::get_glyph_scanner(enc)};
   auto const data{std::data(text)};
   auto const size{std::size(text)};
   if (size == 0)
-    throw conversion_error{"Cannot parse composite value from empty string."};
+    throw conversion_error{"Cannot parse composite value from empty string.", loc};
 
   std::size_t here{0}, next{scan(data, size, here)};
   if (next != 1 or data[here] != '(')
     throw conversion_error{
-      internal::concat("Invalid composite value string: ", text)};
+      internal::concat("Invalid composite value string: ", text), loc};
 
   here = next;
 
   // TODO: Reuse parse_composite_field specialisation across calls.
   constexpr auto num_fields{sizeof...(fields)};
   std::size_t index{0};
-  (pqxx::internal::specialize_parse_composite_field<T>(enc)(
-     index, text, here, fields, num_fields - 1),
+  (pqxx::internal::specialize_parse_composite_field<T>(enc, loc)(
+     index, text, here, fields, num_fields - 1, loc),
    ...);
   if (here != std::size(text))
     throw conversion_error{internal::concat(
       "Composite value did not end at the closing parenthesis: '", text,
-      "'.")};
+      "'."), loc};
   if (text[here - 1] != ')')
     throw conversion_error{internal::concat(
-      "Composive value did not end in parenthesis: '", text, "'")};
+      "Composite value did not end in parenthesis: '", text, "'"), loc};
 }
 
 
+// TODO: How can we pass std::source_location here?
 /// Parse a string representation of a value of a composite type.
 /** @warning This version only works for UTF-8 and single-byte encodings.
  *
@@ -113,6 +117,7 @@ composite_size_buffer(T const &...fields) noexcept
 }
 
 
+// TODO: How can we pass std::source_location here?
 /// Render a series of values as a single composite SQL value.
 /** @warning This code is still experimental.  Use with care.
  *
@@ -122,9 +127,10 @@ composite_size_buffer(T const &...fields) noexcept
 template<typename... T>
 inline char *composite_into_buf(char *begin, char *end, T const &...fields)
 {
+  auto loc{PQXX_LOC::current()};
   if (std::size_t(end - begin) < composite_size_buffer(fields...))
     throw conversion_error{
-      "Buffer space may not be enough to represent composite value."};
+      "Buffer space may not be enough to represent composite value.", loc};
 
   constexpr auto num_fields{sizeof...(fields)};
   if constexpr (num_fields == 0)

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -315,9 +315,11 @@ public:
 
   ~connection()
   {
+    // TODO: How can we pass std::source_location?
+    sl loc{sl::current()};
     try
     {
-      close();
+      close(loc);
     }
     catch (std::exception const &)
     {}
@@ -439,7 +441,7 @@ public:
    */
   //@{
   /// Get client-side character encoding, by name.
-  [[nodiscard]] std::string get_client_encoding() const;
+  [[nodiscard]] std::string get_client_encoding(sl loc = sl::current()) const;
 
   /// Set client-side character encoding, by name.
   /**
@@ -837,9 +839,10 @@ public:
   //@{
 
   /// Escape string for use as SQL string literal on this connection.
-  [[nodiscard]] std::string esc(char const text[]) const
+  [[nodiscard]] std::string
+  esc(char const text[], sl loc = sl::current()) const
   {
-    return esc(std::string_view{text});
+    return esc(std::string_view{text}, loc);
   }
 
   /// Escape string for use as SQL string literal, into `buffer`.
@@ -1173,7 +1176,7 @@ private:
   {
     connect_nonblocking
   };
-  connection(connect_mode, zview connection_string, sl = sl::current());
+  connection(connect_mode, zview connection_string, sl);
 
   /// For use by @ref seize_raw_connection.
   explicit connection(internal::pq::PGconn *raw_conn);
@@ -1363,7 +1366,7 @@ class PQXX_LIBEXPORT connecting
 {
 public:
   /// Start connecting.
-  connecting(zview connection_string = ""_zv);
+  connecting(zview connection_string = ""_zv, sl = sl::current());
 
   connecting(connecting const &) = delete;
   connecting(connecting &&) = default;

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -1204,7 +1204,14 @@ private:
 
   result make_result(
     internal::pq::PGresult *pgr, std::shared_ptr<std::string> const &query,
-    std::string_view desc = ""sv);
+    std::string_view desc, PQXX_LOC = PQXX_LOC::current());
+
+  result make_result(
+    internal::pq::PGresult *pgr, std::shared_ptr<std::string> const &query,
+    PQXX_LOC loc = PQXX_LOC::current())
+  {
+    return make_result(pgr, query, "", loc);
+  }
 
   void PQXX_PRIVATE set_up_state(PQXX_LOC);
 

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -1045,8 +1045,9 @@ public:
    * The SQL "LIKE" operator also lets you choose your own escape character.
    * This is supported, but must be a single-byte character.
    */
-  [[nodiscard]] std::string
-  esc_like(std::string_view text, char escape_char = '\\') const;
+  [[nodiscard]] std::string esc_like(
+    std::string_view text, char escape_char = '\\',
+    PQXX_LOC loc = PQXX_LOC::current()) const;
   //@}
 
   /// Attempt to cancel the ongoing query, if any.

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -1268,7 +1268,7 @@ private:
   read_copy_line();
 
   friend class internal::gate::connection_stream_to;
-  void PQXX_PRIVATE write_copy_line(std::string_view);
+  void PQXX_PRIVATE write_copy_line(std::string_view, PQXX_LOC);
   void PQXX_PRIVATE end_copy_write();
 
   friend class internal::gate::connection_largeobject;

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -953,11 +953,12 @@ public:
    * "bytea" escape format, used prior to PostgreSQL 9.0, is no longer
    * supported.)
    */
-  [[nodiscard]] bytes unesc_bin(std::string_view text) const
+  [[nodiscard]] bytes
+  unesc_bin(std::string_view text, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     bytes buf;
     buf.resize(pqxx::internal::size_unesc_bin(std::size(text)));
-    pqxx::internal::unesc_bin(text, buf.data());
+    pqxx::internal::unesc_bin(text, buf.data(), loc);
     return buf;
   }
 

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -273,17 +273,17 @@ enum class error_verbosity : int
 class PQXX_LIBEXPORT connection
 {
 public:
-  connection(PQXX_LOC loc = PQXX_LOC::current()) : connection{"", loc} {}
+  connection(sl loc = sl::current()) : connection{"", loc} {}
 
   /// Connect to a database, using `options` string.
-  explicit connection(char const options[], PQXX_LOC loc = PQXX_LOC::current())
+  explicit connection(char const options[], sl loc = sl::current())
   {
     check_version();
     init(options, loc);
   }
 
   /// Connect to a database, using `options` string.
-  explicit connection(zview options, PQXX_LOC loc = PQXX_LOC::current()) :
+  explicit connection(zview options, sl loc = sl::current()) :
           connection{options.c_str(), loc}
   {
     // (Delegates to other constructor which calls check_version for us.)
@@ -295,7 +295,7 @@ public:
    * other objects may hold references to the old object which would become
    * invalid and might produce hard-to-diagnose bugs.
    */
-  connection(connection &&rhs, PQXX_LOC = PQXX_LOC::current());
+  connection(connection &&rhs, sl = sl::current());
 
   /// Connect to a database, passing options as a range of key/value pairs.
   /** There's no need to escape the parameter values.
@@ -311,7 +311,7 @@ public:
    * `std::map<std::string, pqxx::zview>`, and so on.
    */
   template<internal::ZKey_ZValues MAPPING>
-  inline connection(MAPPING const &params, PQXX_LOC = PQXX_LOC::current());
+  inline connection(MAPPING const &params, sl = sl::current());
 
   ~connection()
   {
@@ -445,8 +445,7 @@ public:
   /**
    * @param encoding Name of the character set encoding to use.
    */
-  void
-  set_client_encoding(zview encoding, PQXX_LOC loc = PQXX_LOC::current()) &
+  void set_client_encoding(zview encoding, sl loc = sl::current()) &
   {
     set_client_encoding(encoding.c_str(), loc);
   }
@@ -455,11 +454,10 @@ public:
   /**
    * @param encoding Name of the character set encoding to use.
    */
-  void
-  set_client_encoding(char const encoding[], PQXX_LOC = PQXX_LOC::current()) &;
+  void set_client_encoding(char const encoding[], sl = sl::current()) &;
 
   /// Get the connection's encoding, as a PostgreSQL-defined code.
-  [[nodiscard]] int encoding_id(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] int encoding_id(sl = sl::current()) const;
 
   //@}
 
@@ -487,8 +485,7 @@ public:
    */
   template<typename TYPE>
   void set_session_var(
-    std::string_view var, TYPE const &value,
-    PQXX_LOC loc = PQXX_LOC::current()) &
+    std::string_view var, TYPE const &value, sl loc = sl::current()) &
   {
     if constexpr (nullness<TYPE>::has_null)
     {
@@ -508,8 +505,7 @@ public:
    * @return a blank `std::optional` if the variable's value is null, or its
    * string value otherwise.
    */
-  std::string
-  get_var(std::string_view var, PQXX_LOC loc = PQXX_LOC::current());
+  std::string get_var(std::string_view var, sl loc = sl::current());
 
   /// Read currently applicable value of a variable.
   /** This function executes an SQL statement, so it won't work while a
@@ -519,7 +515,7 @@ public:
    * can represent null values.
    */
   template<typename TYPE>
-  TYPE get_var_as(std::string_view var, PQXX_LOC loc = PQXX_LOC::current())
+  TYPE get_var_as(std::string_view var, sl loc = sl::current())
   {
     return from_string<TYPE>(get_var(var, loc));
   }
@@ -632,7 +628,7 @@ public:
    *
    * @return Number of notifications processed.
    */
-  int get_notifs(PQXX_LOC = PQXX_LOC::current());
+  int get_notifs(sl = sl::current());
 
   /// Wait for a notification to come in.
   /** There are other events that will also cancel the wait, such as the
@@ -649,7 +645,7 @@ public:
    *
    * @return Number of notifications processed.
    */
-  int await_notification(PQXX_LOC = PQXX_LOC::current());
+  int await_notification(sl = sl::current());
 
   /// Wait for a notification to come in, or for given timeout to pass.
   /** There are other events that will also cancel the wait, such as the
@@ -669,8 +665,7 @@ public:
    * @return Number of notifications processed.
    */
   int await_notification(
-    std::time_t seconds, long microseconds = 0,
-    PQXX_LOC = PQXX_LOC::current());
+    std::time_t seconds, long microseconds = 0, sl = sl::current());
 
   /// A handler callback for incoming notifications on a given channel.
   /** Your callback must accept a @ref notification object.  This object can
@@ -706,7 +701,7 @@ public:
    */
   void listen(
     std::string_view channel, notification_handler handler = {},
-    PQXX_LOC = PQXX_LOC::current());
+    sl = sl::current());
 
   //@}
 
@@ -799,8 +794,7 @@ public:
    * @param name unique name for the new prepared statement.
    * @param definition SQL statement to prepare.
    */
-  void
-  prepare(zview name, zview definition, PQXX_LOC loc = PQXX_LOC::current()) &
+  void prepare(zview name, zview definition, sl loc = sl::current()) &
   {
     prepare(name.c_str(), definition.c_str(), loc);
   }
@@ -810,8 +804,7 @@ public:
    * @param definition SQL statement to prepare.
    */
   void prepare(
-    char const name[], char const definition[],
-    PQXX_LOC loc = PQXX_LOC::current()) &;
+    char const name[], char const definition[], sl loc = sl::current()) &;
 
   /// Define a nameless prepared statement.
   /**
@@ -821,14 +814,14 @@ public:
    * the nameless statement being redefined unexpectedly by code somewhere
    * else.
    */
-  void prepare(char const definition[], PQXX_LOC loc = PQXX_LOC::current()) &;
-  void prepare(zview definition, PQXX_LOC loc = PQXX_LOC::current()) &
+  void prepare(char const definition[], sl loc = sl::current()) &;
+  void prepare(zview definition, sl loc = sl::current()) &
   {
     return prepare(definition.c_str(), loc);
   }
 
   /// Drop prepared statement.
-  void unprepare(std::string_view name, PQXX_LOC loc = PQXX_LOC::current());
+  void unprepare(std::string_view name, sl loc = sl::current());
 
   //@}
 
@@ -861,9 +854,8 @@ public:
    * Returns a reference to the escaped string, which is actually stored in
    * `buffer`.
    */
-  [[nodiscard]] std::string_view esc(
-    std::string_view text, std::span<char> buffer,
-    PQXX_LOC loc = PQXX_LOC::current())
+  [[nodiscard]] std::string_view
+  esc(std::string_view text, std::span<char> buffer, sl loc = sl::current())
   {
     auto const size{std::size(text)}, space{std::size(buffer)};
     auto const needed{2 * size + 1};
@@ -882,7 +874,7 @@ public:
    * whose value is zero ("nul bytes").
    */
   [[nodiscard]] std::string
-  esc(std::string_view text, PQXX_LOC loc = PQXX_LOC::current()) const;
+  esc(std::string_view text, sl loc = sl::current()) const;
 
   /// Escape binary string for use as SQL string literal on this connection.
   /** This is identical to `esc_raw(data)`. */
@@ -954,7 +946,7 @@ public:
    * supported.)
    */
   [[nodiscard]] bytes
-  unesc_bin(std::string_view text, PQXX_LOC loc = PQXX_LOC::current()) const
+  unesc_bin(std::string_view text, sl loc = sl::current()) const
   {
     bytes buf;
     buf.resize(pqxx::internal::size_unesc_bin(std::size(text)));
@@ -1015,8 +1007,7 @@ public:
    * Recognises nulls and represents them as SQL nulls.  They get no quotes.
    */
   template<typename T>
-  [[nodiscard]] inline std::string
-  quote(T const &t, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] inline std::string quote(T const &t, sl = sl::current()) const;
 
   // TODO: Make "into buffer" variant to eliminate a string allocation.
   /// Escape string for literal LIKE match.
@@ -1047,7 +1038,7 @@ public:
    */
   [[nodiscard]] std::string esc_like(
     std::string_view text, char escape_char = '\\',
-    PQXX_LOC loc = PQXX_LOC::current()) const;
+    sl loc = sl::current()) const;
   //@}
 
   /// Attempt to cancel the ongoing query, if any.
@@ -1055,7 +1046,7 @@ public:
    * in a pipeline, but it's up to you to ensure that you're not canceling the
    * wrong query.  This may involve locking.
    */
-  void cancel_query(PQXX_LOC = PQXX_LOC::current());
+  void cancel_query(sl = sl::current());
 
 #if defined(_WIN32) || __has_include(<fcntl.h>)
   /// Set socket to blocking (true) or nonblocking (false).
@@ -1063,7 +1054,7 @@ public:
    * @warning This function is available on most systems, but not necessarily
    * all.
    */
-  void set_blocking(bool block, PQXX_LOC = PQXX_LOC::current()) &;
+  void set_blocking(bool block, sl = sl::current()) &;
 #endif // defined(_WIN32) || __has_include(<fcntl.h>)
 
   /// Set session verbosity.
@@ -1126,7 +1117,7 @@ public:
    * Closing a connection is idempotent.  Closing a connection that's already
    * closed does nothing.
    */
-  void close(PQXX_LOC = PQXX_LOC::current());
+  void close(sl = sl::current());
 
   /// Seize control of a raw libpq connection.
   /** @warning Do not do this.  Please.  It's for very rare, very specific
@@ -1167,15 +1158,14 @@ public:
    */
   [[deprecated("To set session variables, use set_session_var.")]] void
   set_variable(
-    std::string_view var, std::string_view value,
-    PQXX_LOC loc = PQXX_LOC::current()) &;
+    std::string_view var, std::string_view value, sl loc = sl::current()) &;
 
   /// Read session variable, using SQL's `SHOW` command.
   /** @warning This executes an SQL query, so do not get or set variables while
    * a table stream or pipeline is active on the same connection.
    */
   [[deprecated("Use get_var instead.")]] std::string
-  get_variable(std::string_view, PQXX_LOC loc = PQXX_LOC::current());
+  get_variable(std::string_view, sl loc = sl::current());
 
 private:
   friend class connecting;
@@ -1183,8 +1173,7 @@ private:
   {
     connect_nonblocking
   };
-  connection(
-    connect_mode, zview connection_string, PQXX_LOC = PQXX_LOC::current());
+  connection(connect_mode, zview connection_string, sl = sl::current());
 
   /// For use by @ref seize_raw_connection.
   explicit connection(internal::pq::PGconn *raw_conn);
@@ -1195,27 +1184,27 @@ private:
    *
    * Throws an exception if polling indicates that the connection has failed.
    */
-  std::pair<bool, bool> poll_connect(PQXX_LOC);
+  std::pair<bool, bool> poll_connect(sl);
 
   // Initialise based on connection string.
-  void init(char const options[], PQXX_LOC);
+  void init(char const options[], sl);
   // Initialise based on parameter names and values.
-  void init(char const *params[], char const *values[], PQXX_LOC);
+  void init(char const *params[], char const *values[], sl);
   void set_up_notice_handlers();
-  void complete_init(PQXX_LOC);
+  void complete_init(sl);
 
   result make_result(
     internal::pq::PGresult *pgr, std::shared_ptr<std::string> const &query,
-    std::string_view desc, PQXX_LOC = PQXX_LOC::current());
+    std::string_view desc, sl = sl::current());
 
   result make_result(
     internal::pq::PGresult *pgr, std::shared_ptr<std::string> const &query,
-    PQXX_LOC loc = PQXX_LOC::current())
+    sl loc = sl::current())
   {
     return make_result(pgr, query, "", loc);
   }
 
-  void PQXX_PRIVATE set_up_state(PQXX_LOC);
+  void PQXX_PRIVATE set_up_state(sl);
 
   int PQXX_PRIVATE PQXX_PURE status() const noexcept;
 
@@ -1224,34 +1213,30 @@ private:
    *
    * Returns the number of bytes written, including the trailing zero.
    */
-  std::size_t esc_to_buf(std::string_view text, char *buf, PQXX_LOC loc) const;
+  std::size_t esc_to_buf(std::string_view text, char *buf, sl loc) const;
 
   friend class internal::gate::const_connection_largeobject;
   char const *PQXX_PURE err_msg() const noexcept;
 
   result exec_prepared(
     std::string_view statement, internal::c_params const &,
-    PQXX_LOC loc = PQXX_LOC::current());
+    sl loc = sl::current());
 
   /// Throw @ref usage_error if this connection is not in a movable state.
-  void check_movable(PQXX_LOC) const;
+  void check_movable(sl) const;
   /// Throw @ref usage_error if not in a state where it can be move-assigned.
-  void check_overwritable(PQXX_LOC) const;
+  void check_overwritable(sl) const;
 
   friend class internal::gate::connection_errorhandler;
   void PQXX_PRIVATE register_errorhandler(errorhandler *);
   void PQXX_PRIVATE unregister_errorhandler(errorhandler *) noexcept;
 
   friend class internal::gate::connection_transaction;
-  result exec(std::string_view query, PQXX_LOC loc)
-  {
-    return exec(query, "", loc);
-  }
-  result exec(std::string_view, std::string_view, PQXX_LOC);
+  result exec(std::string_view query, sl loc) { return exec(query, "", loc); }
+  result exec(std::string_view, std::string_view, sl);
   result PQXX_PRIVATE
-  exec(std::shared_ptr<std::string> const &, std::string_view, PQXX_LOC);
-  result PQXX_PRIVATE
-  exec(std::shared_ptr<std::string> const &query, PQXX_LOC loc)
+  exec(std::shared_ptr<std::string> const &, std::string_view, sl);
+  result PQXX_PRIVATE exec(std::shared_ptr<std::string> const &query, sl loc)
   {
     return exec(query, "", loc);
   }
@@ -1270,7 +1255,7 @@ private:
   read_copy_line();
 
   friend class internal::gate::connection_stream_to;
-  void PQXX_PRIVATE write_copy_line(std::string_view, PQXX_LOC);
+  void PQXX_PRIVATE write_copy_line(std::string_view, sl);
   void PQXX_PRIVATE end_copy_write();
 
   friend class internal::gate::connection_largeobject;
@@ -1278,7 +1263,7 @@ private:
 
   friend class internal::gate::connection_notification_receiver;
   void add_receiver(notification_receiver *);
-  void remove_receiver(notification_receiver *, PQXX_LOC loc) noexcept;
+  void remove_receiver(notification_receiver *, sl loc) noexcept;
 
   friend class internal::gate::connection_pipeline;
   void PQXX_PRIVATE start_exec(char const query[]);
@@ -1289,8 +1274,8 @@ private:
   friend class internal::gate::connection_dbtransaction;
   friend class internal::gate::connection_sql_cursor;
 
-  result exec_params(
-    std::string_view query, internal::c_params const &args, PQXX_LOC);
+  result
+  exec_params(std::string_view query, internal::c_params const &args, sl);
 
   /// Connection handle.
   internal::pq::PGconn *m_conn = nullptr;
@@ -1401,7 +1386,7 @@ public:
   }
 
   /// Progress towards completion (but don't block).
-  void process(PQXX_LOC loc = PQXX_LOC::current()) &;
+  void process(sl loc = sl::current()) &;
 
   /// Is our connection finished?
   [[nodiscard]] constexpr bool done() const & noexcept
@@ -1418,7 +1403,7 @@ public:
    * it on an rvalue instance of the class.  If what you have is not an rvalue,
    * turn it into one by wrapping it in `std::move()`.
    */
-  [[nodiscard]] connection produce(PQXX_LOC = PQXX_LOC::current()) &&;
+  [[nodiscard]] connection produce(sl = sl::current()) &&;
 
 private:
   connection m_conn;
@@ -1428,7 +1413,7 @@ private:
 
 
 template<typename T>
-inline std::string connection::quote(T const &t, PQXX_LOC loc) const
+inline std::string connection::quote(T const &t, sl loc) const
 {
   if (is_null(t))
   {
@@ -1473,7 +1458,7 @@ inline std::string connection::quote_columns(STRINGS const &columns) const
 
 
 template<internal::ZKey_ZValues MAPPING>
-inline connection::connection(MAPPING const &params, PQXX_LOC loc)
+inline connection::connection(MAPPING const &params, sl loc)
 {
   check_version();
 

--- a/include/pqxx/cursor.hxx
+++ b/include/pqxx/cursor.hxx
@@ -206,7 +206,7 @@ public:
    * Closing a cursor is idempotent.  Closing a cursor that's already closed
    * does nothing.
    */
-  void close() noexcept { m_cur.close(); }
+  void close(PQXX_LOC loc = PQXX_LOC::current()) noexcept { m_cur.close(loc); }
 
   /// Number of rows in cursor's result set
   /** @note This function is not const; it may need to scroll to find the size

--- a/include/pqxx/cursor.hxx
+++ b/include/pqxx/cursor.hxx
@@ -182,8 +182,9 @@ public:
    */
   stateless_cursor(
     transaction_base &tx, std::string_view query, std::string_view cname,
-    bool hold) :
-          m_cur{tx, query, cname, cursor_base::random_access, up, op, hold}
+    bool hold, PQXX_LOC loc = PQXX_LOC::current()) :
+          m_cur{tx, query, cname, cursor_base::random_access,
+                up, op,    hold,  loc}
   {}
 
   /// Adopt an existing scrolling SQL cursor.

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -21,6 +21,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "pqxx/types.hxx"
+
 
 namespace pqxx
 {
@@ -197,7 +199,9 @@ struct PQXX_LIBEXPORT deadlock_detected : transaction_rollback
 /// Internal error in libpqxx library
 struct PQXX_LIBEXPORT internal_error : std::logic_error
 {
-  explicit internal_error(std::string const &);
+  explicit internal_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
+
+  PQXX_LOC location;
 };
 
 

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -73,7 +73,7 @@ struct PQXX_LIBEXPORT failure : std::runtime_error
  */
 struct PQXX_LIBEXPORT broken_connection : failure
 {
-  broken_connection();
+  broken_connection(sl loc = sl::current());
   explicit broken_connection(std::string const &, sl = sl::current());
 };
 

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -45,10 +45,10 @@ namespace pqxx
 /// Run-time failure encountered by libpqxx, similar to std::runtime_error.
 struct PQXX_LIBEXPORT failure : std::runtime_error
 {
-  explicit failure(
-    std::string const &,
-    std::source_location = std::source_location::current());
-  std::source_location location;
+  explicit failure(std::string const &, PQXX_LOC = PQXX_LOC::current());
+
+  /// A `std::source_location` as a hint to the origin of the problem.
+  PQXX_LOC location;
 };
 
 
@@ -76,8 +76,7 @@ struct PQXX_LIBEXPORT broken_connection : failure
 {
   broken_connection();
   explicit broken_connection(
-    std::string const &,
-    std::source_location = std::source_location::current());
+    std::string const &, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -93,8 +92,7 @@ struct PQXX_LIBEXPORT broken_connection : failure
 struct PQXX_LIBEXPORT protocol_violation : broken_connection
 {
   explicit protocol_violation(
-    std::string const &,
-    std::source_location = std::source_location::current());
+    std::string const &, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -102,8 +100,7 @@ struct PQXX_LIBEXPORT protocol_violation : broken_connection
 struct PQXX_LIBEXPORT variable_set_to_null : failure
 {
   explicit variable_set_to_null(
-    std::string const &,
-    std::source_location = std::source_location::current());
+    std::string const &, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -121,8 +118,7 @@ class PQXX_LIBEXPORT sql_error : public failure
 public:
   explicit sql_error(
     std::string const &whatarg = "", std::string Q = "",
-    char const *sqlstate = nullptr,
-    std::source_location = std::source_location::current());
+    char const *sqlstate = nullptr, PQXX_LOC = PQXX_LOC::current());
   virtual ~sql_error() noexcept override;
 
   /// The query whose execution triggered the exception
@@ -142,9 +138,7 @@ public:
  */
 struct PQXX_LIBEXPORT in_doubt_error : failure
 {
-  explicit in_doubt_error(
-    std::string const &,
-    std::source_location = std::source_location::current());
+  explicit in_doubt_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -153,8 +147,7 @@ struct PQXX_LIBEXPORT transaction_rollback : sql_error
 {
   explicit transaction_rollback(
     std::string const &whatarg, std::string const &q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location = std::source_location::current());
+    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -171,8 +164,7 @@ struct PQXX_LIBEXPORT serialization_failure : transaction_rollback
 {
   explicit serialization_failure(
     std::string const &whatarg, std::string const &q,
-    char const sqlstate[] = nullptr,
-    std::source_location = std::source_location::current());
+    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -181,8 +173,7 @@ struct PQXX_LIBEXPORT statement_completion_unknown : transaction_rollback
 {
   explicit statement_completion_unknown(
     std::string const &whatarg, std::string const &q,
-    char const sqlstate[] = nullptr,
-    std::source_location = std::source_location::current());
+    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -191,8 +182,7 @@ struct PQXX_LIBEXPORT deadlock_detected : transaction_rollback
 {
   explicit deadlock_detected(
     std::string const &whatarg, std::string const &q,
-    char const sqlstate[] = nullptr,
-    std::source_location = std::source_location::current());
+    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -201,6 +191,7 @@ struct PQXX_LIBEXPORT internal_error : std::logic_error
 {
   explicit internal_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
 
+  /// A `std::source_location` as a hint to the origin of the problem.
   PQXX_LOC location;
 };
 
@@ -208,22 +199,20 @@ struct PQXX_LIBEXPORT internal_error : std::logic_error
 /// Error in usage of libpqxx library, similar to std::logic_error
 struct PQXX_LIBEXPORT usage_error : std::logic_error
 {
-  explicit usage_error(
-    std::string const &,
-    std::source_location = std::source_location::current());
+  explicit usage_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
 
-  std::source_location location;
+  /// A `std::source_location` as a hint to the origin of the problem.
+  PQXX_LOC location;
 };
 
 
 /// Invalid argument passed to libpqxx, similar to std::invalid_argument
 struct PQXX_LIBEXPORT argument_error : std::invalid_argument
 {
-  explicit argument_error(
-    std::string const &,
-    std::source_location = std::source_location::current());
+  explicit argument_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
 
-  std::source_location location;
+  /// A `std::source_location` as a hint to the origin of the problem.
+  PQXX_LOC location;
 };
 
 
@@ -231,10 +220,10 @@ struct PQXX_LIBEXPORT argument_error : std::invalid_argument
 struct PQXX_LIBEXPORT conversion_error : std::domain_error
 {
   explicit conversion_error(
-    std::string const &,
-    std::source_location = std::source_location::current());
+    std::string const &, PQXX_LOC = PQXX_LOC::current());
 
-  std::source_location location;
+  /// A `std::source_location` as a hint to the origin of the problem.
+  PQXX_LOC location;
 };
 
 
@@ -242,8 +231,7 @@ struct PQXX_LIBEXPORT conversion_error : std::domain_error
 struct PQXX_LIBEXPORT unexpected_null : conversion_error
 {
   explicit unexpected_null(
-    std::string const &,
-    std::source_location = std::source_location::current());
+    std::string const &, PQXX_LOC = PQXX_LOC::current());
 };
 
 
@@ -251,19 +239,17 @@ struct PQXX_LIBEXPORT unexpected_null : conversion_error
 struct PQXX_LIBEXPORT conversion_overrun : conversion_error
 {
   explicit conversion_overrun(
-    std::string const &,
-    std::source_location = std::source_location::current());
+    std::string const &, PQXX_LOC = PQXX_LOC::current());
 };
 
 
 /// Something is out of range, similar to std::out_of_range
 struct PQXX_LIBEXPORT range_error : std::out_of_range
 {
-  explicit range_error(
-    std::string const &,
-    std::source_location = std::source_location::current());
+  explicit range_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
 
-  std::source_location location;
+  /// A `std::source_location` as a hint to the origin of the problem.
+  PQXX_LOC location;
 };
 
 
@@ -271,8 +257,7 @@ struct PQXX_LIBEXPORT range_error : std::out_of_range
 struct PQXX_LIBEXPORT unexpected_rows : public range_error
 {
   explicit unexpected_rows(
-    std::string const &msg,
-    std::source_location loc = std::source_location::current()) :
+    std::string const &msg, PQXX_LOC loc = PQXX_LOC::current()) :
           range_error{msg, loc}
   {}
 };
@@ -283,8 +268,7 @@ struct PQXX_LIBEXPORT feature_not_supported : sql_error
 {
   explicit feature_not_supported(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -294,8 +278,7 @@ struct PQXX_LIBEXPORT data_exception : sql_error
 {
   explicit data_exception(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -304,8 +287,7 @@ struct PQXX_LIBEXPORT integrity_constraint_violation : sql_error
 {
   explicit integrity_constraint_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -314,8 +296,7 @@ struct PQXX_LIBEXPORT restrict_violation : integrity_constraint_violation
 {
   explicit restrict_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -324,8 +305,7 @@ struct PQXX_LIBEXPORT not_null_violation : integrity_constraint_violation
 {
   explicit not_null_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -334,8 +314,7 @@ struct PQXX_LIBEXPORT foreign_key_violation : integrity_constraint_violation
 {
   explicit foreign_key_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -344,8 +323,7 @@ struct PQXX_LIBEXPORT unique_violation : integrity_constraint_violation
 {
   explicit unique_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -354,8 +332,7 @@ struct PQXX_LIBEXPORT check_violation : integrity_constraint_violation
 {
   explicit check_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -364,8 +341,7 @@ struct PQXX_LIBEXPORT invalid_cursor_state : sql_error
 {
   explicit invalid_cursor_state(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -374,8 +350,7 @@ struct PQXX_LIBEXPORT invalid_sql_statement_name : sql_error
 {
   explicit invalid_sql_statement_name(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -384,8 +359,7 @@ struct PQXX_LIBEXPORT invalid_cursor_name : sql_error
 {
   explicit invalid_cursor_name(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -398,7 +372,7 @@ struct PQXX_LIBEXPORT syntax_error : sql_error
   explicit syntax_error(
     std::string const &err, std::string const &Q = "",
     char const sqlstate[] = nullptr, int pos = -1,
-    std::source_location loc = std::source_location::current()) :
+    PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}, error_position{pos}
   {}
 };
@@ -407,8 +381,7 @@ struct PQXX_LIBEXPORT undefined_column : syntax_error
 {
   explicit undefined_column(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           // TODO: Can we get the column?
           syntax_error{err, Q, sqlstate, -1, loc}
   {}
@@ -418,8 +391,7 @@ struct PQXX_LIBEXPORT undefined_function : syntax_error
 {
   explicit undefined_function(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           // TODO: Can we get the column?
           syntax_error{err, Q, sqlstate, -1, loc}
   {}
@@ -429,8 +401,7 @@ struct PQXX_LIBEXPORT undefined_table : syntax_error
 {
   explicit undefined_table(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           // TODO: Can we get the column?
           syntax_error{err, Q, sqlstate, -1, loc}
   {}
@@ -440,8 +411,7 @@ struct PQXX_LIBEXPORT insufficient_privilege : sql_error
 {
   explicit insufficient_privilege(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -451,8 +421,7 @@ struct PQXX_LIBEXPORT insufficient_resources : sql_error
 {
   explicit insufficient_resources(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -461,8 +430,7 @@ struct PQXX_LIBEXPORT disk_full : insufficient_resources
 {
   explicit disk_full(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           insufficient_resources{err, Q, sqlstate, loc}
   {}
 };
@@ -471,8 +439,7 @@ struct PQXX_LIBEXPORT out_of_memory : insufficient_resources
 {
   explicit out_of_memory(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           insufficient_resources{err, Q, sqlstate, loc}
   {}
 };
@@ -480,8 +447,7 @@ struct PQXX_LIBEXPORT out_of_memory : insufficient_resources
 struct PQXX_LIBEXPORT too_many_connections : broken_connection
 {
   explicit too_many_connections(
-    std::string const &err,
-    std::source_location loc = std::source_location::current()) :
+    std::string const &err, PQXX_LOC loc = PQXX_LOC::current()) :
           broken_connection{err, loc}
   {}
 };
@@ -493,8 +459,7 @@ struct PQXX_LIBEXPORT plpgsql_error : sql_error
 {
   explicit plpgsql_error(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -504,8 +469,7 @@ struct PQXX_LIBEXPORT plpgsql_raise : plpgsql_error
 {
   explicit plpgsql_raise(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           plpgsql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -514,8 +478,7 @@ struct PQXX_LIBEXPORT plpgsql_no_data_found : plpgsql_error
 {
   explicit plpgsql_no_data_found(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           plpgsql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -524,8 +487,7 @@ struct PQXX_LIBEXPORT plpgsql_too_many_rows : plpgsql_error
 {
   explicit plpgsql_too_many_rows(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr,
-    std::source_location loc = std::source_location::current()) :
+    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
           plpgsql_error{err, Q, sqlstate, loc}
   {}
 };

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -17,7 +17,6 @@
 #  error "Include libpqxx headers as <pqxx/header>, not <pqxx/header.hxx>."
 #endif
 
-#include <source_location>
 #include <stdexcept>
 #include <string>
 
@@ -45,10 +44,10 @@ namespace pqxx
 /// Run-time failure encountered by libpqxx, similar to std::runtime_error.
 struct PQXX_LIBEXPORT failure : std::runtime_error
 {
-  explicit failure(std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit failure(std::string const &, sl = sl::current());
 
   /// A `std::source_location` as a hint to the origin of the problem.
-  PQXX_LOC location;
+  sl location;
 };
 
 
@@ -75,8 +74,7 @@ struct PQXX_LIBEXPORT failure : std::runtime_error
 struct PQXX_LIBEXPORT broken_connection : failure
 {
   broken_connection();
-  explicit broken_connection(
-    std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit broken_connection(std::string const &, sl = sl::current());
 };
 
 
@@ -91,16 +89,14 @@ struct PQXX_LIBEXPORT broken_connection : failure
  */
 struct PQXX_LIBEXPORT protocol_violation : broken_connection
 {
-  explicit protocol_violation(
-    std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit protocol_violation(std::string const &, sl = sl::current());
 };
 
 
 /// The caller attempted to set a variable to null, which is not allowed.
 struct PQXX_LIBEXPORT variable_set_to_null : failure
 {
-  explicit variable_set_to_null(
-    std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit variable_set_to_null(std::string const &, sl = sl::current());
 };
 
 
@@ -118,7 +114,7 @@ class PQXX_LIBEXPORT sql_error : public failure
 public:
   explicit sql_error(
     std::string const &whatarg = "", std::string Q = "",
-    char const *sqlstate = nullptr, PQXX_LOC = PQXX_LOC::current());
+    char const *sqlstate = nullptr, sl = sl::current());
   virtual ~sql_error() noexcept override;
 
   /// The query whose execution triggered the exception
@@ -138,7 +134,7 @@ public:
  */
 struct PQXX_LIBEXPORT in_doubt_error : failure
 {
-  explicit in_doubt_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit in_doubt_error(std::string const &, sl = sl::current());
 };
 
 
@@ -147,7 +143,7 @@ struct PQXX_LIBEXPORT transaction_rollback : sql_error
 {
   explicit transaction_rollback(
     std::string const &whatarg, std::string const &q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
+    char const sqlstate[] = nullptr, sl = sl::current());
 };
 
 
@@ -164,7 +160,7 @@ struct PQXX_LIBEXPORT serialization_failure : transaction_rollback
 {
   explicit serialization_failure(
     std::string const &whatarg, std::string const &q,
-    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
+    char const sqlstate[] = nullptr, sl = sl::current());
 };
 
 
@@ -173,7 +169,7 @@ struct PQXX_LIBEXPORT statement_completion_unknown : transaction_rollback
 {
   explicit statement_completion_unknown(
     std::string const &whatarg, std::string const &q,
-    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
+    char const sqlstate[] = nullptr, sl = sl::current());
 };
 
 
@@ -182,82 +178,78 @@ struct PQXX_LIBEXPORT deadlock_detected : transaction_rollback
 {
   explicit deadlock_detected(
     std::string const &whatarg, std::string const &q,
-    char const sqlstate[] = nullptr, PQXX_LOC = PQXX_LOC::current());
+    char const sqlstate[] = nullptr, sl = sl::current());
 };
 
 
 /// Internal error in libpqxx library
 struct PQXX_LIBEXPORT internal_error : std::logic_error
 {
-  explicit internal_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit internal_error(std::string const &, sl = sl::current());
 
   /// A `std::source_location` as a hint to the origin of the problem.
-  PQXX_LOC location;
+  sl location;
 };
 
 
 /// Error in usage of libpqxx library, similar to std::logic_error
 struct PQXX_LIBEXPORT usage_error : std::logic_error
 {
-  explicit usage_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit usage_error(std::string const &, sl = sl::current());
 
   /// A `std::source_location` as a hint to the origin of the problem.
-  PQXX_LOC location;
+  sl location;
 };
 
 
 /// Invalid argument passed to libpqxx, similar to std::invalid_argument
 struct PQXX_LIBEXPORT argument_error : std::invalid_argument
 {
-  explicit argument_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit argument_error(std::string const &, sl = sl::current());
 
   /// A `std::source_location` as a hint to the origin of the problem.
-  PQXX_LOC location;
+  sl location;
 };
 
 
 /// Value conversion failed, e.g. when converting "Hello" to int.
 struct PQXX_LIBEXPORT conversion_error : std::domain_error
 {
-  explicit conversion_error(
-    std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit conversion_error(std::string const &, sl = sl::current());
 
   /// A `std::source_location` as a hint to the origin of the problem.
-  PQXX_LOC location;
+  sl location;
 };
 
 
 /// Could not convert null value: target type does not support null.
 struct PQXX_LIBEXPORT unexpected_null : conversion_error
 {
-  explicit unexpected_null(
-    std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit unexpected_null(std::string const &, sl = sl::current());
 };
 
 
 /// Could not convert value to string: not enough buffer space.
 struct PQXX_LIBEXPORT conversion_overrun : conversion_error
 {
-  explicit conversion_overrun(
-    std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit conversion_overrun(std::string const &, sl = sl::current());
 };
 
 
 /// Something is out of range, similar to std::out_of_range
 struct PQXX_LIBEXPORT range_error : std::out_of_range
 {
-  explicit range_error(std::string const &, PQXX_LOC = PQXX_LOC::current());
+  explicit range_error(std::string const &, sl = sl::current());
 
   /// A `std::source_location` as a hint to the origin of the problem.
-  PQXX_LOC location;
+  sl location;
 };
 
 
 /// Query returned an unexpected number of rows.
 struct PQXX_LIBEXPORT unexpected_rows : public range_error
 {
-  explicit unexpected_rows(
-    std::string const &msg, PQXX_LOC loc = PQXX_LOC::current()) :
+  explicit unexpected_rows(std::string const &msg, sl loc = sl::current()) :
           range_error{msg, loc}
   {}
 };
@@ -268,7 +260,7 @@ struct PQXX_LIBEXPORT feature_not_supported : sql_error
 {
   explicit feature_not_supported(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -278,7 +270,7 @@ struct PQXX_LIBEXPORT data_exception : sql_error
 {
   explicit data_exception(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -287,7 +279,7 @@ struct PQXX_LIBEXPORT integrity_constraint_violation : sql_error
 {
   explicit integrity_constraint_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -296,7 +288,7 @@ struct PQXX_LIBEXPORT restrict_violation : integrity_constraint_violation
 {
   explicit restrict_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -305,7 +297,7 @@ struct PQXX_LIBEXPORT not_null_violation : integrity_constraint_violation
 {
   explicit not_null_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -314,7 +306,7 @@ struct PQXX_LIBEXPORT foreign_key_violation : integrity_constraint_violation
 {
   explicit foreign_key_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -323,7 +315,7 @@ struct PQXX_LIBEXPORT unique_violation : integrity_constraint_violation
 {
   explicit unique_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -332,7 +324,7 @@ struct PQXX_LIBEXPORT check_violation : integrity_constraint_violation
 {
   explicit check_violation(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           integrity_constraint_violation{err, Q, sqlstate, loc}
   {}
 };
@@ -341,7 +333,7 @@ struct PQXX_LIBEXPORT invalid_cursor_state : sql_error
 {
   explicit invalid_cursor_state(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -350,7 +342,7 @@ struct PQXX_LIBEXPORT invalid_sql_statement_name : sql_error
 {
   explicit invalid_sql_statement_name(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -359,7 +351,7 @@ struct PQXX_LIBEXPORT invalid_cursor_name : sql_error
 {
   explicit invalid_cursor_name(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -371,8 +363,7 @@ struct PQXX_LIBEXPORT syntax_error : sql_error
 
   explicit syntax_error(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, int pos = -1,
-    PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, int pos = -1, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}, error_position{pos}
   {}
 };
@@ -381,7 +372,7 @@ struct PQXX_LIBEXPORT undefined_column : syntax_error
 {
   explicit undefined_column(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           // TODO: Can we get the column?
           syntax_error{err, Q, sqlstate, -1, loc}
   {}
@@ -391,7 +382,7 @@ struct PQXX_LIBEXPORT undefined_function : syntax_error
 {
   explicit undefined_function(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           // TODO: Can we get the column?
           syntax_error{err, Q, sqlstate, -1, loc}
   {}
@@ -401,7 +392,7 @@ struct PQXX_LIBEXPORT undefined_table : syntax_error
 {
   explicit undefined_table(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           // TODO: Can we get the column?
           syntax_error{err, Q, sqlstate, -1, loc}
   {}
@@ -411,7 +402,7 @@ struct PQXX_LIBEXPORT insufficient_privilege : sql_error
 {
   explicit insufficient_privilege(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -421,7 +412,7 @@ struct PQXX_LIBEXPORT insufficient_resources : sql_error
 {
   explicit insufficient_resources(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -430,7 +421,7 @@ struct PQXX_LIBEXPORT disk_full : insufficient_resources
 {
   explicit disk_full(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           insufficient_resources{err, Q, sqlstate, loc}
   {}
 };
@@ -439,7 +430,7 @@ struct PQXX_LIBEXPORT out_of_memory : insufficient_resources
 {
   explicit out_of_memory(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           insufficient_resources{err, Q, sqlstate, loc}
   {}
 };
@@ -447,7 +438,7 @@ struct PQXX_LIBEXPORT out_of_memory : insufficient_resources
 struct PQXX_LIBEXPORT too_many_connections : broken_connection
 {
   explicit too_many_connections(
-    std::string const &err, PQXX_LOC loc = PQXX_LOC::current()) :
+    std::string const &err, sl loc = sl::current()) :
           broken_connection{err, loc}
   {}
 };
@@ -459,7 +450,7 @@ struct PQXX_LIBEXPORT plpgsql_error : sql_error
 {
   explicit plpgsql_error(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           sql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -469,7 +460,7 @@ struct PQXX_LIBEXPORT plpgsql_raise : plpgsql_error
 {
   explicit plpgsql_raise(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           plpgsql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -478,7 +469,7 @@ struct PQXX_LIBEXPORT plpgsql_no_data_found : plpgsql_error
 {
   explicit plpgsql_no_data_found(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           plpgsql_error{err, Q, sqlstate, loc}
   {}
 };
@@ -487,7 +478,7 @@ struct PQXX_LIBEXPORT plpgsql_too_many_rows : plpgsql_error
 {
   explicit plpgsql_too_many_rows(
     std::string const &err, std::string const &Q = "",
-    char const sqlstate[] = nullptr, PQXX_LOC loc = PQXX_LOC::current()) :
+    char const sqlstate[] = nullptr, sl loc = sl::current()) :
           plpgsql_error{err, Q, sqlstate, loc}
   {}
 };

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -73,21 +73,19 @@ public:
    */
   //@{
   /// Column name.
-  [[nodiscard]] PQXX_PURE char const *
-    name(PQXX_LOC = PQXX_LOC::current()) const &;
+  [[nodiscard]] PQXX_PURE char const *name(sl = sl::current()) const &;
 
   /// Column type.
-  [[nodiscard]] oid PQXX_PURE type(PQXX_LOC loc = PQXX_LOC::current()) const;
+  [[nodiscard]] oid PQXX_PURE type(sl loc = sl::current()) const;
 
   /// What table did this column come from?
-  [[nodiscard]] PQXX_PURE oid table(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] PQXX_PURE oid table(sl = sl::current()) const;
 
   /// Return row number.  The first row is row 0, the second is row 1, etc.
   PQXX_PURE constexpr row_size_type num() const noexcept { return col(); }
 
   /// What column number in its originating table did this column come from?
-  [[nodiscard]] PQXX_PURE
-    row_size_type table_column(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] PQXX_PURE row_size_type table_column(sl = sl::current()) const;
   //@}
 
   /**
@@ -247,8 +245,7 @@ public:
 
   /// Read SQL array contents as a @ref pqxx::array.
   template<typename ELEMENT, auto... ARGS>
-  array<ELEMENT, ARGS...>
-  as_sql_array(PQXX_LOC loc = PQXX_LOC::current()) const
+  array<ELEMENT, ARGS...> as_sql_array(sl loc = sl::current()) const
   {
     using array_type = array<ELEMENT, ARGS...>;
 

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -245,7 +245,7 @@ public:
 
   /// Read SQL array contents as a @ref pqxx::array.
   template<typename ELEMENT, auto... ARGS>
-  array<ELEMENT, ARGS...> as_sql_array() const
+  array<ELEMENT, ARGS...> as_sql_array(PQXX_LOC loc = PQXX_LOC::current()) const
   {
     using array_type = array<ELEMENT, ARGS...>;
 
@@ -253,7 +253,7 @@ public:
     if (is_null())
       internal::throw_null_conversion(type_name<array_type>);
     else
-      return array_type{this->view(), this->m_home.m_encoding};
+      return array_type{this->view(), this->m_home.m_encoding, loc};
   }
 
   /// Parse the field as an SQL array.
@@ -268,7 +268,9 @@ public:
     "Instead, use as_sql_array() to convert to pqxx::array.")]]
   array_parser as_array() const & noexcept
   {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
     return array_parser{c_str(), m_home.m_encoding};
+#include "pqxx/internal/ignore-deprecated-post.hxx"
   }
   //@}
 

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -73,7 +73,8 @@ public:
    */
   //@{
   /// Column name.
-  [[nodiscard]] PQXX_PURE char const *name(PQXX_LOC = PQXX_LOC::current()) const &;
+  [[nodiscard]] PQXX_PURE char const *
+    name(PQXX_LOC = PQXX_LOC::current()) const &;
 
   /// Column type.
   [[nodiscard]] oid PQXX_PURE type(PQXX_LOC loc = PQXX_LOC::current()) const;
@@ -85,7 +86,8 @@ public:
   PQXX_PURE constexpr row_size_type num() const noexcept { return col(); }
 
   /// What column number in its originating table did this column come from?
-  [[nodiscard]] PQXX_PURE row_size_type table_column(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] PQXX_PURE
+    row_size_type table_column(PQXX_LOC = PQXX_LOC::current()) const;
   //@}
 
   /**
@@ -109,7 +111,9 @@ public:
    * been destroyed, the `string_view` will no longer point to valid memory.
    */
   [[nodiscard]] PQXX_PURE std::string_view view() const & noexcept
-  { return {c_str(), size()}; }
+  {
+    return {c_str(), size()};
+  }
 
   /// Read as plain C string.
   /** Since the field's data is stored internally in the form of a

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -73,19 +73,19 @@ public:
    */
   //@{
   /// Column name.
-  [[nodiscard]] PQXX_PURE char const *name() const &;
+  [[nodiscard]] PQXX_PURE char const *name(PQXX_LOC = PQXX_LOC::current()) const &;
 
   /// Column type.
-  [[nodiscard]] oid PQXX_PURE type() const;
+  [[nodiscard]] oid PQXX_PURE type(PQXX_LOC loc = PQXX_LOC::current()) const;
 
   /// What table did this column come from?
-  [[nodiscard]] PQXX_PURE oid table() const;
+  [[nodiscard]] PQXX_PURE oid table(PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Return row number.  The first row is row 0, the second is row 1, etc.
   PQXX_PURE constexpr row_size_type num() const noexcept { return col(); }
 
   /// What column number in its originating table did this column come from?
-  [[nodiscard]] PQXX_PURE row_size_type table_column() const;
+  [[nodiscard]] PQXX_PURE row_size_type table_column(PQXX_LOC = PQXX_LOC::current()) const;
   //@}
 
   /**
@@ -108,10 +108,8 @@ public:
    * @ref result exists.  Once all `result` objects referring to that data have
    * been destroyed, the `string_view` will no longer point to valid memory.
    */
-  [[nodiscard]] PQXX_PURE std::string_view view() const &
-  {
-    return std::string_view(c_str(), size());
-  }
+  [[nodiscard]] PQXX_PURE std::string_view view() const & noexcept
+  { return {c_str(), size()}; }
 
   /// Read as plain C string.
   /** Since the field's data is stored internally in the form of a
@@ -123,7 +121,7 @@ public:
    * convert the value to your desired type using `to()` or `as()`.  For
    * example: `f.as<pqx::bytes>()`.
    */
-  [[nodiscard]] PQXX_PURE char const *c_str() const &;
+  [[nodiscard]] PQXX_PURE char const *c_str() const & noexcept;
 
   /// Is this field's value null?
   [[nodiscard]] PQXX_PURE bool is_null() const noexcept;

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -245,7 +245,8 @@ public:
 
   /// Read SQL array contents as a @ref pqxx::array.
   template<typename ELEMENT, auto... ARGS>
-  array<ELEMENT, ARGS...> as_sql_array(PQXX_LOC loc = PQXX_LOC::current()) const
+  array<ELEMENT, ARGS...>
+  as_sql_array(PQXX_LOC loc = PQXX_LOC::current()) const
   {
     using array_type = array<ELEMENT, ARGS...>;
 

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -524,6 +524,8 @@ template<typename T> inline T from_string(field const &value)
 }
 
 
+// TODO: Can we make this generic across all "always-null" types?
+// TODO: Do the same for streams.
 /// Convert a field's value to `nullptr_t`.
 /** Yes, you read that right.  This conversion does nothing useful.  It always
  * returns `nullptr`.

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -18,7 +18,7 @@ namespace pqxx::internal
  */
 template<encoding_group ENC>
 inline std::size_t scan_double_quoted_string(
-  char const input[], std::size_t size, std::size_t pos, PQXX_LOC loc)
+  char const input[], std::size_t size, std::size_t pos, sl loc)
 {
   // TODO: find_char<'"', '\\'>().
   using scanner = glyph_scanner<ENC>;
@@ -82,7 +82,7 @@ inline std::size_t scan_double_quoted_string(
 /// Un-quote and un-escape a double-quoted SQL string.
 template<encoding_group ENC>
 inline std::string parse_double_quoted_string(
-  char const input[], std::size_t end, std::size_t pos, PQXX_LOC loc)
+  char const input[], std::size_t end, std::size_t pos, sl loc)
 {
   std::string output;
   // Maximum output size is same as the input size, minus the opening and
@@ -128,7 +128,7 @@ inline std::string parse_double_quoted_string(
  */
 template<pqxx::internal::encoding_group ENC, char... STOP>
 inline std::size_t scan_unquoted_string(
-  char const input[], std::size_t size, std::size_t pos, PQXX_LOC loc)
+  char const input[], std::size_t size, std::size_t pos, sl loc)
 {
   using scanner = glyph_scanner<ENC>;
   auto next{scanner::call(input, size, pos, loc)};
@@ -145,8 +145,8 @@ inline std::size_t scan_unquoted_string(
 
 /// Parse an unquoted array entry or cfield of a composite-type field.
 template<pqxx::internal::encoding_group ENC>
-inline std::string_view parse_unquoted_string(
-  char const input[], std::size_t end, std::size_t pos, PQXX_LOC)
+inline std::string_view
+parse_unquoted_string(char const input[], std::size_t end, std::size_t pos, sl)
 {
   return {&input[pos], end - pos};
 }
@@ -179,7 +179,7 @@ inline std::string_view parse_unquoted_string(
 template<encoding_group ENC, typename T>
 inline void parse_composite_field(
   std::size_t &index, std::string_view input, std::size_t &pos, T &field,
-  std::size_t last_field, PQXX_LOC loc)
+  std::size_t last_field, sl loc)
 {
   assert(index <= last_field);
   auto next{
@@ -275,13 +275,13 @@ inline void parse_composite_field(
 template<typename T>
 using composite_field_parser = void (*)(
   std::size_t &index, std::string_view input, std::size_t &pos, T &field,
-  std::size_t last_field, PQXX_LOC loc);
+  std::size_t last_field, sl loc);
 
 
 /// Look up implementation of parse_composite_field for ENC.
 template<typename T>
 composite_field_parser<T>
-specialize_parse_composite_field(encoding_group enc, PQXX_LOC loc)
+specialize_parse_composite_field(encoding_group enc, sl loc)
 {
   switch (enc)
   {

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -127,8 +127,8 @@ inline std::string parse_double_quoted_string(
  * comma or a closing parenthesis.
  */
 template<pqxx::internal::encoding_group ENC, char... STOP>
-inline std::size_t
-scan_unquoted_string(char const input[], std::size_t size, std::size_t pos, PQXX_LOC)
+inline std::size_t scan_unquoted_string(
+  char const input[], std::size_t size, std::size_t pos, PQXX_LOC)
 {
   using scanner = glyph_scanner<ENC>;
   auto next{scanner::call(input, size, pos)};
@@ -145,8 +145,8 @@ scan_unquoted_string(char const input[], std::size_t size, std::size_t pos, PQXX
 
 /// Parse an unquoted array entry or cfield of a composite-type field.
 template<pqxx::internal::encoding_group ENC>
-inline std::string_view
-parse_unquoted_string(char const input[], std::size_t end, std::size_t pos, PQXX_LOC)
+inline std::string_view parse_unquoted_string(
+  char const input[], std::size_t end, std::size_t pos, PQXX_LOC)
 {
   return {&input[pos], end - pos};
 }
@@ -185,7 +185,8 @@ inline void parse_composite_field(
   auto next{glyph_scanner<ENC>::call(std::data(input), std::size(input), pos)};
   PQXX_ASSUME(next > pos);
   if ((next - pos) != 1)
-    throw conversion_error{"Non-ASCII character in composite-type syntax.", loc};
+    throw conversion_error{
+      "Non-ASCII character in composite-type syntax.", loc};
 
   // Expect a field.
   switch (input[pos])
@@ -199,12 +200,13 @@ inline void parse_composite_field(
     else
       throw conversion_error{
         "Can't read composite field " + to_string(index) + ": C++ type " +
-        type_name<T> + " does not support nulls.", loc};
+          type_name<T> + " does not support nulls.",
+        loc};
     break;
 
   case '"': {
-    auto const stop{
-      scan_double_quoted_string<ENC>(std::data(input), std::size(input), pos, loc)};
+    auto const stop{scan_double_quoted_string<ENC>(
+      std::data(input), std::size(input), pos, loc)};
     PQXX_ASSUME(stop > pos);
     auto const text{
       parse_double_quoted_string<ENC>(std::data(input), stop, pos, loc)};
@@ -231,30 +233,35 @@ inline void parse_composite_field(
   if ((next - pos) != 1)
     throw conversion_error{
       "Unexpected non-ASCII character after composite field: " +
-      std::string{input}, loc};
+        std::string{input},
+      loc};
 
   if (index < last_field)
   {
     if (input[pos] != ',')
       throw conversion_error{
         "Found '" + std::string{input[pos]} +
-        "' in composite value where comma was expected: " + std::data(input), loc};
+          "' in composite value where comma was expected: " + std::data(input),
+        loc};
   }
   else
   {
     if (input[pos] == ',')
       throw conversion_error{
         "Composite value contained more fields than the expected " +
-        to_string(last_field) + ": " + std::data(input), loc};
+          to_string(last_field) + ": " + std::data(input),
+        loc};
     if (input[pos] != ')' and input[pos] != ']')
       throw conversion_error{
         "Composite value has unexpected characters where closing parenthesis "
         "was expected: " +
-        std::string{input}, loc};
+          std::string{input},
+        loc};
     if (next != std::size(input))
       throw conversion_error{
         "Composite value has unexpected text after closing parenthesis: " +
-        std::string{input}, loc};
+          std::string{input},
+        loc};
   }
 
   pos = next;
@@ -271,7 +278,8 @@ using composite_field_parser = void (*)(
 
 /// Look up implementation of parse_composite_field for ENC.
 template<typename T>
-composite_field_parser<T> specialize_parse_composite_field(encoding_group enc, PQXX_LOC loc)
+composite_field_parser<T>
+specialize_parse_composite_field(encoding_group enc, PQXX_LOC loc)
 {
   switch (enc)
   {
@@ -300,7 +308,8 @@ composite_field_parser<T> specialize_parse_composite_field(encoding_group enc, P
   case encoding_group::UTF8:
     return parse_composite_field<encoding_group::UTF8>;
   }
-  throw internal_error{concat("Unexpected encoding group code: ", enc, "."), loc};
+  throw internal_error{
+    concat("Unexpected encoding group code: ", enc, "."), loc};
 }
 
 

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -937,8 +937,7 @@ template<binary DATA> struct string_traits<DATA>
     return begin + budget;
   }
 
-  static DATA
-  from_string(std::string_view text, PQXX_LOC loc = PQXX_LOC::current())
+  static DATA from_string(std::string_view text, sl loc = sl::current())
   {
     auto const size{pqxx::internal::size_unesc_bin(std::size(text))};
     bytes buf;

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -937,13 +937,15 @@ template<binary DATA> struct string_traits<DATA>
     return begin + budget;
   }
 
-  static DATA from_string(std::string_view text)
+  static DATA
+  from_string(std::string_view text, PQXX_LOC loc = PQXX_LOC::current())
   {
     auto const size{pqxx::internal::size_unesc_bin(std::size(text))};
     bytes buf;
     buf.resize(size);
     // XXX: Use std::as_writable_bytes.
-    pqxx::internal::unesc_bin(text, reinterpret_cast<std::byte *>(buf.data()));
+    pqxx::internal::unesc_bin(
+      text, reinterpret_cast<std::byte *>(buf.data()), loc);
     return buf;
   }
 };

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -52,12 +52,12 @@ inline std::string state_buffer_overrun(HAVE have_bytes, NEED need_bytes)
 
 /// Throw exception for attempt to convert SQL NULL to given type.
 [[noreturn]] PQXX_LIBEXPORT PQXX_COLD void
-throw_null_conversion(std::string const &type);
+throw_null_conversion(std::string const &type, sl);
 
 
 /// Throw exception for attempt to convert SQL NULL to given type.
 [[noreturn]] PQXX_LIBEXPORT PQXX_COLD void
-throw_null_conversion(std::string_view type);
+throw_null_conversion(std::string_view type, sl);
 
 
 /// Deliberately nonfunctional conversion traits for `char` types.

--- a/include/pqxx/internal/encoding_group.hxx
+++ b/include/pqxx/internal/encoding_group.hxx
@@ -49,8 +49,8 @@ enum class encoding_group
  * There are multiple different glyph scanner implementations, for different
  * kinds of encodings.
  */
-using glyph_scanner_func =
-  std::size_t(char const buffer[], std::size_t buffer_len, std::size_t start);
+using glyph_scanner_func = std::size_t(
+  char const buffer[], std::size_t buffer_len, std::size_t start, PQXX_LOC);
 
 
 /// Function type: "find first occurrence of specific any of ASCII characters."
@@ -68,7 +68,7 @@ using glyph_scanner_func =
  * end of `haystack`.
  */
 using char_finder_func =
-  std::size_t(std::string_view haystack, std::size_t start);
+  std::size_t(std::string_view haystack, std::size_t start, PQXX_LOC);
 } // namespace pqxx::internal
 
 #endif

--- a/include/pqxx/internal/encoding_group.hxx
+++ b/include/pqxx/internal/encoding_group.hxx
@@ -50,7 +50,7 @@ enum class encoding_group
  * kinds of encodings.
  */
 using glyph_scanner_func = std::size_t(
-  char const buffer[], std::size_t buffer_len, std::size_t start, PQXX_LOC);
+  char const buffer[], std::size_t buffer_len, std::size_t start, sl);
 
 
 /// Function type: "find first occurrence of specific any of ASCII characters."
@@ -68,7 +68,7 @@ using glyph_scanner_func = std::size_t(
  * end of `haystack`.
  */
 using char_finder_func =
-  std::size_t(std::string_view haystack, std::size_t start, PQXX_LOC);
+  std::size_t(std::string_view haystack, std::size_t start, sl);
 } // namespace pqxx::internal
 
 #endif

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -29,7 +29,7 @@ namespace pqxx::internal
 PQXX_PURE char const *name_encoding(int encoding_id);
 
 /// Convert libpq encoding enum value to its libpqxx group.
-PQXX_LIBEXPORT encoding_group enc_group(int /* libpq encoding ID */);
+PQXX_LIBEXPORT encoding_group enc_group(int /* libpq encoding ID */, PQXX_LOC);
 
 
 /// Look up the glyph scanner function for a given encoding group.
@@ -37,7 +37,7 @@ PQXX_LIBEXPORT encoding_group enc_group(int /* libpq encoding ID */);
  * scanner function appropriate for the buffer's encoding.  Then, repeatedly
  * call the scanner function to find the glyphs.
  */
-PQXX_LIBEXPORT glyph_scanner_func *get_glyph_scanner(encoding_group);
+PQXX_LIBEXPORT glyph_scanner_func *get_glyph_scanner(encoding_group, PQXX_LOC);
 
 
 // TODO: Get rid of this one.  Use compile-time-specialised version instead.
@@ -50,14 +50,14 @@ PQXX_LIBEXPORT glyph_scanner_func *get_glyph_scanner(encoding_group);
  */
 template<char... NEEDLE>
 inline std::size_t find_char(
-  glyph_scanner_func *scanner, std::string_view haystack,
-  std::size_t here = 0u)
+  glyph_scanner_func *scanner, std::string_view haystack, std::size_t here,
+  PQXX_LOC loc)
 {
   auto const sz{std::size(haystack)};
   auto const data{std::data(haystack)};
   while (here < sz)
   {
-    auto next{scanner(data, sz, here)};
+    auto next{scanner(data, sz, here, loc)};
     PQXX_ASSUME(next > here);
     // (For some reason gcc had a problem with a right-fold here.  But clang
     // was fine.)
@@ -86,12 +86,12 @@ inline std::size_t find_char(
 template<typename CALLABLE>
 inline void for_glyphs(
   encoding_group enc, CALLABLE callback, char const buffer[],
-  std::size_t buffer_len, std::size_t start = 0)
+  std::size_t buffer_len, std::size_t start, PQXX_LOC loc)
 {
-  auto const scan{get_glyph_scanner(enc)};
+  auto const scan{get_glyph_scanner(enc, loc)};
   for (std::size_t here = start, next; here < buffer_len; here = next)
   {
-    next = scan(buffer, buffer_len, here);
+    next = scan(buffer, buffer_len, here, loc);
     PQXX_ASSUME(next > here);
     callback(buffer + here, buffer + next);
   }
@@ -110,7 +110,7 @@ get_byte(char const buffer[], std::size_t offset) noexcept
 
 [[noreturn]] PQXX_COLD void throw_for_encoding_error(
   char const *encoding_name, char const buffer[], std::size_t start,
-  std::size_t count)
+  std::size_t count, PQXX_LOC loc)
 {
   std::stringstream s;
   s << "Invalid byte sequence for encoding " << encoding_name << " at byte "
@@ -121,7 +121,7 @@ get_byte(char const buffer[], std::size_t offset) noexcept
     if (i + 1 < count)
       s << " ";
   }
-  throw pqxx::argument_error{s.str()};
+  throw pqxx::argument_error{s.str(), loc};
 }
 
 
@@ -143,8 +143,8 @@ template<encoding_group> struct glyph_scanner
 {
   // TODO: Convert to use string_view?
   /// Find the next glyph in `buffer` after position `start`.
-  PQXX_PURE static std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start);
+  PQXX_PURE static std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start, PQXX_LOC);
 };
 
 
@@ -159,7 +159,7 @@ namespace
  */
 template<encoding_group ENC, char... NEEDLE>
 PQXX_PURE inline std::size_t
-find_ascii_char(std::string_view haystack, std::size_t here)
+find_ascii_char(std::string_view haystack, std::size_t here, PQXX_LOC loc)
 {
   // We only know how to search for ASCII characters.  It's an optimisation
   // assumption in the code below.
@@ -171,7 +171,7 @@ find_ascii_char(std::string_view haystack, std::size_t here)
   {
     // Look up the next character boundary.  This can be quite costly, so we
     // desperately want the call inlined.
-    auto next{glyph_scanner<ENC>::call(data, sz, here)};
+    auto next{glyph_scanner<ENC>::call(data, sz, here, loc)};
     PQXX_ASSUME(next > here);
 
     // (For some reason gcc had a problem with a right-fold here.  But clang
@@ -208,7 +208,7 @@ find_ascii_char(std::string_view haystack, std::size_t here)
  */
 template<encoding_group ENC, char... NEEDLE>
 PQXX_PURE std::size_t
-find_s_ascii_char(std::string_view haystack, std::size_t here)
+find_s_ascii_char(std::string_view haystack, std::size_t here, PQXX_LOC loc)
 {
   // We only know how to search for ASCII characters.  It's an optimisation
   // assumption in the code below.
@@ -221,7 +221,7 @@ find_s_ascii_char(std::string_view haystack, std::size_t here)
   // ASCII-range byte.
   while ((... and (data[here] != NEEDLE)))
   {
-    auto const next = glyph_scanner<ENC>::call(data, sz, here);
+    auto const next = glyph_scanner<ENC>::call(data, sz, here, loc);
     PQXX_ASSUME(next > here);
     here = next;
   }
@@ -231,8 +231,9 @@ find_s_ascii_char(std::string_view haystack, std::size_t here)
 
 template<> struct glyph_scanner<encoding_group::MONOBYTE>
 {
-  static PQXX_PURE constexpr std::size_t
-  call(char const /* buffer */[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE constexpr std::size_t call(
+    char const /* buffer */[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC)
   {
     // TODO: Don't bother with npos.  Let the caller check.
     if (start >= buffer_len) [[unlikely]]
@@ -246,8 +247,9 @@ template<> struct glyph_scanner<encoding_group::MONOBYTE>
 // https://en.wikipedia.org/wiki/Big5#Organization
 template<> struct glyph_scanner<encoding_group::BIG5>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -258,13 +260,13 @@ template<> struct glyph_scanner<encoding_group::BIG5>
 
     if (not between_inc(byte1, 0x81, 0xfe) or (start + 2 > buffer_len))
       [[unlikely]]
-      throw_for_encoding_error("BIG5", buffer, start, 1);
+      throw_for_encoding_error("BIG5", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (
       not between_inc(byte2, 0x40, 0x7e) and
       not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-      throw_for_encoding_error("BIG5", buffer, start, 2);
+      throw_for_encoding_error("BIG5", buffer, start, 2, loc);
 
     return start + 2;
   }
@@ -285,8 +287,9 @@ depending on the specific extension:
 // https://en.wikipedia.org/wiki/GB_2312#EUC-CN
 template<> struct glyph_scanner<encoding_group::EUC_CN>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len)
       return std::string::npos;
@@ -297,11 +300,11 @@ template<> struct glyph_scanner<encoding_group::EUC_CN>
 
     if (not between_inc(byte1, 0xa1, 0xf7) or start + 2 > buffer_len)
       [[unlikely]]
-      throw_for_encoding_error("EUC_CN", buffer, start, 1);
+      throw_for_encoding_error("EUC_CN", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-      throw_for_encoding_error("EUC_CN", buffer, start, 2);
+      throw_for_encoding_error("EUC_CN", buffer, start, 2, loc);
 
     return start + 2;
   }
@@ -315,8 +318,9 @@ template<> struct glyph_scanner<encoding_group::EUC_CN>
 // http://x0213.org/codetable/index.en.html
 template<> struct glyph_scanner<encoding_group::EUC_JP>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len)
       return std::string::npos;
@@ -326,13 +330,13 @@ template<> struct glyph_scanner<encoding_group::EUC_JP>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("EUC_JP", buffer, start, 1);
+      throw_for_encoding_error("EUC_JP", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (byte1 == 0x8e)
     {
       if (not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-        throw_for_encoding_error("EUC_JP", buffer, start, 2);
+        throw_for_encoding_error("EUC_JP", buffer, start, 2, loc);
 
       return start + 2;
     }
@@ -340,7 +344,7 @@ template<> struct glyph_scanner<encoding_group::EUC_JP>
     if (between_inc(byte1, 0xa1, 0xfe))
     {
       if (not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-        throw_for_encoding_error("EUC_JP", buffer, start, 2);
+        throw_for_encoding_error("EUC_JP", buffer, start, 2, loc);
 
       return start + 2;
     }
@@ -351,12 +355,12 @@ template<> struct glyph_scanner<encoding_group::EUC_JP>
       if (
         not between_inc(byte2, 0xa1, 0xfe) or
         not between_inc(byte3, 0xa1, 0xfe)) [[unlikely]]
-        throw_for_encoding_error("EUC_JP", buffer, start, 3);
+        throw_for_encoding_error("EUC_JP", buffer, start, 3, loc);
 
       return start + 3;
     }
 
-    throw_for_encoding_error("EUC_JP", buffer, start, 1);
+    throw_for_encoding_error("EUC_JP", buffer, start, 1, loc);
   }
 };
 
@@ -364,8 +368,9 @@ template<> struct glyph_scanner<encoding_group::EUC_JP>
 // https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR
 template<> struct glyph_scanner<encoding_group::EUC_KR>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -376,11 +381,11 @@ template<> struct glyph_scanner<encoding_group::EUC_KR>
 
     if (not between_inc(byte1, 0xa1, 0xfe) or start + 2 > buffer_len)
       [[unlikely]]
-      throw_for_encoding_error("EUC_KR", buffer, start, 1);
+      throw_for_encoding_error("EUC_KR", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-      throw_for_encoding_error("EUC_KR", buffer, start, 1);
+      throw_for_encoding_error("EUC_KR", buffer, start, 1, loc);
 
     return start + 2;
   }
@@ -390,8 +395,9 @@ template<> struct glyph_scanner<encoding_group::EUC_KR>
 // https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-TW
 template<> struct glyph_scanner<encoding_group::EUC_TW>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -401,19 +407,19 @@ template<> struct glyph_scanner<encoding_group::EUC_TW>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("EUC_KR", buffer, start, 1);
+      throw_for_encoding_error("EUC_KR", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (between_inc(byte1, 0xa1, 0xfe))
     {
       if (not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-        throw_for_encoding_error("EUC_KR", buffer, start, 2);
+        throw_for_encoding_error("EUC_KR", buffer, start, 2, loc);
 
       return start + 2;
     }
 
     if (byte1 != 0x8e or start + 4 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("EUC_KR", buffer, start, 1);
+      throw_for_encoding_error("EUC_KR", buffer, start, 1, loc);
 
     if (
       between_inc(byte2, 0xa1, 0xb0) and
@@ -421,7 +427,7 @@ template<> struct glyph_scanner<encoding_group::EUC_TW>
       between_inc(get_byte(buffer, start + 3), 0xa1, 0xfe))
       return start + 4;
 
-    [[unlikely]] throw_for_encoding_error("EUC_KR", buffer, start, 4);
+    [[unlikely]] throw_for_encoding_error("EUC_KR", buffer, start, 4, loc);
   }
 };
 
@@ -429,8 +435,9 @@ template<> struct glyph_scanner<encoding_group::EUC_TW>
 // https://en.wikipedia.org/wiki/GB_18030#Mapping
 template<> struct glyph_scanner<encoding_group::GB18030>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -439,22 +446,25 @@ template<> struct glyph_scanner<encoding_group::GB18030>
     if (byte1 < 0x80)
       return start + 1;
     if (byte1 == 0x80)
-      throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
+      throw_for_encoding_error(
+        "GB18030", buffer, start, buffer_len - start, loc);
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
+      throw_for_encoding_error(
+        "GB18030", buffer, start, buffer_len - start, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (between_inc(byte2, 0x40, 0xfe))
     {
       if (byte2 == 0x7f) [[unlikely]]
-        throw_for_encoding_error("GB18030", buffer, start, 2);
+        throw_for_encoding_error("GB18030", buffer, start, 2, loc);
 
       return start + 2;
     }
 
     if (start + 4 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("GB18030", buffer, start, buffer_len - start);
+      throw_for_encoding_error(
+        "GB18030", buffer, start, buffer_len - start, loc);
 
     if (
       between_inc(byte2, 0x30, 0x39) and
@@ -462,7 +472,7 @@ template<> struct glyph_scanner<encoding_group::GB18030>
       between_inc(get_byte(buffer, start + 3), 0x30, 0x39))
       return start + 4;
 
-    [[unlikely]] throw_for_encoding_error("GB18030", buffer, start, 4);
+    [[unlikely]] throw_for_encoding_error("GB18030", buffer, start, 4, loc);
   }
 };
 
@@ -470,8 +480,9 @@ template<> struct glyph_scanner<encoding_group::GB18030>
 // https://en.wikipedia.org/wiki/GBK_(character_encoding)#Encoding
 template<> struct glyph_scanner<encoding_group::GBK>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -481,7 +492,7 @@ template<> struct glyph_scanner<encoding_group::GBK>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("GBK", buffer, start, 1);
+      throw_for_encoding_error("GBK", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (
@@ -499,7 +510,7 @@ template<> struct glyph_scanner<encoding_group::GBK>
        byte2 != 0x7f))
       return start + 2;
 
-    [[unlikely]] throw_for_encoding_error("GBK", buffer, start, 2);
+    [[unlikely]] throw_for_encoding_error("GBK", buffer, start, 2, loc);
   }
 };
 
@@ -515,8 +526,9 @@ CJKV Information Processing by Ken Lunde, pg. 269:
 */
 template<> struct glyph_scanner<encoding_group::JOHAB>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -526,7 +538,7 @@ template<> struct glyph_scanner<encoding_group::JOHAB>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("JOHAB", buffer, start, 1);
+      throw_for_encoding_error("JOHAB", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start)};
     if (
@@ -536,7 +548,7 @@ template<> struct glyph_scanner<encoding_group::JOHAB>
        (between_inc(byte2, 0x31, 0x7e) or between_inc(byte2, 0x91, 0xfe))))
       return start + 2;
 
-    [[unlikely]] throw_for_encoding_error("JOHAB", buffer, start, 2);
+    [[unlikely]] throw_for_encoding_error("JOHAB", buffer, start, 2, loc);
   }
 };
 
@@ -550,8 +562,9 @@ using PostgreSQL 9.2.23.  Use this at your own risk.
 */
 template<> struct glyph_scanner<encoding_group::MULE_INTERNAL>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -561,14 +574,14 @@ template<> struct glyph_scanner<encoding_group::MULE_INTERNAL>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("MULE_INTERNAL", buffer, start, 1);
+      throw_for_encoding_error("MULE_INTERNAL", buffer, start, 1, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (between_inc(byte1, 0x81, 0x8d) and byte2 >= 0xa0)
       return start + 2;
 
     if (start + 3 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("MULE_INTERNAL", buffer, start, 2);
+      throw_for_encoding_error("MULE_INTERNAL", buffer, start, 2, loc);
 
     if (
       ((byte1 == 0x9a and between_inc(byte2, 0xa0, 0xdf)) or
@@ -578,7 +591,7 @@ template<> struct glyph_scanner<encoding_group::MULE_INTERNAL>
       return start + 3;
 
     if (start + 4 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("MULE_INTERNAL", buffer, start, 3);
+      throw_for_encoding_error("MULE_INTERNAL", buffer, start, 3, loc);
 
     if (
       ((byte1 == 0x9c and between_inc(byte2, 0xf0, 0xf4)) or
@@ -587,7 +600,8 @@ template<> struct glyph_scanner<encoding_group::MULE_INTERNAL>
       get_byte(buffer, start + 4) >= 0xa0)
       return start + 4;
 
-    [[unlikely]] throw_for_encoding_error("MULE_INTERNAL", buffer, start, 4);
+    [[unlikely]] throw_for_encoding_error(
+      "MULE_INTERNAL", buffer, start, 4, loc);
   }
 };
 
@@ -603,8 +617,9 @@ template<> struct glyph_scanner<encoding_group::MULE_INTERNAL>
 // http://x0213.org/codetable/index.en.html
 template<> struct glyph_scanner<encoding_group::SJIS>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len)
       return std::string::npos;
@@ -616,19 +631,19 @@ template<> struct glyph_scanner<encoding_group::SJIS>
     if (
       not between_inc(byte1, 0x81, 0x9f) and
       not between_inc(byte1, 0xe0, 0xfc)) [[unlikely]]
-      throw_for_encoding_error("SJIS", buffer, start, 1);
+      throw_for_encoding_error("SJIS", buffer, start, 1, loc);
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("SJIS", buffer, start, buffer_len - start);
+      throw_for_encoding_error("SJIS", buffer, start, buffer_len - start, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (byte2 == 0x7f) [[unlikely]]
-      throw_for_encoding_error("SJIS", buffer, start, 2);
+      throw_for_encoding_error("SJIS", buffer, start, 2, loc);
 
     if (between_inc(byte2, 0x40, 0x9e) or between_inc(byte2, 0x9f, 0xfc))
       return start + 2;
 
-    [[unlikely]] throw_for_encoding_error("SJIS", buffer, start, 2);
+    [[unlikely]] throw_for_encoding_error("SJIS", buffer, start, 2, loc);
   }
 };
 
@@ -636,8 +651,9 @@ template<> struct glyph_scanner<encoding_group::SJIS>
 // https://en.wikipedia.org/wiki/Unified_Hangul_Code
 template<> struct glyph_scanner<encoding_group::UHC>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -647,7 +663,7 @@ template<> struct glyph_scanner<encoding_group::UHC>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("UHC", buffer, start, buffer_len - start);
+      throw_for_encoding_error("UHC", buffer, start, buffer_len - start, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (between_inc(byte1, 0x80, 0xc6))
@@ -657,18 +673,18 @@ template<> struct glyph_scanner<encoding_group::UHC>
         between_inc(byte2, 0x80, 0xfe))
         return start + 2;
 
-      [[unlikely]] throw_for_encoding_error("UHC", buffer, start, 2);
+      [[unlikely]] throw_for_encoding_error("UHC", buffer, start, 2, loc);
     }
 
     if (between_inc(byte1, 0xa1, 0xfe))
     {
       if (not between_inc(byte2, 0xa1, 0xfe)) [[unlikely]]
-        throw_for_encoding_error("UHC", buffer, start, 2);
+        throw_for_encoding_error("UHC", buffer, start, 2, loc);
 
       return start + 2;
     }
 
-    throw_for_encoding_error("UHC", buffer, start, 1);
+    throw_for_encoding_error("UHC", buffer, start, 1, loc);
   }
 };
 
@@ -676,8 +692,9 @@ template<> struct glyph_scanner<encoding_group::UHC>
 // https://en.wikipedia.org/wiki/UTF-8#Description
 template<> struct glyph_scanner<encoding_group::UTF8>
 {
-  static PQXX_PURE std::size_t
-  call(char const buffer[], std::size_t buffer_len, std::size_t start)
+  static PQXX_PURE std::size_t call(
+    char const buffer[], std::size_t buffer_len, std::size_t start,
+    PQXX_LOC loc)
   {
     if (start >= buffer_len) [[unlikely]]
       return std::string::npos;
@@ -687,19 +704,19 @@ template<> struct glyph_scanner<encoding_group::UTF8>
       return start + 1;
 
     if (start + 2 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
+      throw_for_encoding_error("UTF8", buffer, start, buffer_len - start, loc);
 
     auto const byte2{get_byte(buffer, start + 1)};
     if (between_inc(byte1, 0xc0, 0xdf))
     {
       if (not between_inc(byte2, 0x80, 0xbf)) [[unlikely]]
-        throw_for_encoding_error("UTF8", buffer, start, 2);
+        throw_for_encoding_error("UTF8", buffer, start, 2, loc);
 
       return start + 2;
     }
 
     if (start + 3 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
+      throw_for_encoding_error("UTF8", buffer, start, buffer_len - start, loc);
 
     auto const byte3{get_byte(buffer, start + 2)};
     if (between_inc(byte1, 0xe0, 0xef))
@@ -707,11 +724,11 @@ template<> struct glyph_scanner<encoding_group::UTF8>
       if (between_inc(byte2, 0x80, 0xbf) and between_inc(byte3, 0x80, 0xbf))
         return start + 3;
 
-      [[unlikely]] throw_for_encoding_error("UTF8", buffer, start, 3);
+      [[unlikely]] throw_for_encoding_error("UTF8", buffer, start, 3, loc);
     }
 
     if (start + 4 > buffer_len) [[unlikely]]
-      throw_for_encoding_error("UTF8", buffer, start, buffer_len - start);
+      throw_for_encoding_error("UTF8", buffer, start, buffer_len - start, loc);
 
     if (between_inc(byte1, 0xf0, 0xf7))
     {
@@ -720,10 +737,10 @@ template<> struct glyph_scanner<encoding_group::UTF8>
         between_inc(get_byte(buffer, start + 3), 0x80, 0xbf))
         return start + 4;
 
-      [[unlikely]] throw_for_encoding_error("UTF8", buffer, start, 4);
+      [[unlikely]] throw_for_encoding_error("UTF8", buffer, start, 4, loc);
     }
 
-    [[unlikely]] throw_for_encoding_error("UTF8", buffer, start, 1);
+    [[unlikely]] throw_for_encoding_error("UTF8", buffer, start, 1, loc);
   }
 };
 
@@ -774,7 +791,7 @@ map_ascii_search_group(encoding_group enc) noexcept
  */
 template<char... NEEDLE>
 PQXX_PURE constexpr inline char_finder_func *
-get_char_finder(encoding_group enc)
+get_char_finder(encoding_group enc, PQXX_LOC loc)
 {
   auto const as_if{map_ascii_search_group(enc)};
   switch (as_if)
@@ -796,8 +813,10 @@ get_char_finder(encoding_group enc)
     return pqxx::internal::find_ascii_char<encoding_group::UHC, NEEDLE...>;
 
   default:
-    throw pqxx::internal_error{concat(
-      "Unexpected encoding group: ", as_if, " (mapped from ", enc, ").")};
+    throw pqxx::internal_error{
+      concat(
+        "Unexpected encoding group: ", as_if, " (mapped from ", enc, ")."),
+      loc};
   }
 }
 
@@ -808,7 +827,7 @@ get_char_finder(encoding_group enc)
  */
 template<char... NEEDLE>
 PQXX_PURE constexpr inline char_finder_func *
-get_s_char_finder(encoding_group enc)
+get_s_char_finder(encoding_group enc, PQXX_LOC loc)
 {
   auto const as_if{map_ascii_search_group(enc)};
   switch (as_if)
@@ -831,8 +850,10 @@ get_s_char_finder(encoding_group enc)
     return pqxx::internal::find_s_ascii_char<encoding_group::UHC, NEEDLE...>;
 
   default:
-    throw pqxx::internal_error{concat(
-      "Unexpected encoding group: ", as_if, " (mapped from ", enc, ").")};
+    throw pqxx::internal_error{
+      concat(
+        "Unexpected encoding group: ", as_if, " (mapped from ", enc, ")."),
+      loc};
   }
 }
 } // namespace pqxx::internal

--- a/include/pqxx/internal/gates/connection-notification_receiver.hxx
+++ b/include/pqxx/internal/gates/connection-notification_receiver.hxx
@@ -21,7 +21,7 @@ class PQXX_PRIVATE connection_notification_receiver : callgate<connection>
   {
     home().add_receiver(receiver);
   }
-  void remove_receiver(notification_receiver *receiver, PQXX_LOC loc) noexcept
+  void remove_receiver(notification_receiver *receiver, sl loc) noexcept
   {
     home().remove_receiver(receiver, loc);
   }

--- a/include/pqxx/internal/gates/connection-notification_receiver.hxx
+++ b/include/pqxx/internal/gates/connection-notification_receiver.hxx
@@ -21,9 +21,9 @@ class PQXX_PRIVATE connection_notification_receiver : callgate<connection>
   {
     home().add_receiver(receiver);
   }
-  void remove_receiver(notification_receiver *receiver) noexcept
+  void remove_receiver(notification_receiver *receiver, PQXX_LOC loc) noexcept
   {
-    home().remove_receiver(receiver);
+    home().remove_receiver(receiver, loc);
   }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/connection-pipeline.hxx
+++ b/include/pqxx/internal/gates/connection-pipeline.hxx
@@ -13,12 +13,12 @@ class PQXX_PRIVATE connection_pipeline : callgate<connection>
 
   void start_exec(char const query[]) { home().start_exec(query); }
   pqxx::internal::pq::PGresult *get_result() { return home().get_result(); }
-  void cancel_query() { home().cancel_query(); }
+  void cancel_query(sl loc) { home().cancel_query(loc); }
 
   bool consume_input() noexcept { return home().consume_input(); }
   bool is_busy() const noexcept { return home().is_busy(); }
 
-  int encoding_id() { return home().encoding_id(); }
+  int encoding_id(sl loc) { return home().encoding_id(loc); }
 
   auto get_notice_waiters() const { return home().m_notice_waiters; }
 };

--- a/include/pqxx/internal/gates/connection-sql_cursor.hxx
+++ b/include/pqxx/internal/gates/connection-sql_cursor.hxx
@@ -14,6 +14,9 @@ class PQXX_PRIVATE connection_sql_cursor : callgate<connection>
 
   connection_sql_cursor(reference x) : super(x) {}
 
-  result exec(char const query[]) { return home().exec(query); }
+  result exec(char const query[], PQXX_LOC loc)
+  {
+    return home().exec(query, loc);
+  }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/connection-sql_cursor.hxx
+++ b/include/pqxx/internal/gates/connection-sql_cursor.hxx
@@ -14,9 +14,6 @@ class PQXX_PRIVATE connection_sql_cursor : callgate<connection>
 
   connection_sql_cursor(reference x) : super(x) {}
 
-  result exec(char const query[], PQXX_LOC loc)
-  {
-    return home().exec(query, loc);
-  }
+  result exec(char const query[], sl loc) { return home().exec(query, loc); }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/connection-stream_to.hxx
+++ b/include/pqxx/internal/gates/connection-stream_to.hxx
@@ -11,7 +11,10 @@ class PQXX_PRIVATE connection_stream_to : callgate<connection>
 
   connection_stream_to(reference x) : super(x) {}
 
-  void write_copy_line(std::string_view line) { home().write_copy_line(line); }
+  void write_copy_line(std::string_view line, PQXX_LOC loc)
+  {
+    home().write_copy_line(line, loc);
+  }
   void end_copy_write() { home().end_copy_write(); }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/connection-stream_to.hxx
+++ b/include/pqxx/internal/gates/connection-stream_to.hxx
@@ -11,7 +11,7 @@ class PQXX_PRIVATE connection_stream_to : callgate<connection>
 
   connection_stream_to(reference x) : super(x) {}
 
-  void write_copy_line(std::string_view line, PQXX_LOC loc)
+  void write_copy_line(std::string_view line, sl loc)
   {
     home().write_copy_line(line, loc);
   }

--- a/include/pqxx/internal/gates/connection-transaction.hxx
+++ b/include/pqxx/internal/gates/connection-transaction.hxx
@@ -14,12 +14,12 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
   connection_transaction(reference x) : super(x) {}
 
   template<typename STRING>
-  result exec(STRING query, std::string_view desc, PQXX_LOC loc)
+  result exec(STRING query, std::string_view desc, sl loc)
   {
     return home().exec(query, desc, loc);
   }
 
-  template<typename STRING> result exec(STRING query, PQXX_LOC loc)
+  template<typename STRING> result exec(STRING query, sl loc)
   {
     return home().exec(query, "", loc);
   }
@@ -34,20 +34,20 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
   }
 
   auto read_copy_line() { return home().read_copy_line(); }
-  void write_copy_line(std::string_view line, PQXX_LOC loc)
+  void write_copy_line(std::string_view line, sl loc)
   {
     home().write_copy_line(line, loc);
   }
   void end_copy_write() { home().end_copy_write(); }
 
   result exec_prepared(
-    std::string_view statement, internal::c_params const &args, PQXX_LOC loc)
+    std::string_view statement, internal::c_params const &args, sl loc)
   {
     return home().exec_prepared(statement, args, loc);
   }
 
-  result exec_params(
-    std::string_view query, internal::c_params const &args, PQXX_LOC loc)
+  result
+  exec_params(std::string_view query, internal::c_params const &args, sl loc)
   {
     return home().exec_params(query, args, loc);
   }

--- a/include/pqxx/internal/gates/connection-transaction.hxx
+++ b/include/pqxx/internal/gates/connection-transaction.hxx
@@ -40,10 +40,10 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
   }
   void end_copy_write() { home().end_copy_write(); }
 
-  result
-  exec_prepared(std::string_view statement, internal::c_params const &args)
+  result exec_prepared(
+    std::string_view statement, internal::c_params const &args, PQXX_LOC loc)
   {
-    return home().exec_prepared(statement, args);
+    return home().exec_prepared(statement, args, loc);
   }
 
   result exec_params(

--- a/include/pqxx/internal/gates/connection-transaction.hxx
+++ b/include/pqxx/internal/gates/connection-transaction.hxx
@@ -13,9 +13,15 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
 
   connection_transaction(reference x) : super(x) {}
 
-  template<typename STRING> result exec(STRING query, std::string_view desc)
+  template<typename STRING>
+  result exec(STRING query, std::string_view desc, PQXX_LOC loc)
   {
-    return home().exec(query, desc);
+    return home().exec(query, desc, loc);
+  }
+
+  template<typename STRING> result exec(STRING query, PQXX_LOC loc)
+  {
+    return home().exec(query, "", loc);
   }
 
   void register_transaction(transaction_base *t)
@@ -37,9 +43,10 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
     return home().exec_prepared(statement, args);
   }
 
-  result exec_params(std::string_view query, internal::c_params const &args)
+  result exec_params(
+    std::string_view query, internal::c_params const &args, PQXX_LOC loc)
   {
-    return home().exec_params(query, args);
+    return home().exec_params(query, args, loc);
   }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/connection-transaction.hxx
+++ b/include/pqxx/internal/gates/connection-transaction.hxx
@@ -34,7 +34,10 @@ class PQXX_PRIVATE connection_transaction : callgate<connection>
   }
 
   auto read_copy_line() { return home().read_copy_line(); }
-  void write_copy_line(std::string_view line) { home().write_copy_line(line); }
+  void write_copy_line(std::string_view line, PQXX_LOC loc)
+  {
+    home().write_copy_line(line, loc);
+  }
   void end_copy_write() { home().end_copy_write(); }
 
   result

--- a/include/pqxx/internal/gates/icursorstream-icursor_iterator.hxx
+++ b/include/pqxx/internal/gates/icursorstream-icursor_iterator.hxx
@@ -24,9 +24,9 @@ class PQXX_PRIVATE icursorstream_icursor_iterator : callgate<icursorstream>
     return home().forward(n);
   }
 
-  void service_iterators(icursorstream::difference_type p)
+  void service_iterators(icursorstream::difference_type p, PQXX_LOC loc)
   {
-    home().service_iterators(p);
+    home().service_iterators(p, loc);
   }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/icursorstream-icursor_iterator.hxx
+++ b/include/pqxx/internal/gates/icursorstream-icursor_iterator.hxx
@@ -24,7 +24,7 @@ class PQXX_PRIVATE icursorstream_icursor_iterator : callgate<icursorstream>
     return home().forward(n);
   }
 
-  void service_iterators(icursorstream::difference_type p, PQXX_LOC loc)
+  void service_iterators(icursorstream::difference_type p, sl loc)
   {
     home().service_iterators(p, loc);
   }

--- a/include/pqxx/internal/gates/result-creation.hxx
+++ b/include/pqxx/internal/gates/result-creation.hxx
@@ -18,14 +18,11 @@ class PQXX_PRIVATE result_creation : callgate<result const>
     return result(rhs, query, notice_waiters, enc);
   }
 
-  void check_status(std::string_view desc, PQXX_LOC loc) const
+  void check_status(std::string_view desc, sl loc) const
   {
     return home().check_status(desc, loc);
   }
 
-  void check_status(PQXX_LOC loc) const
-  {
-    return home().check_status("", loc);
-  }
+  void check_status(sl loc) const { return home().check_status("", loc); }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/gates/result-creation.hxx
+++ b/include/pqxx/internal/gates/result-creation.hxx
@@ -18,9 +18,14 @@ class PQXX_PRIVATE result_creation : callgate<result const>
     return result(rhs, query, notice_waiters, enc);
   }
 
-  void check_status(std::string_view desc = ""sv) const
+  void check_status(std::string_view desc, PQXX_LOC loc) const
   {
-    return home().check_status(desc);
+    return home().check_status(desc, loc);
+  }
+
+  void check_status(PQXX_LOC loc) const
+  {
+    return home().check_status("", loc);
   }
 };
 } // namespace pqxx::internal::gate

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -54,7 +54,10 @@ public:
   {
     return m_home == rhs.m_home;
   }
-  bool operator!=(result_iter const &rhs) const noexcet { return not(*this == rhs); }
+  bool operator!=(result_iter const &rhs) const noexcept
+  {
+    return not(*this == rhs);
+  }
 
   value_type const &operator*() const noexcept { return m_value; }
 

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -50,13 +50,13 @@ public:
   }
 
   /// Comparison only works for comparing to end().
-  bool operator==(result_iter const &rhs) const
+  bool operator==(result_iter const &rhs) const noexcept
   {
     return m_home == rhs.m_home;
   }
-  bool operator!=(result_iter const &rhs) const { return not(*this == rhs); }
+  bool operator!=(result_iter const &rhs) const noexcet { return not(*this == rhs); }
 
-  value_type const &operator*() const { return m_value; }
+  value_type const &operator*() const noexcept { return m_value; }
 
 private:
   void read() { (*m_home)[m_index].convert(m_value); }

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -62,7 +62,7 @@ public:
   value_type const &operator*() const noexcept { return m_value; }
 
 private:
-  void read(PQXX_LOC loc = PQXX_LOC::current())
+  void read(sl loc = sl::current())
   {
     (*m_home)[m_index].convert(m_value, loc);
   }
@@ -106,7 +106,7 @@ template<typename... TYPE> inline auto pqxx::result::iter() const
 
 
 template<typename CALLABLE>
-inline void pqxx::result::for_each(CALLABLE &&func, PQXX_LOC loc) const
+inline void pqxx::result::for_each(CALLABLE &&func, sl loc) const
 {
   using args_tuple = internal::args_t<decltype(func)>;
   constexpr auto sz{std::tuple_size_v<args_tuple>};

--- a/include/pqxx/internal/result_iter.hxx
+++ b/include/pqxx/internal/result_iter.hxx
@@ -31,21 +31,22 @@ public:
   /// Construct an "end" iterator.
   result_iter() = default;
 
-  explicit result_iter(result const &home) :
+  explicit result_iter(result const &home, sl loc = sl::current()) :
           m_home{&home}, m_size{std::size(home)}
   {
     if (not std::empty(home))
-      read();
+      read(loc);
   }
   result_iter(result_iter const &) = default;
 
   result_iter &operator++()
   {
+    sl loc{sl::current()};
     m_index++;
     if (m_index >= m_size)
       m_home = nullptr;
     else
-      read();
+      read(loc);
     return *this;
   }
 
@@ -62,10 +63,7 @@ public:
   value_type const &operator*() const noexcept { return m_value; }
 
 private:
-  void read(sl loc = sl::current())
-  {
-    (*m_home)[m_index].convert(m_value, loc);
-  }
+  void read(sl loc) { (*m_home)[m_index].convert(m_value, loc); }
 
   result const *m_home{nullptr};
   result::size_type m_index{0};

--- a/include/pqxx/internal/result_iterator.hxx
+++ b/include/pqxx/internal/result_iterator.hxx
@@ -65,10 +65,10 @@ public:
    */
   //@{
   /// Dereference the iterator.
-  [[nodiscard]] pointer operator->() const { return this; }
+  [[nodiscard]] pointer operator->() const noexcept { return this; }
 
   /// Dereference the iterator.
-  [[nodiscard]] reference operator*() const { return *this; }
+  [[nodiscard]] reference operator*() const noexcept { return *this; }
   //@}
 
   /**

--- a/include/pqxx/internal/result_iterator.hxx
+++ b/include/pqxx/internal/result_iterator.hxx
@@ -196,9 +196,9 @@ public:
   using reference = iterator_type::reference;
 
   /// Create an iterator, but in an unusable state.
-  const_reverse_result_iterator() = default;
+  const_reverse_result_iterator() noexcept = default;
   /// Copy an iterator.
-  const_reverse_result_iterator(const_reverse_result_iterator const &rhs) =
+  const_reverse_result_iterator(const_reverse_result_iterator const &rhs) noexcept =
     default;
   /// Copy a reverse iterator from a regular iterator.
   explicit const_reverse_result_iterator(const_result_iterator const &rhs) :

--- a/include/pqxx/internal/result_iterator.hxx
+++ b/include/pqxx/internal/result_iterator.hxx
@@ -198,8 +198,8 @@ public:
   /// Create an iterator, but in an unusable state.
   const_reverse_result_iterator() noexcept = default;
   /// Copy an iterator.
-  const_reverse_result_iterator(const_reverse_result_iterator const &rhs) noexcept =
-    default;
+  const_reverse_result_iterator(
+    const_reverse_result_iterator const &rhs) noexcept = default;
   /// Copy a reverse iterator from a regular iterator.
   explicit const_reverse_result_iterator(const_result_iterator const &rhs) :
           const_result_iterator{rhs}

--- a/include/pqxx/internal/sql_cursor.hxx
+++ b/include/pqxx/internal/sql_cursor.hxx
@@ -34,7 +34,8 @@ public:
   sql_cursor(
     transaction_base &t, std::string_view query, std::string_view cname,
     cursor_base::access_policy ap, cursor_base::update_policy up,
-    cursor_base::ownership_policy op, bool hold);
+    cursor_base::ownership_policy op, bool hold,
+    PQXX_LOC = PQXX_LOC::current());
 
   sql_cursor(
     transaction_base &t, std::string_view cname,

--- a/include/pqxx/internal/sql_cursor.hxx
+++ b/include/pqxx/internal/sql_cursor.hxx
@@ -47,19 +47,15 @@ public:
     close(loc);
   }
 
-  result fetch(
-    difference_type rows, difference_type &displacement,
-    PQXX_LOC = PQXX_LOC::current());
-  result fetch(difference_type rows, PQXX_LOC loc = PQXX_LOC::current())
+  result fetch(difference_type rows, difference_type &displacement, PQXX_LOC);
+  result fetch(difference_type rows, PQXX_LOC loc)
   {
     difference_type d = 0;
     return fetch(rows, d, loc);
   }
-  difference_type move(
-    difference_type rows, difference_type &displacement,
-    PQXX_LOC = PQXX_LOC::current());
   difference_type
-  move(difference_type rows, PQXX_LOC loc = PQXX_LOC::current())
+  move(difference_type rows, difference_type &displacement, PQXX_LOC);
+  difference_type move(difference_type rows, PQXX_LOC loc)
   {
     difference_type d = 0;
     return move(rows, d, loc);
@@ -117,9 +113,11 @@ private:
 };
 
 
-PQXX_LIBEXPORT result_size_type obtain_stateless_cursor_size(sql_cursor &);
+PQXX_LIBEXPORT result_size_type
+obtain_stateless_cursor_size(sql_cursor &, PQXX_LOC);
 PQXX_LIBEXPORT result stateless_cursor_retrieve(
   sql_cursor &, result::difference_type size,
-  result::difference_type begin_pos, result::difference_type end_pos);
+  result::difference_type begin_pos, result::difference_type end_pos,
+  PQXX_LOC);
 } // namespace pqxx::internal
 #endif

--- a/include/pqxx/internal/sql_cursor.hxx
+++ b/include/pqxx/internal/sql_cursor.hxx
@@ -34,8 +34,7 @@ public:
   sql_cursor(
     transaction_base &t, std::string_view query, std::string_view cname,
     cursor_base::access_policy ap, cursor_base::update_policy up,
-    cursor_base::ownership_policy op, bool hold,
-    PQXX_LOC = PQXX_LOC::current());
+    cursor_base::ownership_policy op, bool hold, sl = sl::current());
 
   sql_cursor(
     transaction_base &t, std::string_view cname,
@@ -44,19 +43,19 @@ public:
   ~sql_cursor() noexcept
   {
     // TODO: How can we pass std::source_location here?
-    auto loc{PQXX_LOC::current()};
+    auto loc{sl::current()};
     close(loc);
   }
 
-  result fetch(difference_type rows, difference_type &displacement, PQXX_LOC);
-  result fetch(difference_type rows, PQXX_LOC loc)
+  result fetch(difference_type rows, difference_type &displacement, sl);
+  result fetch(difference_type rows, sl loc)
   {
     difference_type d = 0;
     return fetch(rows, d, loc);
   }
   difference_type
-  move(difference_type rows, difference_type &displacement, PQXX_LOC);
-  difference_type move(difference_type rows, PQXX_LOC loc)
+  move(difference_type rows, difference_type &displacement, sl);
+  difference_type move(difference_type rows, sl loc)
   {
     difference_type d = 0;
     return move(rows, d, loc);
@@ -83,7 +82,7 @@ public:
   /// Return zero-row result for this cursor.
   result const &empty_result() const noexcept { return m_empty_result; }
 
-  void close(PQXX_LOC loc) noexcept;
+  void close(sl loc) noexcept;
 
 private:
   difference_type adjust(difference_type hoped, difference_type actual);
@@ -114,11 +113,9 @@ private:
 };
 
 
-PQXX_LIBEXPORT result_size_type
-obtain_stateless_cursor_size(sql_cursor &, PQXX_LOC);
+PQXX_LIBEXPORT result_size_type obtain_stateless_cursor_size(sql_cursor &, sl);
 PQXX_LIBEXPORT result stateless_cursor_retrieve(
   sql_cursor &, result::difference_type size,
-  result::difference_type begin_pos, result::difference_type end_pos,
-  PQXX_LOC);
+  result::difference_type begin_pos, result::difference_type end_pos, sl);
 } // namespace pqxx::internal
 #endif

--- a/include/pqxx/internal/sql_cursor.hxx
+++ b/include/pqxx/internal/sql_cursor.hxx
@@ -88,7 +88,7 @@ private:
   difference_type adjust(difference_type hoped, difference_type actual);
   static std::string stridestring(difference_type);
   /// Initialize cached empty result.  Call only at beginning or end!
-  void init_empty_result(transaction_base &);
+  void init_empty_result(transaction_base &, sl);
 
   /// Connection in which this cursor lives.
   connection &m_home;

--- a/include/pqxx/internal/sql_cursor.hxx
+++ b/include/pqxx/internal/sql_cursor.hxx
@@ -40,19 +40,29 @@ public:
     transaction_base &t, std::string_view cname,
     cursor_base::ownership_policy op);
 
-  ~sql_cursor() noexcept { close(); }
-
-  result fetch(difference_type rows, difference_type &displacement);
-  result fetch(difference_type rows)
+  ~sql_cursor() noexcept
   {
-    difference_type d = 0;
-    return fetch(rows, d);
+    // TODO: How can we pass std::source_location here?
+    auto loc{PQXX_LOC::current()};
+    close(loc);
   }
-  difference_type move(difference_type rows, difference_type &displacement);
-  difference_type move(difference_type rows)
+
+  result fetch(
+    difference_type rows, difference_type &displacement,
+    PQXX_LOC = PQXX_LOC::current());
+  result fetch(difference_type rows, PQXX_LOC loc = PQXX_LOC::current())
   {
     difference_type d = 0;
-    return move(rows, d);
+    return fetch(rows, d, loc);
+  }
+  difference_type move(
+    difference_type rows, difference_type &displacement,
+    PQXX_LOC = PQXX_LOC::current());
+  difference_type
+  move(difference_type rows, PQXX_LOC loc = PQXX_LOC::current())
+  {
+    difference_type d = 0;
+    return move(rows, d, loc);
   }
 
   /// Current position, or -1 for unknown
@@ -76,7 +86,7 @@ public:
   /// Return zero-row result for this cursor.
   result const &empty_result() const noexcept { return m_empty_result; }
 
-  void close() noexcept;
+  void close(PQXX_LOC loc) noexcept;
 
 private:
   difference_type adjust(difference_type hoped, difference_type actual);

--- a/include/pqxx/internal/stream_iterator.hxx
+++ b/include/pqxx/internal/stream_iterator.hxx
@@ -34,8 +34,7 @@ public:
   /// Construct an "end" iterator.
   stream_from_input_iterator() = default;
 
-  explicit stream_from_input_iterator(stream_t &home, PQXX_LOC loc) :
-          m_home(&home)
+  explicit stream_from_input_iterator(stream_t &home, sl loc) : m_home(&home)
   {
     advance(loc);
   }
@@ -43,7 +42,7 @@ public:
 
   stream_from_input_iterator &operator++()
   {
-    advance(PQXX_LOC::current());
+    advance(sl::current());
     return *this;
   }
 
@@ -61,7 +60,7 @@ public:
   }
 
 private:
-  void advance(PQXX_LOC loc)
+  void advance(sl loc)
   {
     if (m_home == nullptr)
       throw usage_error{"Moving stream_from iterator beyond end().", loc};
@@ -82,7 +81,7 @@ public:
   using stream_t = stream_from;
   using iterator = stream_from_input_iterator<TYPE...>;
   explicit stream_input_iteration(stream_t &home) : m_home{home} {}
-  iterator begin(PQXX_LOC loc = PQXX_LOC::current()) const
+  iterator begin(sl loc = sl::current()) const
   {
     return iterator{m_home, loc};
   }

--- a/include/pqxx/internal/stream_iterator.hxx
+++ b/include/pqxx/internal/stream_iterator.hxx
@@ -34,36 +34,37 @@ public:
   /// Construct an "end" iterator.
   stream_from_input_iterator() = default;
 
-  explicit stream_from_input_iterator(stream_t &home) : m_home(&home)
+  explicit stream_from_input_iterator(stream_t &home, PQXX_LOC loc) :
+          m_home(&home)
   {
-    advance();
+    advance(loc);
   }
   stream_from_input_iterator(stream_from_input_iterator const &) = default;
 
   stream_from_input_iterator &operator++()
   {
-    advance();
+    advance(PQXX_LOC::current());
     return *this;
   }
 
-  value_type const &operator*() const { return m_value; }
+  value_type const &operator*() const noexcept { return m_value; }
 
   /// Comparison only works for comparing to end().
-  bool operator==(stream_from_input_iterator const &rhs) const
+  bool operator==(stream_from_input_iterator const &rhs) const noexcept
   {
     return m_home == rhs.m_home;
   }
   /// Comparison only works for comparing to end().
-  bool operator!=(stream_from_input_iterator const &rhs) const
+  bool operator!=(stream_from_input_iterator const &rhs) const noexcept
   {
     return not(*this == rhs);
   }
 
 private:
-  void advance()
+  void advance(PQXX_LOC loc)
   {
     if (m_home == nullptr)
-      throw usage_error{"Moving stream_from iterator beyond end()."};
+      throw usage_error{"Moving stream_from iterator beyond end().", loc};
     if (not((*m_home) >> m_value))
       m_home = nullptr;
   }
@@ -81,7 +82,10 @@ public:
   using stream_t = stream_from;
   using iterator = stream_from_input_iterator<TYPE...>;
   explicit stream_input_iteration(stream_t &home) : m_home{home} {}
-  iterator begin() const { return iterator{m_home}; }
+  iterator begin(PQXX_LOC loc = PQXX_LOC::current()) const
+  {
+    return iterator{m_home, loc};
+  }
   iterator end() const { return {}; }
 
 private:

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -82,12 +82,10 @@ public:
   using line_handle = std::unique_ptr<char, void (*)(void const *)>;
 
   /// Execute `query` on `tx`, stream results.
-  inline stream_query(
-    transaction_base &tx, std::string_view query, sl loc = sl::current());
+  inline stream_query(transaction_base &tx, std::string_view query, sl loc);
   /// Execute `query` on `tx`, stream results.
   inline stream_query(
-    transaction_base &tx, std::string_view query, params const &,
-    sl loc = sl::current());
+    transaction_base &tx, std::string_view query, params const &, sl loc);
 
   stream_query(stream_query &&) = delete;
   stream_query &operator=(stream_query &&) = delete;
@@ -117,7 +115,7 @@ public:
   auto end() const & { return stream_query_end_iterator{}; }
 
   /// Parse and convert the latest line of data we received.
-  std::tuple<TYPE...> parse_line(zview line, sl loc = sl::current()) &
+  std::tuple<TYPE...> parse_line(zview line, sl loc) &
   {
     assert(not done());
 
@@ -292,7 +290,7 @@ private:
       if constexpr (nullity::has_null)
         return nullity::null();
       else
-        internal::throw_null_conversion(type_name<field_type>);
+        internal::throw_null_conversion(type_name<field_type>, loc);
     }
     else
     {

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -83,12 +83,11 @@ public:
 
   /// Execute `query` on `tx`, stream results.
   inline stream_query(
-    transaction_base &tx, std::string_view query,
-    PQXX_LOC loc = PQXX_LOC::current());
+    transaction_base &tx, std::string_view query, sl loc = sl::current());
   /// Execute `query` on `tx`, stream results.
   inline stream_query(
     transaction_base &tx, std::string_view query, params const &,
-    PQXX_LOC loc = PQXX_LOC::current());
+    sl loc = sl::current());
 
   stream_query(stream_query &&) = delete;
   stream_query &operator=(stream_query &&) = delete;
@@ -118,8 +117,7 @@ public:
   auto end() const & { return stream_query_end_iterator{}; }
 
   /// Parse and convert the latest line of data we received.
-  std::tuple<TYPE...>
-  parse_line(zview line, PQXX_LOC loc = PQXX_LOC::current()) &
+  std::tuple<TYPE...> parse_line(zview line, sl loc = sl::current()) &
   {
     assert(not done());
 
@@ -157,8 +155,7 @@ private:
   /** This is the only encoding-dependent code in the class.  All we need to
    * store after that is this function pointer.
    */
-  static inline char_finder_func *
-  get_finder(transaction_base const &tx, PQXX_LOC);
+  static inline char_finder_func *get_finder(transaction_base const &tx, sl);
 
   /// Scan and unescape a field into the row buffer.
   /** The row buffer is `m_row`.
@@ -176,7 +173,7 @@ private:
    * one greater than the size of the line, pointing at the terminating zero.
    */
   std::tuple<std::size_t, char *, zview>
-  read_field(zview line, std::size_t offset, char *write, PQXX_LOC loc)
+  read_field(zview line, std::size_t offset, char *write, sl loc)
   {
 #if !defined(NDEBUG)
     auto const line_size{std::size(line)};
@@ -271,8 +268,7 @@ private:
    * @return Field value converted to TARGET type.
    */
   template<typename TARGET>
-  TARGET
-  parse_field(zview line, std::size_t &offset, char *&write, PQXX_LOC loc)
+  TARGET parse_field(zview line, std::size_t &offset, char *&write, sl loc)
   {
     using field_type = std::remove_cvref_t<TARGET>;
     using nullity = nullness<field_type>;

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -82,10 +82,13 @@ public:
   using line_handle = std::unique_ptr<char, void (*)(void const *)>;
 
   /// Execute `query` on `tx`, stream results.
-  inline stream_query(transaction_base &tx, std::string_view query);
+  inline stream_query(
+    transaction_base &tx, std::string_view query,
+    PQXX_LOC loc = PQXX_LOC::current());
   /// Execute `query` on `tx`, stream results.
   inline stream_query(
-    transaction_base &tx, std::string_view query, params const &);
+    transaction_base &tx, std::string_view query, params const &,
+    PQXX_LOC loc = PQXX_LOC::current());
 
   stream_query(stream_query &&) = delete;
   stream_query &operator=(stream_query &&) = delete;

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -45,7 +45,7 @@ template<typename... TYPE>
 inline char_finder_func *
 stream_query<TYPE...>::get_finder(transaction_base const &tx, sl loc)
 {
-  auto const group{enc_group(tx.conn().encoding_id(), loc)};
+  auto const group{enc_group(tx.conn().encoding_id(loc), loc)};
   return get_s_char_finder<'\t', '\\'>(group, loc);
 }
 
@@ -93,7 +93,8 @@ public:
   /// Dereference.  There's no caching in here, so don't repeat calls.
   value_type operator*() const
   {
-    return m_home->parse_line(zview{m_line.get(), m_line_size});
+    sl loc{sl::current()};
+    return m_home->parse_line(zview{m_line.get(), m_line_size}, loc);
   }
 
   /// Are we at the end?

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -10,7 +10,7 @@ namespace pqxx::internal
 {
 template<typename... TYPE>
 inline stream_query<TYPE...>::stream_query(
-  transaction_base &tx, std::string_view query, PQXX_LOC loc) :
+  transaction_base &tx, std::string_view query, sl loc) :
         transaction_focus{tx, "stream_query"},
         m_char_finder{get_finder(tx, loc)}
 {
@@ -23,8 +23,7 @@ inline stream_query<TYPE...>::stream_query(
 
 template<typename... TYPE>
 inline stream_query<TYPE...>::stream_query(
-  transaction_base &tx, std::string_view query, params const &parms,
-  PQXX_LOC loc) :
+  transaction_base &tx, std::string_view query, params const &parms, sl loc) :
         transaction_focus{tx, "stream_query"},
         m_char_finder{get_finder(tx, loc)}
 {
@@ -44,7 +43,7 @@ inline stream_query<TYPE...>::stream_query(
 
 template<typename... TYPE>
 inline char_finder_func *
-stream_query<TYPE...>::get_finder(transaction_base const &tx, PQXX_LOC loc)
+stream_query<TYPE...>::get_finder(transaction_base const &tx, sl loc)
 {
   auto const group{enc_group(tx.conn().encoding_id(), loc)};
   return get_s_char_finder<'\t', '\\'>(group, loc);

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -11,7 +11,8 @@ namespace pqxx::internal
 template<typename... TYPE>
 inline stream_query<TYPE...>::stream_query(
   transaction_base &tx, std::string_view query, PQXX_LOC loc) :
-        transaction_focus{tx, "stream_query"}, m_char_finder{get_finder(tx)}
+        transaction_focus{tx, "stream_query"},
+        m_char_finder{get_finder(tx, loc)}
 {
   auto const r{tx.exec(internal::concat("COPY (", query, ") TO STDOUT"), loc)};
   r.expect_columns(sizeof...(TYPE), loc);
@@ -24,7 +25,8 @@ template<typename... TYPE>
 inline stream_query<TYPE...>::stream_query(
   transaction_base &tx, std::string_view query, params const &parms,
   PQXX_LOC loc) :
-        transaction_focus{tx, "stream_query"}, m_char_finder{get_finder(tx)}
+        transaction_focus{tx, "stream_query"},
+        m_char_finder{get_finder(tx, loc)}
 {
   auto const r{
     tx.exec(internal::concat("COPY (", query, ") TO STDOUT"), parms, loc)
@@ -42,10 +44,10 @@ inline stream_query<TYPE...>::stream_query(
 
 template<typename... TYPE>
 inline char_finder_func *
-stream_query<TYPE...>::get_finder(transaction_base const &tx)
+stream_query<TYPE...>::get_finder(transaction_base const &tx, PQXX_LOC loc)
 {
-  auto const group{enc_group(tx.conn().encoding_id())};
-  return get_s_char_finder<'\t', '\\'>(group);
+  auto const group{enc_group(tx.conn().encoding_id(), loc)};
+  return get_s_char_finder<'\t', '\\'>(group, loc);
 }
 
 

--- a/include/pqxx/internal/wait.hxx
+++ b/include/pqxx/internal/wait.hxx
@@ -1,6 +1,9 @@
 #if !defined(PQXX_WAIT_HXX)
 #  define PQXX_WAIT_HXX
 
+#  include "pqxx/types.hxx"
+
+
 namespace pqxx::internal
 {
 /// Wait.
@@ -13,6 +16,6 @@ void PQXX_LIBEXPORT wait_for(unsigned int microseconds);
 /// Wait for a socket to be ready for reading/writing, or timeout.
 PQXX_LIBEXPORT void wait_fd(
   int fd, bool for_read, bool for_write, unsigned seconds = 1,
-  unsigned microseconds = 0);
+  unsigned microseconds = 0, sl = sl::current());
 } // namespace pqxx::internal
 #endif

--- a/include/pqxx/nontransaction.hxx
+++ b/include/pqxx/nontransaction.hxx
@@ -72,7 +72,7 @@ public:
     register_transaction();
   }
 
-  virtual ~nontransaction() override { close(); }
+  virtual ~nontransaction() override { close(sl::current()); }
 
 private:
   virtual void do_commit(sl) override {}

--- a/include/pqxx/nontransaction.hxx
+++ b/include/pqxx/nontransaction.hxx
@@ -75,7 +75,7 @@ public:
   virtual ~nontransaction() override { close(); }
 
 private:
-  virtual void do_commit() override {}
+  virtual void do_commit(PQXX_LOC) override {}
 };
 } // namespace pqxx
 #endif

--- a/include/pqxx/nontransaction.hxx
+++ b/include/pqxx/nontransaction.hxx
@@ -75,7 +75,7 @@ public:
   virtual ~nontransaction() override { close(); }
 
 private:
-  virtual void do_commit(PQXX_LOC) override {}
+  virtual void do_commit(sl) override {}
 };
 } // namespace pqxx
 #endif

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -146,7 +146,7 @@ public:
    * As soon as we climb back out of that call tree, we're done with that
    * data.
    */
-  pqxx::internal::c_params make_c_params() const;
+  pqxx::internal::c_params make_c_params(sl loc) const;
 
 private:
   /// Recursively append a pack of params.
@@ -215,11 +215,13 @@ public:
   std::string get() const { return std::string(std::data(m_buf), m_len); }
 
   /// Move on to the next parameter.
-  void next() &
+  void next(sl loc = sl::current()) &
   {
     if (m_current >= max_params)
-      throw range_error{pqxx::internal::concat(
-        "Too many parameters in one statement: limit is ", max_params, ".")};
+      throw range_error{
+        pqxx::internal::concat(
+          "Too many parameters in one statement: limit is ", max_params, "."),
+        loc};
     PQXX_ASSUME(m_current > 0);
     ++m_current;
     if (m_current % 10 == 0)
@@ -231,7 +233,7 @@ public:
       char *const end{string_traits<COUNTER>::into_buf(
         data + 1, data + std::size(m_buf), m_current)};
       // (Subtract because we don't include the trailing zero.)
-      m_len = check_cast<COUNTER>(end - data, "placeholders counter") - 1;
+      m_len = check_cast<COUNTER>(end - data, "placeholders counter", loc) - 1;
     }
     else
     {

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -60,15 +60,14 @@ public:
 
 
   /// Start a pipeline.
-  explicit pipeline(transaction_base &t, PQXX_LOC loc = PQXX_LOC::current()) :
+  explicit pipeline(transaction_base &t, sl loc = sl::current()) :
           transaction_focus{t, s_classname}
   {
     init(loc);
   }
   /// Start a pipeline.  Assign it a name, for more helpful error messages.
   pipeline(
-    transaction_base &t, std::string_view tname,
-    PQXX_LOC loc = PQXX_LOC::current()) :
+    transaction_base &t, std::string_view tname, sl loc = sl::current()) :
           transaction_focus{t, s_classname, tname}
   {
     init(loc);
@@ -128,14 +127,14 @@ public:
    * than the one in which their queries were inserted, errors may "propagate"
    * to subsequent queries.
    */
-  result retrieve(query_id qid, PQXX_LOC loc = PQXX_LOC::current())
+  result retrieve(query_id qid, sl loc = sl::current())
   {
     return retrieve(m_queries.find(qid), loc).second;
   }
 
   /// Retrieve oldest unretrieved result (possibly wait for one).
   /** @return The query's identifier and its result set. */
-  std::pair<query_id, result> retrieve(PQXX_LOC = PQXX_LOC::current());
+  std::pair<query_id, result> retrieve(sl = sl::current());
 
   [[nodiscard]] bool empty() const noexcept { return std::empty(m_queries); }
 
@@ -171,7 +170,7 @@ private:
 
   using QueryMap = std::map<query_id, Query>;
 
-  void init(PQXX_LOC);
+  void init(sl);
   void attach();
   void detach();
 
@@ -205,11 +204,11 @@ private:
 
   /// Throw pqxx::internal_error.
   [[noreturn]] PQXX_PRIVATE void
-  internal_error(std::string const &err, PQXX_LOC = PQXX_LOC::current());
+  internal_error(std::string const &err, sl = sl::current());
 
   PQXX_PRIVATE bool obtain_result(bool expect_none = false);
 
-  PQXX_PRIVATE void obtain_dummy(PQXX_LOC = PQXX_LOC::current());
+  PQXX_PRIVATE void obtain_dummy(sl = sl::current());
   PQXX_PRIVATE void get_further_available_results();
   PQXX_PRIVATE void check_end_results();
 
@@ -219,7 +218,7 @@ private:
   /// Receive results, up to stop if possible.
   PQXX_PRIVATE void receive(pipeline::QueryMap::const_iterator stop);
   std::pair<pipeline::query_id, result>
-    retrieve(pipeline::QueryMap::iterator, PQXX_LOC);
+    retrieve(pipeline::QueryMap::iterator, sl);
 
   QueryMap m_queries;
   std::pair<QueryMap::iterator, QueryMap::iterator> m_issuedrange;

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -83,7 +83,7 @@ public:
    *
    * @return Identifier for this query, unique only within this pipeline.
    */
-  query_id insert(std::string_view) &;
+  query_id insert(std::string_view, sl = sl::current()) &;
 
   /// Wait for all ongoing or pending operations to complete, and detach.
   /** Detaches from the transaction when done.
@@ -92,7 +92,7 @@ public:
    * errors which may have occurred in their execution.  To be sure that your
    * statements succeeded, call @ref retrieve until the pipeline is empty.
    */
-  void complete();
+  void complete(sl = sl::current());
 
   /// Forget all ongoing or pending operations and retrieved results.
   /** Queries already sent to the backend may still be completed, depending
@@ -104,7 +104,7 @@ public:
    *
    * Detaches from the transaction when done.
    */
-  void flush();
+  void flush(sl = sl::current());
 
   /// Cancel ongoing query, if any.
   /** May cancel any or all of the queries that have been inserted at this
@@ -115,7 +115,7 @@ public:
    * Therefore, either use this function in a nontransaction, or abort the
    * transaction after calling it.
    */
-  void cancel();
+  void cancel(sl = sl::current());
 
   /// Is result for given query available?
   [[nodiscard]] bool is_finished(query_id) const;
@@ -155,7 +155,7 @@ public:
 
 
   /// Resume retained query emission.  Harmless when not needed.
-  void resume() &;
+  void resume(sl loc = sl::current()) &;
 
 private:
   struct PQXX_PRIVATE Query
@@ -192,7 +192,7 @@ private:
     return m_issuedrange.second != m_issuedrange.first;
   }
 
-  PQXX_PRIVATE void issue();
+  PQXX_PRIVATE void issue(sl);
 
   /// The given query failed; never issue anything beyond that.
   void set_error_at(query_id qid) noexcept
@@ -203,20 +203,19 @@ private:
   }
 
   /// Throw pqxx::internal_error.
-  [[noreturn]] PQXX_PRIVATE void
-  internal_error(std::string const &err, sl = sl::current());
+  [[noreturn]] PQXX_PRIVATE void internal_error(std::string const &err, sl);
 
-  PQXX_PRIVATE bool obtain_result(bool expect_none = false);
+  PQXX_PRIVATE bool obtain_result(bool expect_none, sl);
 
-  PQXX_PRIVATE void obtain_dummy(sl = sl::current());
-  PQXX_PRIVATE void get_further_available_results();
+  PQXX_PRIVATE void obtain_dummy(sl);
+  PQXX_PRIVATE void get_further_available_results(sl);
   PQXX_PRIVATE void check_end_results();
 
   /// Receive any results that happen to be available; it's not urgent.
-  PQXX_PRIVATE void receive_if_available();
+  PQXX_PRIVATE void receive_if_available(sl loc);
 
   /// Receive results, up to stop if possible.
-  PQXX_PRIVATE void receive(pipeline::QueryMap::const_iterator stop);
+  PQXX_PRIVATE void receive(pipeline::QueryMap::const_iterator stop, sl);
   std::pair<pipeline::query_id, result>
     retrieve(pipeline::QueryMap::iterator, sl);
 

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -116,8 +116,7 @@ public:
   void cancel();
 
   /// Is result for given query available?
-  [[nodiscard]] bool
-    is_finished(query_id, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] bool is_finished(query_id) const;
 
   /// Retrieve result for given query.
   /** If the query failed for whatever reason, this will throw an exception.

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -60,15 +60,18 @@ public:
 
 
   /// Start a pipeline.
-  explicit pipeline(transaction_base &t) : transaction_focus{t, s_classname}
+  explicit pipeline(transaction_base &t, PQXX_LOC loc = PQXX_LOC::current()) :
+          transaction_focus{t, s_classname}
   {
-    init();
+    init(loc);
   }
   /// Start a pipeline.  Assign it a name, for more helpful error messages.
-  pipeline(transaction_base &t, std::string_view tname) :
+  pipeline(
+    transaction_base &t, std::string_view tname,
+    PQXX_LOC loc = PQXX_LOC::current()) :
           transaction_focus{t, s_classname, tname}
   {
-    init();
+    init(loc);
   }
 
   /// Close the pipeline.
@@ -168,7 +171,7 @@ private:
 
   using QueryMap = std::map<query_id, Query>;
 
-  void init();
+  void init(PQXX_LOC);
   void attach();
   void detach();
 

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -202,11 +202,12 @@ private:
   }
 
   /// Throw pqxx::internal_error.
-  [[noreturn]] PQXX_PRIVATE void internal_error(std::string const &err);
+  [[noreturn]] PQXX_PRIVATE void
+  internal_error(std::string const &err, PQXX_LOC = PQXX_LOC::current());
 
   PQXX_PRIVATE bool obtain_result(bool expect_none = false);
 
-  PQXX_PRIVATE void obtain_dummy();
+  PQXX_PRIVATE void obtain_dummy(PQXX_LOC = PQXX_LOC::current());
   PQXX_PRIVATE void get_further_available_results();
   PQXX_PRIVATE void check_end_results();
 

--- a/include/pqxx/pipeline.hxx
+++ b/include/pqxx/pipeline.hxx
@@ -116,7 +116,8 @@ public:
   void cancel();
 
   /// Is result for given query available?
-  [[nodiscard]] bool is_finished(query_id) const;
+  [[nodiscard]] bool
+    is_finished(query_id, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Retrieve result for given query.
   /** If the query failed for whatever reason, this will throw an exception.
@@ -125,14 +126,14 @@ public:
    * than the one in which their queries were inserted, errors may "propagate"
    * to subsequent queries.
    */
-  result retrieve(query_id qid)
+  result retrieve(query_id qid, PQXX_LOC loc = PQXX_LOC::current())
   {
-    return retrieve(m_queries.find(qid)).second;
+    return retrieve(m_queries.find(qid), loc).second;
   }
 
   /// Retrieve oldest unretrieved result (possibly wait for one).
   /** @return The query's identifier and its result set. */
-  std::pair<query_id, result> retrieve();
+  std::pair<query_id, result> retrieve(PQXX_LOC = PQXX_LOC::current());
 
   [[nodiscard]] bool empty() const noexcept { return std::empty(m_queries); }
 
@@ -214,7 +215,8 @@ private:
 
   /// Receive results, up to stop if possible.
   PQXX_PRIVATE void receive(pipeline::QueryMap::const_iterator stop);
-  std::pair<pipeline::query_id, result> retrieve(pipeline::QueryMap::iterator);
+  std::pair<pipeline::query_id, result>
+    retrieve(pipeline::QueryMap::iterator, PQXX_LOC);
 
   QueryMap m_queries;
   std::pair<QueryMap::iterator, QueryMap::iterator> m_issuedrange;

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -48,7 +48,7 @@ private:
 public:
   inclusive_bound() = delete;
   constexpr explicit inclusive_bound(
-    TYPE const &value, PQXX_LOC loc = PQXX_LOC::current()) :
+    TYPE const &value, sl loc = sl::current()) :
           m_value{value}
   {
     if (is_null(value))
@@ -89,7 +89,7 @@ private:
 public:
   exclusive_bound() = delete;
   constexpr explicit exclusive_bound(
-    TYPE const &value, PQXX_LOC loc = PQXX_LOC::current()) :
+    TYPE const &value, sl loc = sl::current()) :
           m_value{value}
   {
     if (is_null(value))
@@ -253,8 +253,7 @@ public:
    * @ref exclusive_bound.
    */
   constexpr range(
-    range_bound<TYPE> lower, range_bound<TYPE> upper,
-    PQXX_LOC loc = PQXX_LOC::current()) :
+    range_bound<TYPE> lower, range_bound<TYPE> upper, sl loc = sl::current()) :
           m_lower{lower}, m_upper{upper}
   {
     if (
@@ -417,8 +416,7 @@ template<typename TYPE> struct string_traits<range<TYPE>>
   }
 
   static inline char *into_buf(
-    char *begin, char *end, range<TYPE> const &value,
-    PQXX_LOC loc = PQXX_LOC::current())
+    char *begin, char *end, range<TYPE> const &value, sl loc = sl::current())
   {
     if (value.empty())
     {
@@ -454,7 +452,7 @@ template<typename TYPE> struct string_traits<range<TYPE>>
   }
 
   [[nodiscard]] static inline range<TYPE>
-  from_string(std::string_view text, PQXX_LOC loc = PQXX_LOC::current())
+  from_string(std::string_view text, sl loc = sl::current())
   {
     if (std::size(text) < 3)
       throw pqxx::conversion_error{err_bad_input(text), loc};

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -444,10 +444,10 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     }
   }
 
-  [[nodiscard]] static inline range<TYPE> from_string(std::string_view text)
+  [[nodiscard]] static inline range<TYPE> from_string(std::string_view text, PQXX_LOC loc = PQXX_LOC::current())
   {
     if (std::size(text) < 3)
-      throw pqxx::conversion_error{err_bad_input(text)};
+      throw pqxx::conversion_error{err_bad_input(text), loc};
     bool left_inc{false};
     switch (text[0])
     {
@@ -463,11 +463,11 @@ template<typename TYPE> struct string_traits<range<TYPE>>
         (text[2] != 'p' and text[2] != 'P') or
         (text[3] != 't' and text[3] != 'T') or
         (text[4] != 'y' and text[4] != 'Y'))
-        throw pqxx::conversion_error{err_bad_input(text)};
+        throw pqxx::conversion_error{err_bad_input(text), loc};
       return {};
       break;
 
-    default: throw pqxx::conversion_error{err_bad_input(text)};
+    default: throw pqxx::conversion_error{err_bad_input(text), loc};
     }
 
     // The field parser uses this to track which field it's parsing, and
@@ -482,16 +482,16 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     // We reuse the same field parser we use for composite values and arrays.
     auto const field_parser{
       pqxx::internal::specialize_parse_composite_field<std::optional<TYPE>>(
-        pqxx::internal::encoding_group::UTF8)};
-    field_parser(index, text, pos, lower, last);
-    field_parser(index, text, pos, upper, last);
+        pqxx::internal::encoding_group::UTF8, loc)};
+    field_parser(index, text, pos, lower, last, loc);
+    field_parser(index, text, pos, upper, last, loc);
 
     // We need one more character: the closing parenthesis or bracket.
     if (pos != std::size(text))
-      throw pqxx::conversion_error{err_bad_input(text)};
+      throw pqxx::conversion_error{err_bad_input(text), loc};
     char const closing{text[pos - 1]};
     if (closing != ')' and closing != ']')
-      throw pqxx::conversion_error{err_bad_input(text)};
+      throw pqxx::conversion_error{err_bad_input(text), loc};
     bool const right_inc{closing == ']'};
 
     range_bound<TYPE> lower_bound{no_bound{}}, upper_bound{no_bound{}};

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -444,7 +444,8 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     }
   }
 
-  [[nodiscard]] static inline range<TYPE> from_string(std::string_view text, PQXX_LOC loc = PQXX_LOC::current())
+  [[nodiscard]] static inline range<TYPE>
+  from_string(std::string_view text, PQXX_LOC loc = PQXX_LOC::current())
   {
     if (std::size(text) < 3)
       throw pqxx::conversion_error{err_bad_input(text), loc};

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -206,10 +206,10 @@ public:
   [[nodiscard]] PQXX_PURE row_size_type columns() const noexcept;
 
   /// Number of given column (throws exception if it doesn't exist).
-  [[nodiscard]] row_size_type column_number(zview name) const;
+  [[nodiscard]] row_size_type column_number(zview name, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Name of column with this number (throws exception if it doesn't exist)
-  [[nodiscard]] char const *column_name(row_size_type number) const &;
+  [[nodiscard]] char const *column_name(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const &;
 
   /// Server-side storage size for field of column's type, in bytes.
   /** Returns the size of the server's internal representation of the column's
@@ -231,30 +231,30 @@ public:
   [[nodiscard]] int column_type_modifier(row_size_type number) const noexcept;
 
   /// Return column's type, as an OID from the system catalogue.
-  [[nodiscard]] oid column_type(row_size_type col_num) const;
+  [[nodiscard]] oid column_type(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Return column's type, as an OID from the system catalogue.
-  [[nodiscard]] oid column_type(zview col_name) const
+  [[nodiscard]] oid column_type(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    return column_type(column_number(col_name));
+    return column_type(column_number(col_name, loc));
   }
 
   /// What table did this column come from?
-  [[nodiscard]] oid column_table(row_size_type col_num) const;
+  [[nodiscard]] oid column_table(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// What table did this column come from?
-  [[nodiscard]] oid column_table(zview col_name) const
+  [[nodiscard]] oid column_table(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    return column_table(column_number(col_name));
+    return column_table(column_number(col_name, loc), loc);
   }
 
   /// What column in its table did this column come from?
-  [[nodiscard]] row_size_type table_column(row_size_type col_num) const;
+  [[nodiscard]] row_size_type table_column(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// What column in its table did this column come from?
-  [[nodiscard]] row_size_type table_column(zview col_name) const
+  [[nodiscard]] row_size_type table_column(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    return table_column(column_number(col_name));
+    return table_column(column_number(col_name), loc);
   }
   //@}
 

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -206,10 +206,12 @@ public:
   [[nodiscard]] PQXX_PURE row_size_type columns() const noexcept;
 
   /// Number of given column (throws exception if it doesn't exist).
-  [[nodiscard]] row_size_type column_number(zview name, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] row_size_type
+  column_number(zview name, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Name of column with this number (throws exception if it doesn't exist)
-  [[nodiscard]] char const *column_name(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const &;
+  [[nodiscard]] char const *
+  column_name(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const &;
 
   /// Server-side storage size for field of column's type, in bytes.
   /** Returns the size of the server's internal representation of the column's
@@ -231,28 +233,34 @@ public:
   [[nodiscard]] int column_type_modifier(row_size_type number) const noexcept;
 
   /// Return column's type, as an OID from the system catalogue.
-  [[nodiscard]] oid column_type(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] oid
+  column_type(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Return column's type, as an OID from the system catalogue.
-  [[nodiscard]] oid column_type(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
+  [[nodiscard]] oid
+  column_type(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     return column_type(column_number(col_name, loc));
   }
 
   /// What table did this column come from?
-  [[nodiscard]] oid column_table(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] oid
+  column_table(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// What table did this column come from?
-  [[nodiscard]] oid column_table(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
+  [[nodiscard]] oid
+  column_table(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     return column_table(column_number(col_name, loc), loc);
   }
 
   /// What column in its table did this column come from?
-  [[nodiscard]] row_size_type table_column(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] row_size_type
+  table_column(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// What column in its table did this column come from?
-  [[nodiscard]] row_size_type table_column(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
+  [[nodiscard]] row_size_type
+  table_column(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     return table_column(column_number(col_name), loc);
   }

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -179,10 +179,10 @@ public:
 #endif // PQXX_HAVE_MULTIDIM
 
   /// Index a row by number, but check that the row number is valid.
-  row at(size_type, PQXX_LOC = PQXX_LOC::current()) const;
+  row at(size_type, sl = sl::current()) const;
 
   /// Index a field by row number and column number.
-  field at(size_type, row_size_type, PQXX_LOC = PQXX_LOC::current()) const;
+  field at(size_type, row_size_type, sl = sl::current()) const;
 
   /// Let go of the result's data.
   /** Use this if you need to deallocate the result data earlier than you can
@@ -207,18 +207,18 @@ public:
 
   /// Number of given column (throws exception if it doesn't exist).
   [[nodiscard]] row_size_type
-  column_number(zview name, PQXX_LOC = PQXX_LOC::current()) const;
+  column_number(zview name, sl = sl::current()) const;
 
   /// Name of column with this number (throws exception if it doesn't exist)
   [[nodiscard]] char const *
-  column_name(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const &;
+  column_name(row_size_type number, sl = sl::current()) const &;
 
   /// Server-side storage size for field of column's type, in bytes.
   /** Returns the size of the server's internal representation of the column's
    * data type.  A negative value indicates the data type is variable-length.
    */
   [[nodiscard]] int
-  column_storage(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const;
+  column_storage(row_size_type number, sl = sl::current()) const;
 
   /// Type modifier of the column with this number.
   /** The meaning of modifier values is type-specific; they typically indicate
@@ -235,33 +235,31 @@ public:
 
   /// Return column's type, as an OID from the system catalogue.
   [[nodiscard]] oid
-  column_type(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
+  column_type(row_size_type col_num, sl = sl::current()) const;
 
   /// Return column's type, as an OID from the system catalogue.
-  [[nodiscard]] oid
-  column_type(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
+  [[nodiscard]] oid column_type(zview col_name, sl loc = sl::current()) const
   {
     return column_type(column_number(col_name, loc));
   }
 
   /// What table did this column come from?
   [[nodiscard]] oid
-  column_table(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
+  column_table(row_size_type col_num, sl = sl::current()) const;
 
   /// What table did this column come from?
-  [[nodiscard]] oid
-  column_table(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
+  [[nodiscard]] oid column_table(zview col_name, sl loc = sl::current()) const
   {
     return column_table(column_number(col_name, loc), loc);
   }
 
   /// What column in its table did this column come from?
   [[nodiscard]] row_size_type
-  table_column(row_size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
+  table_column(row_size_type col_num, sl = sl::current()) const;
 
   /// What column in its table did this column come from?
   [[nodiscard]] row_size_type
-  table_column(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
+  table_column(zview col_name, sl loc = sl::current()) const
   {
     return table_column(column_number(col_name), loc);
   }
@@ -274,8 +272,7 @@ public:
   /** @return Identifier of inserted row if exactly one row was inserted, or
    * @ref oid_none otherwise.
    */
-  [[nodiscard]] PQXX_PURE
-    oid inserted_oid(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] PQXX_PURE oid inserted_oid(sl = sl::current()) const;
 
   /// If command was `INSERT`, `UPDATE`, or `DELETE`: number of affected rows.
   /** @return Number of affected rows if last command was `INSERT`, `UPDATE`,
@@ -323,13 +320,13 @@ public:
    * defined; see @ref datatypes.
    */
   template<typename CALLABLE>
-  inline void for_each(CALLABLE &&func, PQXX_LOC = PQXX_LOC::current()) const;
+  inline void for_each(CALLABLE &&func, sl = sl::current()) const;
 
   /// Check that result contains exactly `n` rows.
   /** @return The result itself, for convenience.
    * @throw @ref unexpected_rows if the actual count is not equal to `n`.
    */
-  result expect_rows(size_type n, PQXX_LOC loc = PQXX_LOC::current()) const
+  result expect_rows(size_type n, sl loc = sl::current()) const
   {
     auto const sz{size()};
     if (sz != n)
@@ -354,7 +351,7 @@ public:
   /** @return @ref pqxx::row
    * @throw @ref unexpected_rows if the actual count is not equal to `n`.
    */
-  row one_row(PQXX_LOC = PQXX_LOC::current()) const;
+  row one_row(sl = sl::current()) const;
 
   /// Expect that result contains at moost one row, and return as optional.
   /** Returns an empty `std::optional` if the result is empty, or if it has
@@ -362,10 +359,10 @@ public:
    *
    * @throw @ref unexpected_rows is the row count is not 0 or 1.
    */
-  std::optional<row> opt_row(PQXX_LOC = PQXX_LOC::current()) const;
+  std::optional<row> opt_row(sl = sl::current()) const;
 
   /// Expect that result contains no rows.  Return result for convenience.
-  result no_rows(PQXX_LOC loc = PQXX_LOC::current()) const
+  result no_rows(sl loc = sl::current()) const
   {
     expect_rows(0, loc);
     return *this;
@@ -375,8 +372,7 @@ public:
   /** @return The result itself, for convenience.
    * @throw @ref usage_error otherwise.
    */
-  result
-  expect_columns(row_size_type cols, PQXX_LOC loc = PQXX_LOC::current()) const
+  result expect_columns(row_size_type cols, sl loc = sl::current()) const
   {
     auto const actual{columns()};
     if (actual != cols)
@@ -401,7 +397,7 @@ public:
   /** @return The one @ref pqxx::field in the result.
    * @throw @ref usage_error otherwise.
    */
-  field one_field(PQXX_LOC = PQXX_LOC::current()) const;
+  field one_field(sl = sl::current()) const;
 
 private:
   using data_pointer = std::shared_ptr<internal::pq::PGresult const>;
@@ -443,17 +439,17 @@ private:
     std::shared_ptr<pqxx::internal::notice_waiters> const &waiters,
     internal::encoding_group enc);
 
-  PQXX_PRIVATE void check_status(std::string_view desc, PQXX_LOC loc) const;
+  PQXX_PRIVATE void check_status(std::string_view desc, sl loc) const;
 
   friend class pqxx::internal::gate::result_connection;
   friend class pqxx::internal::gate::result_row;
   bool operator!() const noexcept { return m_data.get() == nullptr; }
   operator bool() const noexcept { return m_data.get() != nullptr; }
 
-  [[noreturn]] PQXX_PRIVATE PQXX_COLD void throw_sql_error(
-    std::string const &Err, std::string const &Query, PQXX_LOC) const;
+  [[noreturn]] PQXX_PRIVATE PQXX_COLD void
+  throw_sql_error(std::string const &Err, std::string const &Query, sl) const;
   PQXX_PRIVATE PQXX_PURE int errorposition() const;
-  PQXX_PRIVATE std::string status_error(PQXX_LOC) const;
+  PQXX_PRIVATE std::string status_error(sl) const;
 
   friend class pqxx::internal::gate::result_sql_cursor;
   PQXX_PURE char const *cmd_status() const noexcept;

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -217,7 +217,8 @@ public:
   /** Returns the size of the server's internal representation of the column's
    * data type.  A negative value indicates the data type is variable-length.
    */
-  [[nodiscard]] int column_storage(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] int
+  column_storage(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Type modifier of the column with this number.
   /** The meaning of modifier values is type-specific; they typically indicate
@@ -273,7 +274,8 @@ public:
   /** @return Identifier of inserted row if exactly one row was inserted, or
    * @ref oid_none otherwise.
    */
-  [[nodiscard]] PQXX_PURE oid inserted_oid(PQXX_LOC = PQXX_LOC::current()) const;
+  [[nodiscard]] PQXX_PURE
+    oid inserted_oid(PQXX_LOC = PQXX_LOC::current()) const;
 
   /// If command was `INSERT`, `UPDATE`, or `DELETE`: number of affected rows.
   /** @return Number of affected rows if last command was `INSERT`, `UPDATE`,
@@ -333,12 +335,16 @@ public:
     {
       // TODO: See whether result contains a generated statement.
       if (not m_query or m_query->empty())
-        throw unexpected_rows{pqxx::internal::concat(
-          "Expected ", n, " row(s) from query, got ", sz, "."), loc};
+        throw unexpected_rows{
+          pqxx::internal::concat(
+            "Expected ", n, " row(s) from query, got ", sz, "."),
+          loc};
       else
-        throw unexpected_rows{pqxx::internal::concat(
-          "Expected ", n, " row(s) from query '", *m_query, "', got ", sz,
-          "."), loc};
+        throw unexpected_rows{
+          pqxx::internal::concat(
+            "Expected ", n, " row(s) from query '", *m_query, "', got ", sz,
+            "."),
+          loc};
     }
     return *this;
   }
@@ -368,18 +374,24 @@ public:
   /** @return The result itself, for convenience.
    * @throw @ref usage_error otherwise.
    */
-  result expect_columns(row_size_type cols, PQXX_LOC loc = PQXX_LOC::current()) const
+  result
+  expect_columns(row_size_type cols, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     auto const actual{columns()};
     if (actual != cols)
     {
       // TODO: See whether result contains a generated statement.
       if (not m_query or m_query->empty())
-        throw usage_error{pqxx::internal::concat(
-          "Expected 1 column from query, got ", actual, "."), loc};
+        throw usage_error{
+          pqxx::internal::concat(
+            "Expected 1 column from query, got ", actual, "."),
+          loc};
       else
-        throw usage_error{pqxx::internal::concat(
-          "Expected 1 column from query '", *m_query, "', got ", actual, "."), loc};
+        throw usage_error{
+          pqxx::internal::concat(
+            "Expected 1 column from query '", *m_query, "', got ", actual,
+            "."),
+          loc};
     }
     return *this;
   }
@@ -437,8 +449,8 @@ private:
   bool operator!() const noexcept { return m_data.get() == nullptr; }
   operator bool() const noexcept { return m_data.get() != nullptr; }
 
-  [[noreturn]] PQXX_PRIVATE PQXX_COLD void
-  throw_sql_error(std::string const &Err, std::string const &Query, PQXX_LOC) const;
+  [[noreturn]] PQXX_PRIVATE PQXX_COLD void throw_sql_error(
+    std::string const &Err, std::string const &Query, PQXX_LOC) const;
   PQXX_PRIVATE PQXX_PURE int errorposition() const;
   PQXX_PRIVATE std::string status_error(PQXX_LOC) const;
 

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -142,10 +142,10 @@ public:
    */
   template<typename... TYPE> auto iter() const;
 
-  [[nodiscard]] const_reverse_iterator rbegin() const;
-  [[nodiscard]] const_reverse_iterator crbegin() const;
-  [[nodiscard]] const_reverse_iterator rend() const;
-  [[nodiscard]] const_reverse_iterator crend() const;
+  [[nodiscard]] const_reverse_iterator rbegin() const noexcept;
+  [[nodiscard]] const_reverse_iterator crbegin() const noexcept;
+  [[nodiscard]] const_reverse_iterator rend() const noexcept;
+  [[nodiscard]] const_reverse_iterator crend() const noexcept;
 
   [[nodiscard]] const_iterator begin() const noexcept;
   [[nodiscard]] const_iterator cbegin() const noexcept;
@@ -179,10 +179,10 @@ public:
 #endif // PQXX_HAVE_MULTIDIM
 
   /// Index a row by number, but check that the row number is valid.
-  row at(size_type) const;
+  row at(size_type, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Index a field by row number and column number.
-  field at(size_type, row_size_type) const;
+  field at(size_type, row_size_type, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Let go of the result's data.
   /** Use this if you need to deallocate the result data earlier than you can
@@ -217,7 +217,7 @@ public:
   /** Returns the size of the server's internal representation of the column's
    * data type.  A negative value indicates the data type is variable-length.
    */
-  [[nodiscard]] int column_storage(row_size_type number) const;
+  [[nodiscard]] int column_storage(row_size_type number, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Type modifier of the column with this number.
   /** The meaning of modifier values is type-specific; they typically indicate
@@ -273,7 +273,7 @@ public:
   /** @return Identifier of inserted row if exactly one row was inserted, or
    * @ref oid_none otherwise.
    */
-  [[nodiscard]] PQXX_PURE oid inserted_oid() const;
+  [[nodiscard]] PQXX_PURE oid inserted_oid(PQXX_LOC = PQXX_LOC::current()) const;
 
   /// If command was `INSERT`, `UPDATE`, or `DELETE`: number of affected rows.
   /** @return Number of affected rows if last command was `INSERT`, `UPDATE`,
@@ -326,7 +326,7 @@ public:
   /** @return The result itself, for convenience.
    * @throw @ref unexpected_rows if the actual count is not equal to `n`.
    */
-  result expect_rows(size_type n) const
+  result expect_rows(size_type n, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     auto const sz{size()};
     if (sz != n)
@@ -334,11 +334,11 @@ public:
       // TODO: See whether result contains a generated statement.
       if (not m_query or m_query->empty())
         throw unexpected_rows{pqxx::internal::concat(
-          "Expected ", n, " row(s) from query, got ", sz, ".")};
+          "Expected ", n, " row(s) from query, got ", sz, "."), loc};
       else
         throw unexpected_rows{pqxx::internal::concat(
           "Expected ", n, " row(s) from query '", *m_query, "', got ", sz,
-          ".")};
+          "."), loc};
     }
     return *this;
   }
@@ -347,7 +347,7 @@ public:
   /** @return @ref pqxx::row
    * @throw @ref unexpected_rows if the actual count is not equal to `n`.
    */
-  row one_row() const;
+  row one_row(PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Expect that result contains at moost one row, and return as optional.
   /** Returns an empty `std::optional` if the result is empty, or if it has
@@ -355,12 +355,12 @@ public:
    *
    * @throw @ref unexpected_rows is the row count is not 0 or 1.
    */
-  std::optional<row> opt_row() const;
+  std::optional<row> opt_row(PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Expect that result contains no rows.  Return result for convenience.
-  result no_rows() const
+  result no_rows(PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    expect_rows(0);
+    expect_rows(0, loc);
     return *this;
   }
 
@@ -368,7 +368,7 @@ public:
   /** @return The result itself, for convenience.
    * @throw @ref usage_error otherwise.
    */
-  result expect_columns(row_size_type cols) const
+  result expect_columns(row_size_type cols, PQXX_LOC loc = PQXX_LOC::current()) const
   {
     auto const actual{columns()};
     if (actual != cols)
@@ -376,10 +376,10 @@ public:
       // TODO: See whether result contains a generated statement.
       if (not m_query or m_query->empty())
         throw usage_error{pqxx::internal::concat(
-          "Expected 1 column from query, got ", actual, ".")};
+          "Expected 1 column from query, got ", actual, "."), loc};
       else
         throw usage_error{pqxx::internal::concat(
-          "Expected 1 column from query '", *m_query, "', got ", actual, ".")};
+          "Expected 1 column from query '", *m_query, "', got ", actual, "."), loc};
     }
     return *this;
   }
@@ -388,7 +388,7 @@ public:
   /** @return The one @ref pqxx::field in the result.
    * @throw @ref usage_error otherwise.
    */
-  field one_field() const;
+  field one_field(PQXX_LOC = PQXX_LOC::current()) const;
 
 private:
   using data_pointer = std::shared_ptr<internal::pq::PGresult const>;
@@ -430,7 +430,7 @@ private:
     std::shared_ptr<pqxx::internal::notice_waiters> const &waiters,
     internal::encoding_group enc);
 
-  PQXX_PRIVATE void check_status(std::string_view desc = ""sv) const;
+  PQXX_PRIVATE void check_status(std::string_view desc, PQXX_LOC loc) const;
 
   friend class pqxx::internal::gate::result_connection;
   friend class pqxx::internal::gate::result_row;
@@ -438,9 +438,9 @@ private:
   operator bool() const noexcept { return m_data.get() != nullptr; }
 
   [[noreturn]] PQXX_PRIVATE PQXX_COLD void
-  throw_sql_error(std::string const &Err, std::string const &Query) const;
+  throw_sql_error(std::string const &Err, std::string const &Query, PQXX_LOC) const;
   PQXX_PRIVATE PQXX_PURE int errorposition() const;
-  PQXX_PRIVATE std::string status_error() const;
+  PQXX_PRIVATE std::string status_error(PQXX_LOC) const;
 
   friend class pqxx::internal::gate::result_sql_cursor;
   PQXX_PURE char const *cmd_status() const noexcept;

--- a/include/pqxx/result.hxx
+++ b/include/pqxx/result.hxx
@@ -322,7 +322,8 @@ public:
    * The parameter types must have conversions from PostgreSQL's string format
    * defined; see @ref datatypes.
    */
-  template<typename CALLABLE> inline void for_each(CALLABLE &&func) const;
+  template<typename CALLABLE>
+  inline void for_each(CALLABLE &&func, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Check that result contains exactly `n` rows.
   /** @return The result itself, for convenience.

--- a/include/pqxx/robusttransaction.hxx
+++ b/include/pqxx/robusttransaction.hxx
@@ -30,8 +30,8 @@ public:
 
 protected:
   basic_robusttransaction(
-    connection &cx, zview begin_command, std::string_view tname);
-  basic_robusttransaction(connection &cx, zview begin_command);
+    connection &cx, zview begin_command, std::string_view tname, PQXX_LOC);
+  basic_robusttransaction(connection &cx, zview begin_command, PQXX_LOC);
 
 private:
   using IDType = unsigned long;
@@ -40,10 +40,10 @@ private:
   std::string m_xid;
   int m_backendpid = -1;
 
-  void init(zview begin_command);
+  void init(zview begin_command, PQXX_LOC);
 
   // @warning This function will become `final`.
-  virtual void do_commit() override;
+  virtual void do_commit(PQXX_LOC) override;
 };
 } // namespace pqxx::internal
 
@@ -105,9 +105,11 @@ public:
   /** Create robusttransaction of given name.
    * @param cx Connection inside which this robusttransaction should live.
    */
-  explicit robusttransaction(connection &cx) :
+  explicit robusttransaction(
+    connection &cx, PQXX_LOC loc = PQXX_LOC::current()) :
           internal::basic_robusttransaction{
-            cx, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>}
+            cx, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>,
+            loc}
   {}
 
   virtual ~robusttransaction() noexcept override { close(); }

--- a/include/pqxx/robusttransaction.hxx
+++ b/include/pqxx/robusttransaction.hxx
@@ -111,7 +111,7 @@ public:
             loc}
   {}
 
-  virtual ~robusttransaction() noexcept override { close(); }
+  virtual ~robusttransaction() noexcept override { close(sl::current()); }
 };
 
 /**

--- a/include/pqxx/robusttransaction.hxx
+++ b/include/pqxx/robusttransaction.hxx
@@ -30,8 +30,8 @@ public:
 
 protected:
   basic_robusttransaction(
-    connection &cx, zview begin_command, std::string_view tname, PQXX_LOC);
-  basic_robusttransaction(connection &cx, zview begin_command, PQXX_LOC);
+    connection &cx, zview begin_command, std::string_view tname, sl);
+  basic_robusttransaction(connection &cx, zview begin_command, sl);
 
 private:
   using IDType = unsigned long;
@@ -40,10 +40,10 @@ private:
   std::string m_xid;
   int m_backendpid = -1;
 
-  void init(zview begin_command, PQXX_LOC);
+  void init(zview begin_command, sl);
 
   // @warning This function will become `final`.
-  virtual void do_commit(PQXX_LOC) override;
+  virtual void do_commit(sl) override;
 };
 } // namespace pqxx::internal
 
@@ -105,8 +105,7 @@ public:
   /** Create robusttransaction of given name.
    * @param cx Connection inside which this robusttransaction should live.
    */
-  explicit robusttransaction(
-    connection &cx, PQXX_LOC loc = PQXX_LOC::current()) :
+  explicit robusttransaction(connection &cx, sl loc = sl::current()) :
           internal::basic_robusttransaction{
             cx, pqxx::internal::begin_cmd<ISOLATION, write_policy::read_write>,
             loc}

--- a/include/pqxx/row.hxx
+++ b/include/pqxx/row.hxx
@@ -97,11 +97,13 @@ public:
    */
   [[nodiscard]] reference operator[](zview col_name) const;
 
-  reference at(size_type) const;
+  /// Address a field by number, but check that the number is in range.
+  reference at(size_type, PQXX_LOC = PQXX_LOC::current()) const;
+
   /** Address field by name.
    * @warning This is much slower than indexing by number, or iterating.
    */
-  reference at(zview col_name) const;
+  reference at(zview col_name, PQXX_LOC = PQXX_LOC::current()) const;
 
   [[nodiscard]] constexpr size_type size() const noexcept { return m_end; }
 
@@ -116,24 +118,29 @@ public:
    */
   //@{
   /// Number of given column (throws exception if it doesn't exist).
-  [[nodiscard]] size_type column_number(zview col_name) const;
+  [[nodiscard]] size_type
+  column_number(zview col_name, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Return a column's type.
-  [[nodiscard]] oid column_type(size_type) const;
+  [[nodiscard]] oid
+    column_type(size_type, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// Return a column's type.
-  [[nodiscard]] oid column_type(zview col_name) const
+  [[nodiscard]] oid
+  column_type(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    return column_type(column_number(col_name));
+    return column_type(column_number(col_name, loc), loc);
   }
 
   /// What table did this column come from?
-  [[nodiscard]] oid column_table(size_type col_num) const;
+  [[nodiscard]] oid
+  column_table(size_type col_num, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// What table did this column come from?
-  [[nodiscard]] oid column_table(zview col_name) const
+  [[nodiscard]] oid
+  column_table(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    return column_table(column_number(col_name));
+    return column_table(column_number(col_name, loc), loc);
   }
 
   /// What column number in its table did this result column come from?
@@ -144,12 +151,14 @@ public:
    * @param col_num a zero-based column number in this result set
    * @return a zero-based column number in originating table
    */
-  [[nodiscard]] size_type table_column(size_type) const;
+  [[nodiscard]] size_type
+    table_column(size_type, PQXX_LOC = PQXX_LOC::current()) const;
 
   /// What column number in its table did this result column come from?
-  [[nodiscard]] size_type table_column(zview col_name) const
+  [[nodiscard]] size_type
+  table_column(zview col_name, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    return table_column(column_number(col_name));
+    return table_column(column_number(col_name, loc), loc);
   }
   //@}
 
@@ -167,10 +176,11 @@ public:
    * @throw usage_error If the number of columns in the `row` does not match
    * the number of fields in `t`.
    */
-  template<typename Tuple> void to(Tuple &t) const
+  template<typename Tuple>
+  void to(Tuple &t, PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    check_size(std::tuple_size_v<Tuple>);
-    convert(t);
+    check_size(std::tuple_size_v<Tuple>, loc);
+    convert(t, loc);
   }
 
   /// Extract entire row's values into a tuple.
@@ -182,11 +192,12 @@ public:
    * @throw usage_error If the number of columns in the `row` does not match
    * the number of fields in `t`.
    */
-  template<typename... TYPE> std::tuple<TYPE...> as() const
+  template<typename... TYPE>
+  std::tuple<TYPE...> as(PQXX_LOC loc = PQXX_LOC::current()) const
   {
-    check_size(sizeof...(TYPE));
+    check_size(sizeof...(TYPE), loc);
     using seq = std::make_index_sequence<sizeof...(TYPE)>;
-    return get_tuple<std::tuple<TYPE...>>(seq{});
+    return get_tuple<std::tuple<TYPE...>>(seq{}, loc);
   }
 
   [[deprecated("Swap iterators, not rows.")]] void swap(row &) noexcept;
@@ -197,29 +208,32 @@ protected:
   row(result r, result_size_type index, size_type cols) noexcept;
 
   /// Throw @ref usage_error if row size is not `expected`.
-  void check_size(size_type expected) const
+  void check_size(size_type expected, PQXX_LOC loc) const
   {
     if (size() != expected)
-      throw usage_error{internal::concat(
-        "Tried to extract ", expected, " field(s) from a row of ", size(),
-        ".")};
+      throw usage_error{
+        internal::concat(
+          "Tried to extract ", expected, " field(s) from a row of ", size(),
+          "."),
+        loc};
   }
 
   /// Convert to a given tuple of values, don't check sizes.
   /** We need this for cases where we have a full tuple of field types, but
    * not a parameter pack.
    */
-  template<typename TUPLE> TUPLE as_tuple() const
+  template<typename TUPLE> TUPLE as_tuple(PQXX_LOC loc) const
   {
     using seq = std::make_index_sequence<std::tuple_size_v<TUPLE>>;
-    return get_tuple<TUPLE>(seq{});
+    return get_tuple<TUPLE>(seq{}, loc);
   }
 
   template<typename... T> friend class pqxx::internal::result_iter;
   /// Convert entire row to tuple fields, without checking row size.
-  template<typename Tuple> void convert(Tuple &t) const
+  template<typename Tuple> void convert(Tuple &t, PQXX_LOC loc) const
   {
-    extract_fields(t, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+    extract_fields(
+      t, std::make_index_sequence<std::tuple_size_v<Tuple>>{}, loc);
   }
 
   friend class field;
@@ -239,17 +253,18 @@ protected:
 
 private:
   template<typename Tuple, std::size_t... indexes>
-  void extract_fields(Tuple &t, std::index_sequence<indexes...>) const
+  void
+  extract_fields(Tuple &t, std::index_sequence<indexes...>, PQXX_LOC loc) const
   {
-    (extract_value<Tuple, indexes>(t), ...);
+    (extract_value<Tuple, indexes>(t, loc), ...);
   }
 
   template<typename Tuple, std::size_t index>
-  void extract_value(Tuple &t) const;
+  void extract_value(Tuple &t, PQXX_LOC loc) const;
 
   /// Convert row's values as a new tuple.
   template<typename TUPLE, std::size_t... indexes>
-  auto get_tuple(std::index_sequence<indexes...>) const
+  auto get_tuple(std::index_sequence<indexes...>, PQXX_LOC) const
   {
     return std::make_tuple(get_field<TUPLE, indexes>()...);
   }
@@ -543,7 +558,7 @@ const_row_iterator::operator-(const_row_iterator const &i) const noexcept
 
 
 template<typename Tuple, std::size_t index>
-inline void row::extract_value(Tuple &t) const
+inline void row::extract_value(Tuple &t, PQXX_LOC) const
 {
   using field_type = std::remove_cvref_t<decltype(std::get<index>(t))>;
   field const f{m_result, m_index, index};

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -276,9 +276,9 @@ private:
     std::string_view columns, from_table_t, int);
 
   template<typename Tuple, std::size_t... indexes>
-  void extract_fields(Tuple &t, std::index_sequence<indexes...>) const
+  void extract_fields(Tuple &t, std::index_sequence<indexes...>, sl loc) const
   {
-    (extract_value<Tuple, indexes>(t), ...);
+    (extract_value<Tuple, indexes>(t, loc), ...);
   }
 
   pqxx::internal::char_finder_func *m_char_finder;
@@ -294,7 +294,7 @@ private:
   void close();
 
   template<typename Tuple, std::size_t index>
-  void extract_value(Tuple &) const;
+  void extract_value(Tuple &, sl loc) const;
 
   /// Read a line of COPY data, write `m_row` and `m_fields`.
   void parse_line(sl);
@@ -320,6 +320,7 @@ inline stream_from::stream_from(
 {}
 
 
+// TODO: How can we pass std::source_location?
 template<typename Tuple> inline stream_from &stream_from::operator>>(Tuple &t)
 {
   sl loc{sl::current()};
@@ -336,13 +337,13 @@ template<typename Tuple> inline stream_from &stream_from::operator>>(Tuple &t)
       "Tried to extract ", tup_size, " field(s) from a stream of ",
       std::size(m_fields), ".")};
 
-  extract_fields(t, std::make_index_sequence<tup_size>{});
+  extract_fields(t, std::make_index_sequence<tup_size>{}, loc);
   return *this;
 }
 
 
 template<typename Tuple, std::size_t index>
-inline void stream_from::extract_value(Tuple &t) const
+inline void stream_from::extract_value(Tuple &t, sl loc) const
 {
   using field_type = std::remove_cvref_t<decltype(std::get<index>(t))>;
   using nullity = nullness<field_type>;
@@ -350,14 +351,14 @@ inline void stream_from::extract_value(Tuple &t) const
   if constexpr (nullity::always_null)
   {
     if (std::data(m_fields[index]) != nullptr)
-      throw conversion_error{"Streaming non-null value into null field."};
+      throw conversion_error{"Streaming non-null value into null field.", loc};
   }
   else if (std::data(m_fields[index]) == nullptr)
   {
     if constexpr (nullity::has_null)
       std::get<index>(t) = nullity::null();
     else
-      internal::throw_null_conversion(type_name<field_type>);
+      internal::throw_null_conversion(type_name<field_type>, loc);
   }
   else
   {

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -256,7 +256,7 @@ public:
    * @warning The return type may change in the future, to support C++20
    * coroutine-based usage.
    */
-  std::vector<zview> const *read_row() &;
+  std::vector<zview> const *read_row(PQXX_LOC loc = PQXX_LOC::current()) &;
 
   /// Read a raw line of text from the COPY command.
   /** @warning Do not use this unless you really know what you're doing. */
@@ -297,7 +297,7 @@ private:
   void extract_value(Tuple &) const;
 
   /// Read a line of COPY data, write `m_row` and `m_fields`.
-  void parse_line();
+  void parse_line(PQXX_LOC);
 };
 
 
@@ -322,11 +322,12 @@ inline stream_from::stream_from(
 
 template<typename Tuple> inline stream_from &stream_from::operator>>(Tuple &t)
 {
+  PQXX_LOC loc{PQXX_LOC::current()};
   if (m_finished) [[unlikely]]
     return *this;
   static constexpr auto tup_size{std::tuple_size_v<Tuple>};
   m_fields.reserve(tup_size);
-  parse_line();
+  parse_line(loc);
   if (m_finished) [[unlikely]]
     return *this;
 

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -256,7 +256,7 @@ public:
    * @warning The return type may change in the future, to support C++20
    * coroutine-based usage.
    */
-  std::vector<zview> const *read_row(PQXX_LOC loc = PQXX_LOC::current()) &;
+  std::vector<zview> const *read_row(sl loc = sl::current()) &;
 
   /// Read a raw line of text from the COPY command.
   /** @warning Do not use this unless you really know what you're doing. */
@@ -297,7 +297,7 @@ private:
   void extract_value(Tuple &) const;
 
   /// Read a line of COPY data, write `m_row` and `m_fields`.
-  void parse_line(PQXX_LOC);
+  void parse_line(sl);
 };
 
 
@@ -322,7 +322,7 @@ inline stream_from::stream_from(
 
 template<typename Tuple> inline stream_from &stream_from::operator>>(Tuple &t)
 {
-  PQXX_LOC loc{PQXX_LOC::current()};
+  sl loc{sl::current()};
   if (m_finished) [[unlikely]]
     return *this;
   static constexpr auto tup_size{std::tuple_size_v<Tuple>};

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -203,7 +203,8 @@ public:
    */
   template<typename Row> stream_to &operator<<(Row const &row)
   {
-    write_row(row);
+    sl loc{sl::current()};
+    write_row(row, loc);
     return *this;
   }
 

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -102,9 +102,10 @@ public:
    *     the stream will write all columns in the table, in schema order.
    */
   static stream_to raw_table(
-    transaction_base &tx, std::string_view path, std::string_view columns = "")
+    transaction_base &tx, std::string_view path, std::string_view columns = "",
+    PQXX_LOC loc = PQXX_LOC::current())
   {
-    return {tx, path, columns};
+    return {tx, path, columns, loc};
   }
 
   /// Create a `stream_to` writing to a named table and columns.
@@ -242,7 +243,8 @@ public:
 private:
   /// Stream a pre-quoted table name and columns list.
   stream_to(
-    transaction_base &tx, std::string_view path, std::string_view columns);
+    transaction_base &tx, std::string_view path, std::string_view columns,
+    PQXX_LOC);
 
   bool m_finished = false;
 

--- a/include/pqxx/subtransaction.hxx
+++ b/include/pqxx/subtransaction.hxx
@@ -40,6 +40,7 @@ namespace pqxx
  *   do_firstpart(tx);
  *
  *   // Attempt to delete our temporary table if it already existed.
+ *   // (In reality you would just use the IF EXISTS option to DROP TABLE.)
  *   try
  *   {
  *     subtransaction S(tx, "droptemp");

--- a/include/pqxx/subtransaction.hxx
+++ b/include/pqxx/subtransaction.hxx
@@ -80,11 +80,10 @@ class PQXX_LIBEXPORT subtransaction : public transaction_focus,
 public:
   /// Nest a subtransaction nested in another transaction.
   explicit subtransaction(
-    dbtransaction &t, std::string_view tname, PQXX_LOC = PQXX_LOC::current());
+    dbtransaction &t, std::string_view tname, sl = sl::current());
 
   /// Nest a subtransaction nested in another transaction.
-  explicit subtransaction(
-    dbtransaction &t, PQXX_LOC loc = PQXX_LOC::current()) :
+  explicit subtransaction(dbtransaction &t, sl loc = sl::current()) :
           subtransaction(t, "", loc)
   {}
 
@@ -98,7 +97,7 @@ private:
   {
     return quote_name(transaction_focus::name());
   }
-  virtual void do_commit(PQXX_LOC) override;
+  virtual void do_commit(sl) override;
 };
 } // namespace pqxx
 #endif

--- a/include/pqxx/subtransaction.hxx
+++ b/include/pqxx/subtransaction.hxx
@@ -78,7 +78,14 @@ class PQXX_LIBEXPORT subtransaction : public transaction_focus,
 {
 public:
   /// Nest a subtransaction nested in another transaction.
-  explicit subtransaction(dbtransaction &t, std::string_view tname = ""sv);
+  explicit subtransaction(
+    dbtransaction &t, std::string_view tname, PQXX_LOC = PQXX_LOC::current());
+
+  /// Nest a subtransaction nested in another transaction.
+  explicit subtransaction(
+    dbtransaction &t, PQXX_LOC loc = PQXX_LOC::current()) :
+          subtransaction(t, "", loc)
+  {}
 
   /// Nest a subtransaction in another subtransaction.
   explicit subtransaction(subtransaction &t, std::string_view name = ""sv);
@@ -90,7 +97,7 @@ private:
   {
     return quote_name(transaction_focus::name());
   }
-  virtual void do_commit() override;
+  virtual void do_commit(PQXX_LOC) override;
 };
 } // namespace pqxx
 #endif

--- a/include/pqxx/subtransaction.hxx
+++ b/include/pqxx/subtransaction.hxx
@@ -88,7 +88,8 @@ public:
   {}
 
   /// Nest a subtransaction in another subtransaction.
-  explicit subtransaction(subtransaction &t, std::string_view name = ""sv);
+  explicit subtransaction(
+    subtransaction &t, std::string_view name = ""sv, sl loc = sl::current());
 
   virtual ~subtransaction() noexcept override;
 

--- a/include/pqxx/time.hxx
+++ b/include/pqxx/time.hxx
@@ -65,11 +65,12 @@ template<> struct PQXX_LIBEXPORT string_traits<std::chrono::year_month_day>
     return generic_to_buf(begin, end, value);
   }
 
-  static char *
-  into_buf(char *begin, char *end, std::chrono::year_month_day const &value);
+  static char *into_buf(
+    char *begin, char *end, std::chrono::year_month_day const &value,
+    PQXX_LOC = PQXX_LOC::current());
 
   [[nodiscard]] static std::chrono::year_month_day
-  from_string(std::string_view text);
+  from_string(std::string_view text, PQXX_LOC = PQXX_LOC::current());
 
   [[nodiscard]] static std::size_t
   size_buffer(std::chrono::year_month_day const &) noexcept

--- a/include/pqxx/time.hxx
+++ b/include/pqxx/time.hxx
@@ -67,10 +67,10 @@ template<> struct PQXX_LIBEXPORT string_traits<std::chrono::year_month_day>
 
   static char *into_buf(
     char *begin, char *end, std::chrono::year_month_day const &value,
-    PQXX_LOC = PQXX_LOC::current());
+    sl = sl::current());
 
   [[nodiscard]] static std::chrono::year_month_day
-  from_string(std::string_view text, PQXX_LOC = PQXX_LOC::current());
+  from_string(std::string_view text, sl = sl::current());
 
   [[nodiscard]] static std::size_t
   size_buffer(std::chrono::year_month_day const &) noexcept

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -25,14 +25,18 @@ class PQXX_LIBEXPORT basic_transaction : public dbtransaction
 {
 protected:
   basic_transaction(
-    connection &cx, zview begin_command, std::string_view tname);
-  basic_transaction(connection &cx, zview begin_command, std::string &&tname);
-  basic_transaction(connection &cx, zview begin_command);
+    connection &cx, zview begin_command, std::string_view tname,
+    PQXX_LOC = PQXX_LOC::current());
+  basic_transaction(
+    connection &cx, zview begin_command, std::string &&tname,
+    PQXX_LOC = PQXX_LOC::current());
+  basic_transaction(
+    connection &cx, zview begin_command, PQXX_LOC = PQXX_LOC::current());
 
   virtual ~basic_transaction() noexcept override = 0;
 
 private:
-  virtual void do_commit() override;
+  virtual void do_commit(PQXX_LOC) override;
 };
 } // namespace pqxx::internal
 

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -81,9 +81,11 @@ public:
    * @param tname Optional name for transaction.  Must begin with a letter and
    * may contain letters and digits only.
    */
-  transaction(connection &cx, std::string_view tname) :
+  transaction(
+    connection &cx, std::string_view tname,
+    PQXX_LOC loc = PQXX_LOC::current()) :
           internal::basic_transaction{
-            cx, internal::begin_cmd<ISOLATION, READWRITE>, tname}
+            cx, internal::begin_cmd<ISOLATION, READWRITE>, tname, loc}
   {}
 
   /// Begin a transaction.

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -90,12 +90,12 @@ public:
    * @param cx Connection for this transaction to operate on.
    * may contain letters and digits only.
    */
-  explicit transaction(connection &cx) :
+  explicit transaction(connection &cx, sl loc = sl::current()) :
           internal::basic_transaction{
-            cx, internal::begin_cmd<ISOLATION, READWRITE>}
+            cx, internal::begin_cmd<ISOLATION, READWRITE>, loc}
   {}
 
-  virtual ~transaction() noexcept override { close(); }
+  virtual ~transaction() noexcept override { close(sl::current()); }
 };
 
 

--- a/include/pqxx/transaction.hxx
+++ b/include/pqxx/transaction.hxx
@@ -26,17 +26,16 @@ class PQXX_LIBEXPORT basic_transaction : public dbtransaction
 protected:
   basic_transaction(
     connection &cx, zview begin_command, std::string_view tname,
-    PQXX_LOC = PQXX_LOC::current());
+    sl = sl::current());
   basic_transaction(
     connection &cx, zview begin_command, std::string &&tname,
-    PQXX_LOC = PQXX_LOC::current());
-  basic_transaction(
-    connection &cx, zview begin_command, PQXX_LOC = PQXX_LOC::current());
+    sl = sl::current());
+  basic_transaction(connection &cx, zview begin_command, sl = sl::current());
 
   virtual ~basic_transaction() noexcept override = 0;
 
 private:
-  virtual void do_commit(PQXX_LOC) override;
+  virtual void do_commit(sl) override;
 };
 } // namespace pqxx::internal
 
@@ -81,9 +80,7 @@ public:
    * @param tname Optional name for transaction.  Must begin with a letter and
    * may contain letters and digits only.
    */
-  transaction(
-    connection &cx, std::string_view tname,
-    PQXX_LOC loc = PQXX_LOC::current()) :
+  transaction(connection &cx, std::string_view tname, sl loc = sl::current()) :
           internal::basic_transaction{
             cx, internal::begin_cmd<ISOLATION, READWRITE>, tname, loc}
   {}

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -97,9 +97,8 @@ namespace pqxx
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>
-inline auto perform(
-  TRANSACTION_CALLBACK &&callback, int attempts,
-  PQXX_LOC loc = PQXX_LOC::current())
+inline auto
+perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
   -> std::invoke_result_t<TRANSACTION_CALLBACK>
 {
   if (attempts <= 0)
@@ -182,8 +181,7 @@ inline auto perform(
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>
-inline auto
-perform(TRANSACTION_CALLBACK &&callback, PQXX_LOC loc = PQXX_LOC::current())
+inline auto perform(TRANSACTION_CALLBACK &&callback, sl loc = sl::current())
   -> std::invoke_result_t<TRANSACTION_CALLBACK>
 {
   return perform(callback, 3, loc);

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -97,7 +97,9 @@ namespace pqxx
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>
-inline auto perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
+inline auto perform(
+  TRANSACTION_CALLBACK &&callback, int attempts,
+  PQXX_LOC loc = PQXX_LOC::current())
   -> std::invoke_result_t<TRANSACTION_CALLBACK>
 {
   if (attempts <= 0)
@@ -145,7 +147,46 @@ inline auto perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
       continue;
     }
   }
-  throw pqxx::internal_error{"No outcome reached on perform()."};
+  throw pqxx::internal_error{"No outcome reached on perform().", loc};
+}
+
+
+/// Simple way to execute a transaction with automatic retry.
+/**
+ * Executes your transaction code as a callback.  Repeats it until it completes
+ * normally, or it throws an error other than the few libpqxx-generated
+ * exceptions that the framework understands, or after a given number of failed
+ * attempts, or if the transaction ends in an "in-doubt" state.
+ *
+ * (An in-doubt state is one where libpqxx cannot determine whether the server
+ * finally committed a transaction or not.  This can happen if the network
+ * connection to the server is lost just while we're waiting for its reply to
+ * a "commit" statement.  The server may have completed the commit, or not, but
+ * it can't tell you because there's no longer a connection.
+ *
+ * Using this still takes a bit of care.  If your callback makes use of data
+ * from the database, you'll probably have to query that data within your
+ * callback.  If the attempt to perform your callback fails, and the framework
+ * tries again, you'll be in a new transaction and the data in the database may
+ * have changed under your feet.
+ *
+ * Also be careful about changing variables or data structures from within
+ * your callback.  The run may still fail, and perhaps get run again.  The
+ * ideal way to do it (in most cases) is to return your result from your
+ * callback, and change your program's data state only after @ref perform
+ * completes successfully.
+ *
+ * @param callback Transaction code that can be called with no arguments.
+ * @param attempts Maximum number of times to attempt performing callback.
+ *     Must be greater than zero.
+ * @return Whatever your callback returns.
+ */
+template<typename TRANSACTION_CALLBACK>
+inline auto
+perform(TRANSACTION_CALLBACK &&callback, PQXX_LOC loc = PQXX_LOC::current())
+  -> std::invoke_result_t<TRANSACTION_CALLBACK>
+{
+  return perform(callback, 3, loc);
 }
 } // namespace pqxx
 //@}

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -20,6 +20,10 @@
 #include <type_traits>
 
 
+/// Conenience alias for `std::source_location`.  It's just too long.
+#define PQXX_LOC std::source_location
+
+
 namespace pqxx
 {
 /// Number of rows in a result set.

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -17,15 +17,15 @@
 #include <cstdint>
 #include <iterator>
 #include <ranges>
+#include <source_location>
 #include <type_traits>
-
-
-/// Conenience alias for `std::source_location`.  It's just too long.
-#define PQXX_LOC std::source_location
 
 
 namespace pqxx
 {
+/// Conenience alias for `std::source_location`.  It's just too long.
+using sl = std::source_location;
+
 /// Number of rows in a result set.
 using result_size_type = int;
 

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -88,7 +88,8 @@ template<typename... T> inline constexpr void ignore_unused(T &&...) noexcept
  * or both floating-point types.
  */
 template<typename TO, typename FROM>
-inline TO check_cast(FROM value, std::string_view description)
+inline TO check_cast(
+  FROM value, std::string_view description, PQXX_LOC loc = PQXX_LOC::current())
 {
   static_assert(std::is_arithmetic_v<FROM>);
   static_assert(std::is_arithmetic_v<TO>);
@@ -110,7 +111,8 @@ inline TO check_cast(FROM value, std::string_view description)
     if constexpr (std::is_signed_v<TO>)
     {
       if (value < to_limits::lowest())
-        throw range_error{internal::cat2("Cast underflow: "sv, description)};
+        throw range_error{
+          internal::cat2("Cast underflow: "sv, description), loc};
     }
     else
     {
@@ -118,8 +120,10 @@ inline TO check_cast(FROM value, std::string_view description)
       // there may not be a good broader type in which the compiler can even
       // perform our check.
       if (value < 0)
-        throw range_error{internal::cat2(
-          "Casting negative value to unsigned type: "sv, description)};
+        throw range_error{
+          internal::cat2(
+            "Casting negative value to unsigned type: "sv, description),
+          loc};
     }
   }
   else
@@ -137,13 +141,14 @@ inline TO check_cast(FROM value, std::string_view description)
     if constexpr (from_max > to_max)
     {
       if (std::cmp_greater(value, to_max))
-        throw range_error{internal::cat2("Cast overflow: "sv, description)};
+        throw range_error{
+          internal::cat2("Cast overflow: "sv, description), loc};
     }
   }
   else if constexpr ((from_limits::max)() > (to_limits::max)())
   {
     if (value > (to_limits::max)())
-      throw range_error{internal::cat2("Cast overflow: ", description)};
+      throw range_error{internal::cat2("Cast overflow: ", description), loc};
   }
 
   return static_cast<TO>(value);

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -457,11 +457,11 @@ std::string PQXX_LIBEXPORT esc_bin(bytes_view binary_data);
 
 /// Reconstitute binary data from its escaped version.
 void PQXX_LIBEXPORT
-unesc_bin(std::string_view escaped_data, std::byte buffer[]);
+unesc_bin(std::string_view escaped_data, std::byte buffer[], PQXX_LOC loc);
 
 
 /// Reconstitute binary data from its escaped version.
-bytes PQXX_LIBEXPORT unesc_bin(std::string_view escaped_data);
+bytes PQXX_LIBEXPORT unesc_bin(std::string_view escaped_data, PQXX_LOC loc);
 
 
 /// Helper for determining a function's parameter types.

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -88,8 +88,7 @@ template<typename... T> inline constexpr void ignore_unused(T &&...) noexcept
  * or both floating-point types.
  */
 template<typename TO, typename FROM>
-inline TO
-check_cast(FROM value, std::string_view description, sl loc = sl::current())
+inline TO check_cast(FROM value, std::string_view description, sl loc)
 {
   static_assert(std::is_arithmetic_v<FROM>);
   static_assert(std::is_arithmetic_v<TO>);

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -88,8 +88,8 @@ template<typename... T> inline constexpr void ignore_unused(T &&...) noexcept
  * or both floating-point types.
  */
 template<typename TO, typename FROM>
-inline TO check_cast(
-  FROM value, std::string_view description, PQXX_LOC loc = PQXX_LOC::current())
+inline TO
+check_cast(FROM value, std::string_view description, sl loc = sl::current())
 {
   static_assert(std::is_arithmetic_v<FROM>);
   static_assert(std::is_arithmetic_v<TO>);
@@ -462,11 +462,11 @@ std::string PQXX_LIBEXPORT esc_bin(bytes_view binary_data);
 
 /// Reconstitute binary data from its escaped version.
 void PQXX_LIBEXPORT
-unesc_bin(std::string_view escaped_data, std::byte buffer[], PQXX_LOC loc);
+unesc_bin(std::string_view escaped_data, std::byte buffer[], sl loc);
 
 
 /// Reconstitute binary data from its escaped version.
-bytes PQXX_LIBEXPORT unesc_bin(std::string_view escaped_data, PQXX_LOC loc);
+bytes PQXX_LIBEXPORT unesc_bin(std::string_view escaped_data, sl loc);
 
 
 /// Helper for determining a function's parameter types.

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -28,7 +28,7 @@ namespace pqxx
 /// Scan to next glyph in the buffer.  Assumes there is one.
 template<pqxx::internal::encoding_group ENC>
 [[nodiscard]] std::string::size_type
-array_parser::scan_glyph(std::string::size_type pos, PQXX_LOC loc) const
+array_parser::scan_glyph(std::string::size_type pos, sl loc) const
 {
   return pqxx::internal::glyph_scanner<ENC>::call(
     std::data(m_input), std::size(m_input), pos, loc);
@@ -38,7 +38,7 @@ array_parser::scan_glyph(std::string::size_type pos, PQXX_LOC loc) const
 /// Scan to next glyph in a substring.  Assumes there is one.
 template<pqxx::internal::encoding_group ENC>
 std::string::size_type array_parser::scan_glyph(
-  std::string::size_type pos, std::string::size_type end, PQXX_LOC loc) const
+  std::string::size_type pos, std::string::size_type end, sl loc) const
 {
   return pqxx::internal::glyph_scanner<ENC>::call(
     std::data(m_input), end, pos, loc);
@@ -47,8 +47,7 @@ std::string::size_type array_parser::scan_glyph(
 
 /// Find the end of a double-quoted SQL string in an SQL array.
 template<pqxx::internal::encoding_group ENC>
-std::string::size_type
-array_parser::scan_double_quoted_string(PQXX_LOC loc) const
+std::string::size_type array_parser::scan_double_quoted_string(sl loc) const
 {
   return pqxx::internal::scan_double_quoted_string<ENC>(
     std::data(m_input), std::size(m_input), m_pos, loc);
@@ -58,7 +57,7 @@ array_parser::scan_double_quoted_string(PQXX_LOC loc) const
 /// Parse a double-quoted SQL string: un-quote it and un-escape it.
 template<pqxx::internal::encoding_group ENC>
 std::string array_parser::parse_double_quoted_string(
-  std::string::size_type end, PQXX_LOC loc) const
+  std::string::size_type end, sl loc) const
 {
   return pqxx::internal::parse_double_quoted_string<ENC>(
     std::data(m_input), end, m_pos, loc);
@@ -69,7 +68,7 @@ std::string array_parser::parse_double_quoted_string(
 /** Assumes UTF-8 or an ASCII-superset single-byte encoding.
  */
 template<pqxx::internal::encoding_group ENC>
-std::string::size_type array_parser::scan_unquoted_string(PQXX_LOC loc) const
+std::string::size_type array_parser::scan_unquoted_string(sl loc) const
 {
   return pqxx::internal::scan_unquoted_string<ENC, ',', '}'>(
     std::data(m_input), std::size(m_input), m_pos, loc);
@@ -81,8 +80,8 @@ std::string::size_type array_parser::scan_unquoted_string(PQXX_LOC loc) const
  * that happens to spell "NULL".
  */
 template<pqxx::internal::encoding_group ENC>
-std::string_view array_parser::parse_unquoted_string(
-  std::string::size_type end, PQXX_LOC loc) const
+std::string_view
+array_parser::parse_unquoted_string(std::string::size_type end, sl loc) const
 {
   return pqxx::internal::parse_unquoted_string<ENC>(
     std::data(m_input), end, m_pos, loc);
@@ -91,14 +90,13 @@ std::string_view array_parser::parse_unquoted_string(
 
 array_parser::array_parser(
   std::string_view input, internal::encoding_group enc) :
-        m_input{input},
-        m_impl{specialize_for_encoding(enc, PQXX_LOC::current())}
+        m_input{input}, m_impl{specialize_for_encoding(enc, sl::current())}
 {}
 
 
 template<pqxx::internal::encoding_group ENC>
 std::pair<array_parser::juncture, std::string>
-array_parser::parse_array_step(PQXX_LOC loc)
+array_parser::parse_array_step(sl loc)
 {
   std::string value{};
 
@@ -160,7 +158,7 @@ array_parser::parse_array_step(PQXX_LOC loc)
 
 
 array_parser::implementation array_parser::specialize_for_encoding(
-  pqxx::internal::encoding_group enc, PQXX_LOC loc)
+  pqxx::internal::encoding_group enc, sl loc)
 {
   using encoding_group = pqxx::internal::encoding_group;
 

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -47,7 +47,8 @@ std::string::size_type array_parser::scan_glyph(
 
 /// Find the end of a double-quoted SQL string in an SQL array.
 template<pqxx::internal::encoding_group ENC>
-std::string::size_type array_parser::scan_double_quoted_string(PQXX_LOC loc) const
+std::string::size_type
+array_parser::scan_double_quoted_string(PQXX_LOC loc) const
 {
   return pqxx::internal::scan_double_quoted_string<ENC>(
     std::data(m_input), std::size(m_input), m_pos, loc);
@@ -56,8 +57,8 @@ std::string::size_type array_parser::scan_double_quoted_string(PQXX_LOC loc) con
 
 /// Parse a double-quoted SQL string: un-quote it and un-escape it.
 template<pqxx::internal::encoding_group ENC>
-std::string
-array_parser::parse_double_quoted_string(std::string::size_type end, PQXX_LOC loc) const
+std::string array_parser::parse_double_quoted_string(
+  std::string::size_type end, PQXX_LOC loc) const
 {
   return pqxx::internal::parse_double_quoted_string<ENC>(
     std::data(m_input), end, m_pos, loc);
@@ -80,8 +81,8 @@ std::string::size_type array_parser::scan_unquoted_string(PQXX_LOC loc) const
  * that happens to spell "NULL".
  */
 template<pqxx::internal::encoding_group ENC>
-std::string_view
-array_parser::parse_unquoted_string(std::string::size_type end, PQXX_LOC loc) const
+std::string_view array_parser::parse_unquoted_string(
+  std::string::size_type end, PQXX_LOC loc) const
 {
   return pqxx::internal::parse_unquoted_string<ENC>(
     std::data(m_input), end, m_pos, loc);

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -252,7 +252,7 @@ pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id, sl loc)
   oid const actual_id{create(tx, id, loc)};
   try
   {
-    open_w(tx, actual_id).write(data, loc);
+    open_w(tx, actual_id, loc).write(data, loc);
   }
   catch (std::exception const &)
   {
@@ -292,7 +292,7 @@ void pqxx::blob::append_from_buf(
 void pqxx::blob::to_buf(
   dbtransaction &tx, oid id, bytes &buf, std::size_t max_size, sl loc)
 {
-  open_r(tx, id).read(buf, max_size, loc);
+  open_r(tx, id, loc).read(buf, max_size, loc);
 }
 
 

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -43,52 +43,52 @@ std::string pqxx::blob::errmsg(connection const *cx)
 }
 
 
-pqxx::blob pqxx::blob::open_internal(dbtransaction &tx, oid id, int mode)
+pqxx::blob pqxx::blob::open_internal(dbtransaction &tx, oid id, int mode, PQXX_LOC loc)
 {
   auto &cx{tx.conn()};
   int const fd{lo_open(raw_conn(&cx), id, mode)};
   if (fd == -1)
     throw pqxx::failure{internal::concat(
-      "Could not open binary large object ", id, ": ", errmsg(&cx))};
+      "Could not open binary large object ", id, ": ", errmsg(&cx)), loc};
   return {cx, fd};
 }
 
 
-pqxx::oid pqxx::blob::create(dbtransaction &tx, oid id)
+pqxx::oid pqxx::blob::create(dbtransaction &tx, oid id, PQXX_LOC loc)
 {
   oid const actual_id{lo_create(raw_conn(tx), id)};
   if (actual_id == 0)
     throw failure{internal::concat(
-      "Could not create binary large object: ", errmsg(&tx.conn()))};
+      "Could not create binary large object: ", errmsg(&tx.conn())), loc};
   return actual_id;
 }
 
 
-void pqxx::blob::remove(dbtransaction &tx, oid id)
+void pqxx::blob::remove(dbtransaction &tx, oid id, PQXX_LOC loc)
 {
   if (id == 0)
-    throw usage_error{"Trying to delete binary large object without an ID."};
+    throw usage_error{"Trying to delete binary large object without an ID.", loc};
   if (lo_unlink(raw_conn(tx), id) == -1)
     throw failure{internal::concat(
-      "Could not delete large object ", id, ": ", errmsg(&tx.conn()))};
+      "Could not delete large object ", id, ": ", errmsg(&tx.conn())), loc};
 }
 
 
-pqxx::blob pqxx::blob::open_r(dbtransaction &tx, oid id)
+pqxx::blob pqxx::blob::open_r(dbtransaction &tx, oid id, PQXX_LOC loc)
 {
-  return open_internal(tx, id, INV_READ);
+  return open_internal(tx, id, INV_READ, loc);
 }
 
 
-pqxx::blob pqxx::blob::open_w(dbtransaction &tx, oid id)
+pqxx::blob pqxx::blob::open_w(dbtransaction &tx, oid id, PQXX_LOC loc)
 {
-  return open_internal(tx, id, INV_WRITE);
+  return open_internal(tx, id, INV_WRITE, loc);
 }
 
 
-pqxx::blob pqxx::blob::open_rw(dbtransaction &tx, oid id)
+pqxx::blob pqxx::blob::open_rw(dbtransaction &tx, oid id, PQXX_LOC loc)
 {
-  return open_internal(tx, id, INV_READ | INV_WRITE);
+  return open_internal(tx, id, INV_READ | INV_WRITE, loc);
 }
 
 
@@ -137,111 +137,111 @@ void pqxx::blob::close()
 }
 
 
-std::size_t pqxx::blob::raw_read(std::byte buf[], std::size_t size)
+std::size_t pqxx::blob::raw_read(std::byte buf[], std::size_t size, PQXX_LOC loc)
 {
   if (m_conn == nullptr)
-    throw usage_error{"Attempt to read from a closed binary large object."};
+    throw usage_error{"Attempt to read from a closed binary large object.", loc};
   if (size > chunk_limit)
     throw range_error{
-      "Reads from a binary large object must be less than 2 GB at once."};
+      "Reads from a binary large object must be less than 2 GB at once.", loc};
   auto data{reinterpret_cast<char *>(buf)};
   int const received{lo_read(raw_conn(m_conn), m_fd, data, size)};
   if (received < 0)
     throw failure{
-      internal::concat("Could not read from binary large object: ", errmsg())};
+      internal::concat("Could not read from binary large object: ", errmsg()), loc};
   return static_cast<std::size_t>(received);
 }
 
 
-std::size_t pqxx::blob::read(bytes &buf, std::size_t size)
+std::size_t pqxx::blob::read(bytes &buf, std::size_t size, PQXX_LOC loc)
 {
   buf.resize(size);
-  auto const received{raw_read(std::data(buf), size)};
+  auto const received{raw_read(std::data(buf), size, loc)};
   buf.resize(received);
   return static_cast<std::size_t>(received);
 }
 
 
-void pqxx::blob::raw_write(bytes_view data)
+void pqxx::blob::raw_write(bytes_view data, PQXX_LOC loc)
 {
   if (m_conn == nullptr)
-    throw usage_error{"Attempt to write to a closed binary large object."};
+    throw usage_error{"Attempt to write to a closed binary large object.", loc};
   auto const sz{std::size(data)};
   if (sz > chunk_limit)
-    throw range_error{"Write to binary large object exceeds 2GB limit."};
+    throw range_error{"Write to binary large object exceeds 2GB limit.", loc};
   auto ptr{reinterpret_cast<char const *>(std::data(data))};
   int const written{lo_write(raw_conn(m_conn), m_fd, ptr, sz)};
   if (written < 0)
     throw failure{
-      internal::concat("Write to binary large object failed: ", errmsg())};
+      internal::concat("Write to binary large object failed: ", errmsg()), loc};
 }
 
 
-void pqxx::blob::resize(std::int64_t size)
+void pqxx::blob::resize(std::int64_t size, PQXX_LOC loc)
 {
   if (m_conn == nullptr)
-    throw usage_error{"Attempt to resize a closed binary large object."};
+    throw usage_error{"Attempt to resize a closed binary large object.", loc};
   if (lo_truncate64(raw_conn(m_conn), m_fd, size) < 0)
     throw failure{
-      internal::concat("Binary large object truncation failed: ", errmsg())};
+      internal::concat("Binary large object truncation failed: ", errmsg()), loc};
 }
 
 
-std::int64_t pqxx::blob::tell() const
+std::int64_t pqxx::blob::tell(PQXX_LOC loc) const
 {
   if (m_conn == nullptr)
-    throw usage_error{"Attempt to tell() a closed binary large object."};
+    throw usage_error{"Attempt to tell() a closed binary large object.", loc};
   std::int64_t const offset{lo_tell64(raw_conn(m_conn), m_fd)};
   if (offset < 0)
     throw failure{internal::concat(
-      "Error reading binary large object position: ", errmsg())};
+      "Error reading binary large object position: ", errmsg()), loc};
   return offset;
 }
 
 
-std::int64_t pqxx::blob::seek(std::int64_t offset, int whence)
+std::int64_t pqxx::blob::seek(std::int64_t offset, int whence, PQXX_LOC loc)
 {
   if (m_conn == nullptr)
-    throw usage_error{"Attempt to seek() a closed binary large object."};
+    throw usage_error{"Attempt to seek() a closed binary large object.", loc};
   std::int64_t const seek_result{
     lo_lseek64(raw_conn(m_conn), m_fd, offset, whence)};
   if (seek_result < 0)
     throw failure{internal::concat(
-      "Error during seek on binary large object: ", errmsg())};
+      "Error during seek on binary large object: ", errmsg()), loc};
   return seek_result;
 }
 
 
-std::int64_t pqxx::blob::seek_abs(std::int64_t offset)
+std::int64_t pqxx::blob::seek_abs(std::int64_t offset, PQXX_LOC loc)
 {
-  return this->seek(offset, SEEK_SET);
+  return this->seek(offset, SEEK_SET, loc);
 }
 
 
-std::int64_t pqxx::blob::seek_rel(std::int64_t offset)
+std::int64_t pqxx::blob::seek_rel(std::int64_t offset, PQXX_LOC loc)
 {
-  return this->seek(offset, SEEK_CUR);
+  return this->seek(offset, SEEK_CUR, loc);
 }
 
 
-std::int64_t pqxx::blob::seek_end(std::int64_t offset)
+std::int64_t pqxx::blob::seek_end(std::int64_t offset, PQXX_LOC loc)
 {
-  return this->seek(offset, SEEK_END);
+  return this->seek(offset, SEEK_END, loc);
 }
 
 
-pqxx::oid pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id)
+pqxx::oid pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id, PQXX_LOC loc)
 {
-  oid const actual_id{create(tx, id)};
+  oid const actual_id{create(tx, id, loc)};
   try
   {
-    open_w(tx, actual_id).write(data);
+    open_w(tx, actual_id).write(data, loc);
   }
   catch (std::exception const &)
   {
     try
     {
-      remove(tx, id);
+      remove(tx, id, loc);
     }
     catch (std::exception const &e)
     {
@@ -260,33 +260,33 @@ pqxx::oid pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id)
 }
 
 
-void pqxx::blob::append_from_buf(dbtransaction &tx, bytes_view data, oid id)
+void pqxx::blob::append_from_buf(dbtransaction &tx, bytes_view data, oid id, PQXX_LOC loc)
 {
   if (std::size(data) > chunk_limit)
     throw range_error{
-      "Writes to a binary large object must be less than 2 GB at once."};
-  blob b{open_w(tx, id)};
-  b.seek_end();
-  b.write(data);
+      "Writes to a binary large object must be less than 2 GB at once.", loc};
+  blob b{open_w(tx, id, loc)};
+  b.seek_end(0, loc);
+  b.write(data, loc);
 }
 
 
 void pqxx::blob::to_buf(
-  dbtransaction &tx, oid id, bytes &buf, std::size_t max_size)
+  dbtransaction &tx, oid id, bytes &buf, std::size_t max_size, PQXX_LOC loc)
 {
-  open_r(tx, id).read(buf, max_size);
+  open_r(tx, id).read(buf, max_size, loc);
 }
 
 
 std::size_t pqxx::blob::append_to_buf(
   dbtransaction &tx, oid id, std::int64_t offset, bytes &buf,
-  std::size_t append_max)
+  std::size_t append_max, PQXX_LOC loc)
 {
   if (append_max > chunk_limit)
     throw range_error{
-      "Reads from a binary large object must be less than 2 GB at once."};
-  auto b{open_r(tx, id)};
-  b.seek_abs(offset);
+      "Reads from a binary large object must be less than 2 GB at once.", loc};
+  auto b{open_r(tx, id, loc)};
+  b.seek_abs(offset, loc);
   auto const org_size{std::size(buf)};
   buf.resize(org_size + append_max);
   try
@@ -305,31 +305,31 @@ std::size_t pqxx::blob::append_to_buf(
 }
 
 
-pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path)
+pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, PQXX_LOC loc)
 {
   auto id{lo_import(raw_conn(tx), path.c_str())};
   if (id == 0)
     throw failure{internal::concat(
-      "Could not import '", path, "' as a binary large object: ", errmsg(tx))};
+      "Could not import '", path, "' as a binary large object: ", errmsg(tx)), loc};
   return id;
 }
 
 
-pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, oid id)
+pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, oid id, PQXX_LOC loc)
 {
   auto actual_id{lo_import_with_oid(raw_conn(tx), path.c_str(), id)};
   if (actual_id == 0)
     throw failure{internal::concat(
       "Could not import '", path, "' as binary large object ", id, ": ",
-      errmsg(tx))};
+      errmsg(tx)), loc};
   return actual_id;
 }
 
 
-void pqxx::blob::to_file(dbtransaction &tx, oid id, zview path)
+void pqxx::blob::to_file(dbtransaction &tx, oid id, zview path, PQXX_LOC loc)
 {
   if (lo_export(raw_conn(tx), id, path.c_str()) < 0)
     throw failure{internal::concat(
       "Could not export binary large object ", id, " to file '", path,
-      "': ", errmsg(tx))};
+      "': ", errmsg(tx)), loc};
 }

--- a/src/blob.cxx
+++ b/src/blob.cxx
@@ -44,7 +44,7 @@ std::string pqxx::blob::errmsg(connection const *cx)
 
 
 pqxx::blob
-pqxx::blob::open_internal(dbtransaction &tx, oid id, int mode, PQXX_LOC loc)
+pqxx::blob::open_internal(dbtransaction &tx, oid id, int mode, sl loc)
 {
   auto &cx{tx.conn()};
   int const fd{lo_open(raw_conn(&cx), id, mode)};
@@ -57,7 +57,7 @@ pqxx::blob::open_internal(dbtransaction &tx, oid id, int mode, PQXX_LOC loc)
 }
 
 
-pqxx::oid pqxx::blob::create(dbtransaction &tx, oid id, PQXX_LOC loc)
+pqxx::oid pqxx::blob::create(dbtransaction &tx, oid id, sl loc)
 {
   oid const actual_id{lo_create(raw_conn(tx), id)};
   if (actual_id == 0)
@@ -69,7 +69,7 @@ pqxx::oid pqxx::blob::create(dbtransaction &tx, oid id, PQXX_LOC loc)
 }
 
 
-void pqxx::blob::remove(dbtransaction &tx, oid id, PQXX_LOC loc)
+void pqxx::blob::remove(dbtransaction &tx, oid id, sl loc)
 {
   if (id == 0)
     throw usage_error{
@@ -82,19 +82,19 @@ void pqxx::blob::remove(dbtransaction &tx, oid id, PQXX_LOC loc)
 }
 
 
-pqxx::blob pqxx::blob::open_r(dbtransaction &tx, oid id, PQXX_LOC loc)
+pqxx::blob pqxx::blob::open_r(dbtransaction &tx, oid id, sl loc)
 {
   return open_internal(tx, id, INV_READ, loc);
 }
 
 
-pqxx::blob pqxx::blob::open_w(dbtransaction &tx, oid id, PQXX_LOC loc)
+pqxx::blob pqxx::blob::open_w(dbtransaction &tx, oid id, sl loc)
 {
   return open_internal(tx, id, INV_WRITE, loc);
 }
 
 
-pqxx::blob pqxx::blob::open_rw(dbtransaction &tx, oid id, PQXX_LOC loc)
+pqxx::blob pqxx::blob::open_rw(dbtransaction &tx, oid id, sl loc)
 {
   return open_internal(tx, id, INV_READ | INV_WRITE, loc);
 }
@@ -145,8 +145,7 @@ void pqxx::blob::close()
 }
 
 
-std::size_t
-pqxx::blob::raw_read(std::byte buf[], std::size_t size, PQXX_LOC loc)
+std::size_t pqxx::blob::raw_read(std::byte buf[], std::size_t size, sl loc)
 {
   if (m_conn == nullptr)
     throw usage_error{
@@ -164,7 +163,7 @@ pqxx::blob::raw_read(std::byte buf[], std::size_t size, PQXX_LOC loc)
 }
 
 
-std::size_t pqxx::blob::read(bytes &buf, std::size_t size, PQXX_LOC loc)
+std::size_t pqxx::blob::read(bytes &buf, std::size_t size, sl loc)
 {
   buf.resize(size);
   auto const received{raw_read(std::data(buf), size, loc)};
@@ -173,7 +172,7 @@ std::size_t pqxx::blob::read(bytes &buf, std::size_t size, PQXX_LOC loc)
 }
 
 
-void pqxx::blob::raw_write(bytes_view data, PQXX_LOC loc)
+void pqxx::blob::raw_write(bytes_view data, sl loc)
 {
   if (m_conn == nullptr)
     throw usage_error{
@@ -190,7 +189,7 @@ void pqxx::blob::raw_write(bytes_view data, PQXX_LOC loc)
 }
 
 
-void pqxx::blob::resize(std::int64_t size, PQXX_LOC loc)
+void pqxx::blob::resize(std::int64_t size, sl loc)
 {
   if (m_conn == nullptr)
     throw usage_error{"Attempt to resize a closed binary large object.", loc};
@@ -201,7 +200,7 @@ void pqxx::blob::resize(std::int64_t size, PQXX_LOC loc)
 }
 
 
-std::int64_t pqxx::blob::tell(PQXX_LOC loc) const
+std::int64_t pqxx::blob::tell(sl loc) const
 {
   if (m_conn == nullptr)
     throw usage_error{"Attempt to tell() a closed binary large object.", loc};
@@ -215,7 +214,7 @@ std::int64_t pqxx::blob::tell(PQXX_LOC loc) const
 }
 
 
-std::int64_t pqxx::blob::seek(std::int64_t offset, int whence, PQXX_LOC loc)
+std::int64_t pqxx::blob::seek(std::int64_t offset, int whence, sl loc)
 {
   if (m_conn == nullptr)
     throw usage_error{"Attempt to seek() a closed binary large object.", loc};
@@ -229,26 +228,26 @@ std::int64_t pqxx::blob::seek(std::int64_t offset, int whence, PQXX_LOC loc)
 }
 
 
-std::int64_t pqxx::blob::seek_abs(std::int64_t offset, PQXX_LOC loc)
+std::int64_t pqxx::blob::seek_abs(std::int64_t offset, sl loc)
 {
   return this->seek(offset, SEEK_SET, loc);
 }
 
 
-std::int64_t pqxx::blob::seek_rel(std::int64_t offset, PQXX_LOC loc)
+std::int64_t pqxx::blob::seek_rel(std::int64_t offset, sl loc)
 {
   return this->seek(offset, SEEK_CUR, loc);
 }
 
 
-std::int64_t pqxx::blob::seek_end(std::int64_t offset, PQXX_LOC loc)
+std::int64_t pqxx::blob::seek_end(std::int64_t offset, sl loc)
 {
   return this->seek(offset, SEEK_END, loc);
 }
 
 
 pqxx::oid
-pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id, PQXX_LOC loc)
+pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id, sl loc)
 {
   oid const actual_id{create(tx, id, loc)};
   try
@@ -279,7 +278,7 @@ pqxx::blob::from_buf(dbtransaction &tx, bytes_view data, oid id, PQXX_LOC loc)
 
 
 void pqxx::blob::append_from_buf(
-  dbtransaction &tx, bytes_view data, oid id, PQXX_LOC loc)
+  dbtransaction &tx, bytes_view data, oid id, sl loc)
 {
   if (std::size(data) > chunk_limit)
     throw range_error{
@@ -291,7 +290,7 @@ void pqxx::blob::append_from_buf(
 
 
 void pqxx::blob::to_buf(
-  dbtransaction &tx, oid id, bytes &buf, std::size_t max_size, PQXX_LOC loc)
+  dbtransaction &tx, oid id, bytes &buf, std::size_t max_size, sl loc)
 {
   open_r(tx, id).read(buf, max_size, loc);
 }
@@ -299,7 +298,7 @@ void pqxx::blob::to_buf(
 
 std::size_t pqxx::blob::append_to_buf(
   dbtransaction &tx, oid id, std::int64_t offset, bytes &buf,
-  std::size_t append_max, PQXX_LOC loc)
+  std::size_t append_max, sl loc)
 {
   if (append_max > chunk_limit)
     throw range_error{
@@ -324,7 +323,7 @@ std::size_t pqxx::blob::append_to_buf(
 }
 
 
-pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, PQXX_LOC loc)
+pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, sl loc)
 {
   auto id{lo_import(raw_conn(tx), path.c_str())};
   if (id == 0)
@@ -337,8 +336,7 @@ pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, PQXX_LOC loc)
 }
 
 
-pqxx::oid
-pqxx::blob::from_file(dbtransaction &tx, zview path, oid id, PQXX_LOC loc)
+pqxx::oid pqxx::blob::from_file(dbtransaction &tx, zview path, oid id, sl loc)
 {
   auto actual_id{lo_import_with_oid(raw_conn(tx), path.c_str(), id)};
   if (actual_id == 0)
@@ -351,7 +349,7 @@ pqxx::blob::from_file(dbtransaction &tx, zview path, oid id, PQXX_LOC loc)
 }
 
 
-void pqxx::blob::to_file(dbtransaction &tx, oid id, zview path, PQXX_LOC loc)
+void pqxx::blob::to_file(dbtransaction &tx, oid id, zview path, sl loc)
 {
   if (lo_export(raw_conn(tx), id, path.c_str()) < 0)
     throw failure{

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -913,15 +913,15 @@ pqxx::connection::read_copy_line()
 }
 
 
-void pqxx::connection::write_copy_line(std::string_view line)
+void pqxx::connection::write_copy_line(std::string_view line, PQXX_LOC loc)
 {
   static std::string const err_prefix{"Error writing to table: "};
   auto const size{check_cast<int>(
     std::ssize(line), "Line in stream_to is too long to process."sv)};
   if (PQputCopyData(m_conn, line.data(), size) <= 0) [[unlikely]]
-    throw failure{err_prefix + err_msg()};
+    throw failure{err_prefix + err_msg(), loc};
   if (PQputCopyData(m_conn, "\n", 1) <= 0) [[unlikely]]
-    throw failure{err_prefix + err_msg()};
+    throw failure{err_prefix + err_msg(), loc};
 }
 
 

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -260,7 +260,7 @@ pqxx::connection &pqxx::connection::operator=(connection &&rhs)
 
 pqxx::result pqxx::connection::make_result(
   internal::pq::PGresult *pgr, std::shared_ptr<std::string> const &query,
-  std::string_view desc)
+  std::string_view desc, PQXX_LOC loc)
 {
   std::shared_ptr<internal::pq::PGresult> const smart{
     pgr, internal::clear_result};
@@ -269,12 +269,12 @@ pqxx::result pqxx::connection::make_result(
     if (is_open())
       throw failure(err_msg());
     else
-      throw broken_connection{"Lost connection to the database server."};
+      throw broken_connection{"Lost connection to the database server.", loc};
   }
   auto const enc{internal::enc_group(encoding_id())};
   auto r{pqxx::internal::gate::result_creation::create(
     smart, query, m_notice_waiters, enc)};
-  pqxx::internal::gate::result_creation{r}.check_status(desc);
+  pqxx::internal::gate::result_creation{r}.check_status(desc, loc);
   return r;
 }
 

--- a/src/cursor.cxx
+++ b/src/cursor.cxx
@@ -78,13 +78,13 @@ pqxx::icursorstream::icursorstream(
         m_iterators{nullptr},
         m_done{false}
 {
-  set_stride(sstride);
+  set_stride(sstride, loc);
 }
 
 
 pqxx::icursorstream::icursorstream(
   transaction_base &context, field const &cname, difference_type sstride,
-  cursor_base::ownership_policy op, sl) :
+  cursor_base::ownership_policy op, sl loc) :
         m_cur{context, cname.c_str(), op},
         m_stride{sstride},
         m_realpos{0},
@@ -92,7 +92,7 @@ pqxx::icursorstream::icursorstream(
         m_iterators{nullptr},
         m_done{false}
 {
-  set_stride(sstride);
+  set_stride(sstride, loc);
 }
 
 

--- a/src/cursor.cxx
+++ b/src/cursor.cxx
@@ -63,7 +63,7 @@ pqxx::result pqxx::internal::stateless_cursor_retrieve(
 
 pqxx::icursorstream::icursorstream(
   transaction_base &context, std::string_view query, std::string_view basename,
-  difference_type sstride, PQXX_LOC) :
+  difference_type sstride, PQXX_LOC loc) :
         m_cur{
           context,
           query,
@@ -71,7 +71,8 @@ pqxx::icursorstream::icursorstream(
           cursor_base::forward_only,
           cursor_base::read_only,
           cursor_base::owned,
-          false},
+          false,
+          loc},
         m_stride{sstride},
         m_realpos{0},
         m_reqpos{0},

--- a/src/cursor.cxx
+++ b/src/cursor.cxx
@@ -31,20 +31,21 @@ pqxx::cursor_base::cursor_base(
 
 
 pqxx::result::size_type
-pqxx::internal::obtain_stateless_cursor_size(sql_cursor &cur)
+pqxx::internal::obtain_stateless_cursor_size(sql_cursor &cur, PQXX_LOC loc)
 {
   if (cur.endpos() == -1)
-    cur.move(cursor_base::all());
+    cur.move(cursor_base::all(), loc);
   return result::size_type(cur.endpos() - 1);
 }
 
 
 pqxx::result pqxx::internal::stateless_cursor_retrieve(
   sql_cursor &cur, result::difference_type size,
-  result::difference_type begin_pos, result::difference_type end_pos)
+  result::difference_type begin_pos, result::difference_type end_pos,
+  PQXX_LOC loc)
 {
   if (begin_pos < 0 or begin_pos > size)
-    throw range_error{"Starting position out of range"};
+    throw range_error{"Starting position out of range", loc};
 
   if (end_pos < -1)
     end_pos = -1;
@@ -55,14 +56,14 @@ pqxx::result pqxx::internal::stateless_cursor_retrieve(
     return cur.empty_result();
 
   int const direction{((begin_pos < end_pos) ? 1 : -1)};
-  cur.move((begin_pos - direction) - (cur.pos() - 1));
-  return cur.fetch(end_pos - begin_pos);
+  cur.move((begin_pos - direction) - (cur.pos() - 1), loc);
+  return cur.fetch(end_pos - begin_pos, loc);
 }
 
 
 pqxx::icursorstream::icursorstream(
   transaction_base &context, std::string_view query, std::string_view basename,
-  difference_type sstride) :
+  difference_type sstride, PQXX_LOC) :
         m_cur{
           context,
           query,
@@ -83,7 +84,7 @@ pqxx::icursorstream::icursorstream(
 
 pqxx::icursorstream::icursorstream(
   transaction_base &context, field const &cname, difference_type sstride,
-  cursor_base::ownership_policy op) :
+  cursor_base::ownership_policy op, PQXX_LOC) :
         m_cur{context, cname.c_str(), op},
         m_stride{sstride},
         m_realpos{0},
@@ -95,18 +96,18 @@ pqxx::icursorstream::icursorstream(
 }
 
 
-void pqxx::icursorstream::set_stride(difference_type stride) &
+void pqxx::icursorstream::set_stride(difference_type stride, PQXX_LOC loc) &
 {
   if (stride < 1)
     throw argument_error{
-      internal::concat("Attempt to set cursor stride to ", stride)};
+      internal::concat("Attempt to set cursor stride to ", stride), loc};
   m_stride = stride;
 }
 
 
-pqxx::result pqxx::icursorstream::fetchblock()
+pqxx::result pqxx::icursorstream::fetchblock(PQXX_LOC loc)
 {
-  result r{m_cur.fetch(m_stride)};
+  result r{m_cur.fetch(m_stride, loc)};
   m_realpos += std::size(r);
   if (std::empty(r))
     m_done = true;
@@ -114,9 +115,10 @@ pqxx::result pqxx::icursorstream::fetchblock()
 }
 
 
-pqxx::icursorstream &pqxx::icursorstream::ignore(std::streamsize n) &
+pqxx::icursorstream &
+pqxx::icursorstream::ignore(std::streamsize n, PQXX_LOC loc) &
 {
-  auto offset{m_cur.move(difference_type(n))};
+  auto offset{m_cur.move(difference_type(n), loc)};
   m_realpos += offset;
   if (offset < n)
     m_done = true;
@@ -165,7 +167,8 @@ void pqxx::icursorstream::remove_iterator(icursor_iterator *i) const noexcept
 }
 
 
-void pqxx::icursorstream::service_iterators(difference_type topos)
+void pqxx::icursorstream::service_iterators(
+  difference_type topos, PQXX_LOC loc)
 {
   if (topos < m_realpos)
     return;
@@ -186,7 +189,7 @@ void pqxx::icursorstream::service_iterators(difference_type topos)
     auto const readpos{i->first};
     if (readpos > m_realpos)
       ignore(readpos - m_realpos);
-    result const r{fetchblock()};
+    result const r{fetchblock(loc)};
     for (; i != todo_end and i->first == readpos; ++i)
       pqxx::internal::gate::icursor_iterator_icursorstream{*i->second}.fill(r);
   }
@@ -288,12 +291,14 @@ pqxx::icursor_iterator::operator=(icursor_iterator const &rhs) noexcept
 
 bool pqxx::icursor_iterator::operator==(icursor_iterator const &rhs) const
 {
+  // TODO: How can we pass std::source_location here?
+  auto loc{PQXX_LOC::current()};
   if (m_stream == rhs.m_stream)
     return pos() == rhs.pos();
   if (m_stream != nullptr and rhs.m_stream != nullptr)
     return false;
-  refresh();
-  rhs.refresh();
+  refresh(loc);
+  rhs.refresh(loc);
   return std::empty(m_here) and std::empty(rhs.m_here);
 }
 
@@ -302,17 +307,19 @@ bool pqxx::icursor_iterator::operator<(icursor_iterator const &rhs) const
 {
   if (m_stream == rhs.m_stream)
     return pos() < rhs.pos();
-  refresh();
-  rhs.refresh();
+  // TODO: How can we pass std::source_location here?
+  auto loc{PQXX_LOC::current()};
+  refresh(loc);
+  rhs.refresh(loc);
   return not std::empty(m_here);
 }
 
 
-void pqxx::icursor_iterator::refresh() const
+void pqxx::icursor_iterator::refresh(PQXX_LOC loc) const
 {
   if (m_stream != nullptr)
     pqxx::internal::gate::icursorstream_icursor_iterator{*m_stream}
-      .service_iterators(pos());
+      .service_iterators(pos(), loc);
 }
 
 

--- a/src/encodings.cxx
+++ b/src/encodings.cxx
@@ -165,15 +165,14 @@ PQXX_PURE char const *name_encoding(int encoding_id)
 }
 
 
-encoding_group enc_group(int libpq_enc_id, PQXX_LOC)
+encoding_group enc_group(int libpq_enc_id, sl)
 {
   // TODO: Can we safely do this without using string representation?
   return enc_group(name_encoding(libpq_enc_id));
 }
 
 
-PQXX_PURE glyph_scanner_func *
-get_glyph_scanner(encoding_group enc, PQXX_LOC loc)
+PQXX_PURE glyph_scanner_func *get_glyph_scanner(encoding_group enc, sl loc)
 {
 #define CASE_GROUP(ENC)                                                       \
   case encoding_group::ENC: return glyph_scanner<encoding_group::ENC>::call

--- a/src/encodings.cxx
+++ b/src/encodings.cxx
@@ -165,14 +165,15 @@ PQXX_PURE char const *name_encoding(int encoding_id)
 }
 
 
-encoding_group enc_group(int libpq_enc_id)
+encoding_group enc_group(int libpq_enc_id, PQXX_LOC)
 {
   // TODO: Can we safely do this without using string representation?
   return enc_group(name_encoding(libpq_enc_id));
 }
 
 
-PQXX_PURE glyph_scanner_func *get_glyph_scanner(encoding_group enc)
+PQXX_PURE glyph_scanner_func *
+get_glyph_scanner(encoding_group enc, PQXX_LOC loc)
 {
 #define CASE_GROUP(ENC)                                                       \
   case encoding_group::ENC: return glyph_scanner<encoding_group::ENC>::call
@@ -194,7 +195,7 @@ PQXX_PURE glyph_scanner_func *get_glyph_scanner(encoding_group enc)
     [[likely]] CASE_GROUP(UTF8);
   }
   throw usage_error{
-    internal::concat("Unsupported encoding group code ", enc, ".")};
+    internal::concat("Unsupported encoding group code ", enc, "."), loc};
 
 #undef CASE_GROUP
 }

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -20,8 +20,8 @@ pqxx::failure::failure(std::string const &whatarg, sl loc) :
 {}
 
 
-pqxx::broken_connection::broken_connection() :
-        failure{"Connection to database failed."}
+pqxx::broken_connection::broken_connection(sl loc) :
+        failure{"Connection to database failed.", loc}
 {}
 
 

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -15,7 +15,7 @@
 
 #include "pqxx/internal/header-post.hxx"
 
-pqxx::failure::failure(std::string const &whatarg, std::source_location loc) :
+pqxx::failure::failure(std::string const &whatarg, PQXX_LOC loc) :
         std::runtime_error{whatarg}, location{loc}
 {}
 
@@ -26,26 +26,26 @@ pqxx::broken_connection::broken_connection() :
 
 
 pqxx::broken_connection::broken_connection(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         failure{whatarg, loc}
 {}
 
 
 pqxx::protocol_violation::protocol_violation(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         broken_connection{whatarg, loc}
 {}
 
 
 pqxx::variable_set_to_null::variable_set_to_null(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         failure{whatarg, loc}
 {}
 
 
 pqxx::sql_error::sql_error(
   std::string const &whatarg, std::string Q, char const *sqlstate,
-  std::source_location loc) :
+  PQXX_LOC loc) :
         failure{whatarg, loc},
         m_query{std::move(Q)},
         m_sqlstate{sqlstate ? sqlstate : ""}
@@ -68,35 +68,35 @@ PQXX_PURE std::string const &pqxx::sql_error::sqlstate() const noexcept
 
 
 pqxx::in_doubt_error::in_doubt_error(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         failure{whatarg, loc}
 {}
 
 
 pqxx::transaction_rollback::transaction_rollback(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  std::source_location loc) :
+  PQXX_LOC loc) :
         sql_error{whatarg, q, sqlstate, loc}
 {}
 
 
 pqxx::serialization_failure::serialization_failure(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  std::source_location loc) :
+  PQXX_LOC loc) :
         transaction_rollback{whatarg, q, sqlstate, loc}
 {}
 
 
 pqxx::statement_completion_unknown::statement_completion_unknown(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  std::source_location loc) :
+  PQXX_LOC loc) :
         transaction_rollback{whatarg, q, sqlstate, loc}
 {}
 
 
 pqxx::deadlock_detected::deadlock_detected(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  std::source_location loc) :
+  PQXX_LOC loc) :
         transaction_rollback{whatarg, q, sqlstate, loc}
 {}
 
@@ -109,37 +109,35 @@ pqxx::internal_error::internal_error(
 {}
 
 
-pqxx::usage_error::usage_error(
-  std::string const &whatarg, std::source_location loc) :
+pqxx::usage_error::usage_error(std::string const &whatarg, PQXX_LOC loc) :
         std::logic_error{whatarg}, location{loc}
 {}
 
 
 pqxx::argument_error::argument_error(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         invalid_argument{whatarg}, location{loc}
 {}
 
 
 pqxx::conversion_error::conversion_error(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         domain_error{whatarg}, location{loc}
 {}
 
 
 pqxx::unexpected_null::unexpected_null(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         conversion_error{whatarg, loc}
 {}
 
 
 pqxx::conversion_overrun::conversion_overrun(
-  std::string const &whatarg, std::source_location loc) :
+  std::string const &whatarg, PQXX_LOC loc) :
         conversion_error{whatarg, loc}
 {}
 
 
-pqxx::range_error::range_error(
-  std::string const &whatarg, std::source_location loc) :
+pqxx::range_error::range_error(std::string const &whatarg, PQXX_LOC loc) :
         out_of_range{whatarg}, location{loc}
 {}

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -15,7 +15,7 @@
 
 #include "pqxx/internal/header-post.hxx"
 
-pqxx::failure::failure(std::string const &whatarg, PQXX_LOC loc) :
+pqxx::failure::failure(std::string const &whatarg, sl loc) :
         std::runtime_error{whatarg}, location{loc}
 {}
 
@@ -26,26 +26,25 @@ pqxx::broken_connection::broken_connection() :
 
 
 pqxx::broken_connection::broken_connection(
-  std::string const &whatarg, PQXX_LOC loc) :
+  std::string const &whatarg, sl loc) :
         failure{whatarg, loc}
 {}
 
 
 pqxx::protocol_violation::protocol_violation(
-  std::string const &whatarg, PQXX_LOC loc) :
+  std::string const &whatarg, sl loc) :
         broken_connection{whatarg, loc}
 {}
 
 
 pqxx::variable_set_to_null::variable_set_to_null(
-  std::string const &whatarg, PQXX_LOC loc) :
+  std::string const &whatarg, sl loc) :
         failure{whatarg, loc}
 {}
 
 
 pqxx::sql_error::sql_error(
-  std::string const &whatarg, std::string Q, char const *sqlstate,
-  PQXX_LOC loc) :
+  std::string const &whatarg, std::string Q, char const *sqlstate, sl loc) :
         failure{whatarg, loc},
         m_query{std::move(Q)},
         m_sqlstate{sqlstate ? sqlstate : ""}
@@ -67,77 +66,72 @@ PQXX_PURE std::string const &pqxx::sql_error::sqlstate() const noexcept
 }
 
 
-pqxx::in_doubt_error::in_doubt_error(
-  std::string const &whatarg, PQXX_LOC loc) :
+pqxx::in_doubt_error::in_doubt_error(std::string const &whatarg, sl loc) :
         failure{whatarg, loc}
 {}
 
 
 pqxx::transaction_rollback::transaction_rollback(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  PQXX_LOC loc) :
+  sl loc) :
         sql_error{whatarg, q, sqlstate, loc}
 {}
 
 
 pqxx::serialization_failure::serialization_failure(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  PQXX_LOC loc) :
+  sl loc) :
         transaction_rollback{whatarg, q, sqlstate, loc}
 {}
 
 
 pqxx::statement_completion_unknown::statement_completion_unknown(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  PQXX_LOC loc) :
+  sl loc) :
         transaction_rollback{whatarg, q, sqlstate, loc}
 {}
 
 
 pqxx::deadlock_detected::deadlock_detected(
   std::string const &whatarg, std::string const &q, char const sqlstate[],
-  PQXX_LOC loc) :
+  sl loc) :
         transaction_rollback{whatarg, q, sqlstate, loc}
 {}
 
 
-pqxx::internal_error::internal_error(
-  std::string const &whatarg, PQXX_LOC loc) :
+pqxx::internal_error::internal_error(std::string const &whatarg, sl loc) :
         std::logic_error{
           internal::concat("libpqxx internal error: ", whatarg)},
         location{loc}
 {}
 
 
-pqxx::usage_error::usage_error(std::string const &whatarg, PQXX_LOC loc) :
+pqxx::usage_error::usage_error(std::string const &whatarg, sl loc) :
         std::logic_error{whatarg}, location{loc}
 {}
 
 
-pqxx::argument_error::argument_error(
-  std::string const &whatarg, PQXX_LOC loc) :
+pqxx::argument_error::argument_error(std::string const &whatarg, sl loc) :
         invalid_argument{whatarg}, location{loc}
 {}
 
 
-pqxx::conversion_error::conversion_error(
-  std::string const &whatarg, PQXX_LOC loc) :
+pqxx::conversion_error::conversion_error(std::string const &whatarg, sl loc) :
         domain_error{whatarg}, location{loc}
 {}
 
 
-pqxx::unexpected_null::unexpected_null(
-  std::string const &whatarg, PQXX_LOC loc) :
+pqxx::unexpected_null::unexpected_null(std::string const &whatarg, sl loc) :
         conversion_error{whatarg, loc}
 {}
 
 
 pqxx::conversion_overrun::conversion_overrun(
-  std::string const &whatarg, PQXX_LOC loc) :
+  std::string const &whatarg, sl loc) :
         conversion_error{whatarg, loc}
 {}
 
 
-pqxx::range_error::range_error(std::string const &whatarg, PQXX_LOC loc) :
+pqxx::range_error::range_error(std::string const &whatarg, sl loc) :
         out_of_range{whatarg}, location{loc}
 {}

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -101,9 +101,11 @@ pqxx::deadlock_detected::deadlock_detected(
 {}
 
 
-pqxx::internal_error::internal_error(std::string const &whatarg, PQXX_LOC loc) :
-        std::logic_error{internal::concat("libpqxx internal error: ", whatarg)},
-	location{loc}
+pqxx::internal_error::internal_error(
+  std::string const &whatarg, PQXX_LOC loc) :
+        std::logic_error{
+          internal::concat("libpqxx internal error: ", whatarg)},
+        location{loc}
 {}
 
 

--- a/src/except.cxx
+++ b/src/except.cxx
@@ -101,8 +101,9 @@ pqxx::deadlock_detected::deadlock_detected(
 {}
 
 
-pqxx::internal_error::internal_error(std::string const &whatarg) :
-        std::logic_error{internal::concat("libpqxx internal error: ", whatarg)}
+pqxx::internal_error::internal_error(std::string const &whatarg, PQXX_LOC loc) :
+        std::logic_error{internal::concat("libpqxx internal error: ", whatarg)},
+	location{loc}
 {}
 
 

--- a/src/field.cxx
+++ b/src/field.cxx
@@ -38,25 +38,25 @@ bool PQXX_COLD pqxx::field::operator==(field const &rhs) const noexcept
 }
 
 
-char const *pqxx::field::name(PQXX_LOC loc) const &
+char const *pqxx::field::name(sl loc) const &
 {
   return home().column_name(col(), loc);
 }
 
 
-pqxx::oid pqxx::field::type(PQXX_LOC loc) const
+pqxx::oid pqxx::field::type(sl loc) const
 {
   return home().column_type(col(), loc);
 }
 
 
-pqxx::oid pqxx::field::table(PQXX_LOC loc) const
+pqxx::oid pqxx::field::table(sl loc) const
 {
   return home().column_table(col(), loc);
 }
 
 
-pqxx::row::size_type pqxx::field::table_column(PQXX_LOC loc) const
+pqxx::row::size_type pqxx::field::table_column(sl loc) const
 {
   return home().table_column(col(), loc);
 }

--- a/src/field.cxx
+++ b/src/field.cxx
@@ -38,31 +38,31 @@ bool PQXX_COLD pqxx::field::operator==(field const &rhs) const noexcept
 }
 
 
-char const *pqxx::field::name() const &
+char const *pqxx::field::name(PQXX_LOC loc) const &
 {
-  return home().column_name(col());
+  return home().column_name(col(), loc);
 }
 
 
-pqxx::oid pqxx::field::type() const
+pqxx::oid pqxx::field::type(PQXX_LOC loc) const
 {
-  return home().column_type(col());
+  return home().column_type(col(), loc);
 }
 
 
-pqxx::oid pqxx::field::table() const
+pqxx::oid pqxx::field::table(PQXX_LOC loc) const
 {
-  return home().column_table(col());
+  return home().column_table(col(), loc);
 }
 
 
-pqxx::row::size_type pqxx::field::table_column() const
+pqxx::row::size_type pqxx::field::table_column(PQXX_LOC loc) const
 {
-  return home().table_column(col());
+  return home().table_column(col(), loc);
 }
 
 
-char const *pqxx::field::c_str() const &
+char const *pqxx::field::c_str() const & noexcept
 {
   return home().get_value(idx(), col());
 }

--- a/src/notification.cxx
+++ b/src/notification.cxx
@@ -32,7 +32,7 @@ pqxx::notification_receiver::notification_receiver(
 pqxx::notification_receiver::~notification_receiver()
 {
   // TODO: How can we pass std::source_location here?
-  auto loc{PQXX_LOC::current()};
+  auto loc{sl::current()};
   pqxx::internal::gate::connection_notification_receiver{this->conn()}
     .remove_receiver(this, loc);
 }

--- a/src/notification.cxx
+++ b/src/notification.cxx
@@ -31,6 +31,8 @@ pqxx::notification_receiver::notification_receiver(
 
 pqxx::notification_receiver::~notification_receiver()
 {
+  // TODO: How can we pass std::source_location here?
+  auto loc{PQXX_LOC::current()};
   pqxx::internal::gate::connection_notification_receiver{this->conn()}
-    .remove_receiver(this);
+    .remove_receiver(this, loc);
 }

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -80,13 +80,13 @@ void pqxx::params::append(params &&value) &
 }
 
 
-pqxx::internal::c_params pqxx::params::make_c_params() const
+pqxx::internal::c_params pqxx::params::make_c_params(sl loc) const
 {
   pqxx::internal::c_params p;
   p.reserve(std::size(m_params));
   for (auto const &param : m_params)
     std::visit(
-      [&p](auto const &value) {
+      [&p, loc](auto const &value) {
         using T = std::remove_cvref_t<decltype(value)>;
 
         if constexpr (std::is_same_v<T, std::nullptr_t>)
@@ -97,7 +97,8 @@ pqxx::internal::c_params pqxx::params::make_c_params() const
         else
         {
           p.values.push_back(reinterpret_cast<char const *>(std::data(value)));
-          p.lengths.push_back(check_cast<int>(std::ssize(value), s_overflow));
+          p.lengths.push_back(
+            check_cast<int>(std::ssize(value), s_overflow, loc));
         }
 
         p.formats.push_back(param_format(value));

--- a/src/pipeline.cxx
+++ b/src/pipeline.cxx
@@ -35,9 +35,9 @@ constexpr std::string_view theSeparator{"; "sv}, theDummyValue{"1"sv},
 } // namespace
 
 
-void pqxx::pipeline::init()
+void pqxx::pipeline::init(PQXX_LOC loc)
 {
-  m_encoding = internal::enc_group(m_trans->conn().encoding_id());
+  m_encoding = internal::enc_group(m_trans->conn().encoding_id(), loc);
   m_issuedrange = make_pair(std::end(m_queries), std::end(m_queries));
   attach();
 }

--- a/src/pipeline.cxx
+++ b/src/pipeline.cxx
@@ -35,7 +35,7 @@ constexpr std::string_view theSeparator{"; "sv}, theDummyValue{"1"sv},
 } // namespace
 
 
-void pqxx::pipeline::init(PQXX_LOC loc)
+void pqxx::pipeline::init(sl loc)
 {
   m_encoding = internal::enc_group(m_trans->conn().encoding_id(), loc);
   m_issuedrange = make_pair(std::end(m_queries), std::end(m_queries));
@@ -147,7 +147,7 @@ bool pqxx::pipeline::is_finished(pipeline::query_id q) const
 
 
 std::pair<pqxx::pipeline::query_id, pqxx::result>
-pqxx::pipeline::retrieve(PQXX_LOC loc)
+pqxx::pipeline::retrieve(sl loc)
 {
   if (std::empty(m_queries))
     throw std::logic_error{"Attempt to retrieve result from empty pipeline."};
@@ -225,8 +225,7 @@ void pqxx::pipeline::issue()
 }
 
 
-void PQXX_COLD
-pqxx::pipeline::internal_error(std::string const &err, PQXX_LOC loc)
+void PQXX_COLD pqxx::pipeline::internal_error(std::string const &err, sl loc)
 {
   set_error_at(0);
   throw pqxx::internal_error{err, loc};
@@ -271,7 +270,7 @@ bool pqxx::pipeline::obtain_result(bool expect_none)
 }
 
 
-void pqxx::pipeline::obtain_dummy(PQXX_LOC loc)
+void pqxx::pipeline::obtain_dummy(sl loc)
 {
   // Allocate once, re-use across invocations.
   static auto const text{
@@ -361,7 +360,7 @@ void pqxx::pipeline::obtain_dummy(PQXX_LOC loc)
 
 
 std::pair<pqxx::pipeline::query_id, pqxx::result>
-pqxx::pipeline::retrieve(pipeline::QueryMap::iterator q, PQXX_LOC loc)
+pqxx::pipeline::retrieve(pipeline::QueryMap::iterator q, sl loc)
 {
   if (q == std::end(m_queries))
     throw std::logic_error{"Attempt to retrieve result for unknown query."};

--- a/src/pipeline.cxx
+++ b/src/pipeline.cxx
@@ -135,7 +135,7 @@ void PQXX_COLD pqxx::pipeline::cancel()
 }
 
 
-bool pqxx::pipeline::is_finished(pipeline::query_id q) const
+bool pqxx::pipeline::is_finished(pipeline::query_id q, PQXX_LOC loc) const
 {
   if (not m_queries.contains(q))
     throw std::logic_error{
@@ -146,11 +146,12 @@ bool pqxx::pipeline::is_finished(pipeline::query_id q) const
 }
 
 
-std::pair<pqxx::pipeline::query_id, pqxx::result> pqxx::pipeline::retrieve()
+std::pair<pqxx::pipeline::query_id, pqxx::result>
+pqxx::pipeline::retrieve(PQXX_LOC loc)
 {
   if (std::empty(m_queries))
     throw std::logic_error{"Attempt to retrieve result from empty pipeline."};
-  return retrieve(std::begin(m_queries));
+  return retrieve(std::begin(m_queries), loc);
 }
 
 
@@ -359,7 +360,7 @@ void pqxx::pipeline::obtain_dummy()
 
 
 std::pair<pqxx::pipeline::query_id, pqxx::result>
-pqxx::pipeline::retrieve(pipeline::QueryMap::iterator q)
+pqxx::pipeline::retrieve(pipeline::QueryMap::iterator q, PQXX_LOC loc)
 {
   if (q == std::end(m_queries))
     throw std::logic_error{"Attempt to retrieve result for unknown query."};

--- a/src/pipeline.cxx
+++ b/src/pipeline.cxx
@@ -46,7 +46,7 @@ void pqxx::pipeline::init(sl loc)
 pqxx::pipeline::~pipeline() noexcept
 {
   // TODO: How can we pass std::source_location here?
-  sl loc{sl::current()};
+  sl const loc{sl::current()};
   try
   {
     cancel(loc);

--- a/src/pipeline.cxx
+++ b/src/pipeline.cxx
@@ -135,7 +135,7 @@ void PQXX_COLD pqxx::pipeline::cancel()
 }
 
 
-bool pqxx::pipeline::is_finished(pipeline::query_id q, PQXX_LOC loc) const
+bool pqxx::pipeline::is_finished(pipeline::query_id q) const
 {
   if (not m_queries.contains(q))
     throw std::logic_error{

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -345,12 +345,15 @@ std::string pqxx::result::status_error(PQXX_LOC loc) const
     break;
 
   case PGRES_SINGLE_TUPLE:
-    throw feature_not_supported{"Not supported: single-row mode.", loc};
+    throw feature_not_supported{
+      "Not supported: single-row mode.", nullptr, loc};
 
   default:
-    throw internal_error{internal::concat(
-      "pqxx::result: Unrecognized result status code ",
-      PQresultStatus(m_data.get())), loc};
+    throw internal_error{
+      internal::concat(
+        "pqxx::result: Unrecognized result status code ",
+        PQresultStatus(m_data.get())),
+      loc};
   }
   return err;
 }

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -413,29 +413,29 @@ pqxx::field::size_type pqxx::result::get_length(
 }
 
 
-pqxx::oid pqxx::result::column_type(row::size_type col_num) const
+pqxx::oid pqxx::result::column_type(row::size_type col_num, PQXX_LOC loc) const
 {
   oid const t{PQftype(m_data.get(), col_num)};
   if (t == oid_none)
     throw argument_error{internal::concat(
       "Attempt to retrieve type of nonexistent column ", col_num,
-      " of query result.")};
+      " of query result."), loc};
   return t;
 }
 
 
-pqxx::row::size_type pqxx::result::column_number(zview col_name) const
+pqxx::row::size_type pqxx::result::column_number(zview col_name, PQXX_LOC loc) const
 {
   auto const n{PQfnumber(m_data.get(), col_name.c_str())};
   if (n == -1)
     throw argument_error{
-      internal::concat("Unknown column name: '", col_name, "'.")};
+      internal::concat("Unknown column name: '", col_name, "'."), loc};
 
   return static_cast<row::size_type>(n);
 }
 
 
-pqxx::oid pqxx::result::column_table(row::size_type col_num) const
+pqxx::oid pqxx::result::column_table(row::size_type col_num, PQXX_LOC loc) const
 {
   oid const t{PQftable(m_data.get(), col_num)};
 
@@ -445,13 +445,13 @@ pqxx::oid pqxx::result::column_table(row::size_type col_num) const
   if (t == oid_none and col_num >= columns())
     throw argument_error{internal::concat(
       "Attempt to retrieve table ID for column ", col_num, " out of ",
-      columns())};
+      columns()), loc};
 
   return t;
 }
 
 
-pqxx::row::size_type pqxx::result::table_column(row::size_type col_num) const
+pqxx::row::size_type pqxx::result::table_column(row::size_type col_num, PQXX_LOC loc) const
 {
   auto const n{row::size_type(PQftablecol(m_data.get(), col_num))};
   if (n != 0) [[likely]]
@@ -461,16 +461,16 @@ pqxx::row::size_type pqxx::result::table_column(row::size_type col_num) const
   auto const col_str{to_string(col_num)};
   if (col_num > columns())
     throw range_error{
-      internal::concat("Invalid column index in table_column(): ", col_str)};
+      internal::concat("Invalid column index in table_column(): ", col_str), loc};
 
   if (m_data.get() == nullptr)
     throw usage_error{internal::concat(
       "Can't query origin of column ", col_str,
-      ": result is not initialized.")};
+      ": result is not initialized."), loc};
 
   throw usage_error{internal::concat(
     "Can't query origin of column ", col_str,
-    ": not derived from table column.")};
+    ": not derived from table column."), loc};
 }
 
 
@@ -487,16 +487,16 @@ int pqxx::result::errorposition() const
 }
 
 
-char const *pqxx::result::column_name(pqxx::row::size_type number) const &
+char const *pqxx::result::column_name(pqxx::row::size_type number, PQXX_LOC loc) const &
 {
   auto const n{PQfname(m_data.get(), number)};
   if (n == nullptr) [[unlikely]]
   {
     if (m_data.get() == nullptr)
-      throw usage_error{"Queried column name on null result."};
+      throw usage_error{"Queried column name on null result.", loc};
     throw range_error{internal::concat(
       "Invalid column number: ", number, " (maximum is ", (columns() - 1),
-      ").")};
+      ")."), loc};
   }
   return n;
 }

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -318,7 +318,7 @@ void pqxx::result::check_status(std::string_view desc, PQXX_LOC loc) const
 std::string pqxx::result::status_error(PQXX_LOC loc) const
 {
   if (m_data.get() == nullptr)
-    throw failure{"No result set given."};
+    throw failure{"No result set given.", loc};
 
   std::string err;
 
@@ -335,7 +335,7 @@ std::string pqxx::result::status_error(PQXX_LOC loc) const
 #if defined(LIBPQ_HAS_PIPELINING)
   case PGRES_PIPELINE_SYNC:    // Pipeline mode synchronisation point.
   case PGRES_PIPELINE_ABORTED: // Previous command in pipeline failed.
-    throw feature_not_supported{"Not supported yet: libpq pipelines."};
+    throw feature_not_supported{"Not supported yet: libpq pipelines.", loc};
 #endif
 
   case PGRES_BAD_RESPONSE: // The server's response was not understood.
@@ -345,12 +345,12 @@ std::string pqxx::result::status_error(PQXX_LOC loc) const
     break;
 
   case PGRES_SINGLE_TUPLE:
-    throw feature_not_supported{"Not supported: single-row mode."};
+    throw feature_not_supported{"Not supported: single-row mode.", loc};
 
   default:
     throw internal_error{internal::concat(
       "pqxx::result: Unrecognized result status code ",
-      PQresultStatus(m_data.get()))};
+      PQresultStatus(m_data.get())), loc};
   }
   return err;
 }

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -335,7 +335,8 @@ std::string pqxx::result::status_error(PQXX_LOC loc) const
 #if defined(LIBPQ_HAS_PIPELINING)
   case PGRES_PIPELINE_SYNC:    // Pipeline mode synchronisation point.
   case PGRES_PIPELINE_ABORTED: // Previous command in pipeline failed.
-    throw feature_not_supported{"Not supported yet: libpq pipelines.", loc};
+    throw feature_not_supported{
+      "Not supported yet: libpq pipelines.", "", nullptr, loc};
 #endif
 
   case PGRES_BAD_RESPONSE: // The server's response was not understood.
@@ -346,7 +347,7 @@ std::string pqxx::result::status_error(PQXX_LOC loc) const
 
   case PGRES_SINGLE_TUPLE:
     throw feature_not_supported{
-      "Not supported: single-row mode.", nullptr, loc};
+      "Not supported: single-row mode.", "", nullptr, loc};
 
   default:
     throw internal_error{

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -417,14 +417,17 @@ pqxx::oid pqxx::result::column_type(row::size_type col_num, PQXX_LOC loc) const
 {
   oid const t{PQftype(m_data.get(), col_num)};
   if (t == oid_none)
-    throw argument_error{internal::concat(
-      "Attempt to retrieve type of nonexistent column ", col_num,
-      " of query result."), loc};
+    throw argument_error{
+      internal::concat(
+        "Attempt to retrieve type of nonexistent column ", col_num,
+        " of query result."),
+      loc};
   return t;
 }
 
 
-pqxx::row::size_type pqxx::result::column_number(zview col_name, PQXX_LOC loc) const
+pqxx::row::size_type
+pqxx::result::column_number(zview col_name, PQXX_LOC loc) const
 {
   auto const n{PQfnumber(m_data.get(), col_name.c_str())};
   if (n == -1)
@@ -435,7 +438,8 @@ pqxx::row::size_type pqxx::result::column_number(zview col_name, PQXX_LOC loc) c
 }
 
 
-pqxx::oid pqxx::result::column_table(row::size_type col_num, PQXX_LOC loc) const
+pqxx::oid
+pqxx::result::column_table(row::size_type col_num, PQXX_LOC loc) const
 {
   oid const t{PQftable(m_data.get(), col_num)};
 
@@ -443,15 +447,18 @@ pqxx::oid pqxx::result::column_table(row::size_type col_num, PQXX_LOC loc) const
    * we got an invalid row number.
    */
   if (t == oid_none and col_num >= columns())
-    throw argument_error{internal::concat(
-      "Attempt to retrieve table ID for column ", col_num, " out of ",
-      columns()), loc};
+    throw argument_error{
+      internal::concat(
+        "Attempt to retrieve table ID for column ", col_num, " out of ",
+        columns()),
+      loc};
 
   return t;
 }
 
 
-pqxx::row::size_type pqxx::result::table_column(row::size_type col_num, PQXX_LOC loc) const
+pqxx::row::size_type
+pqxx::result::table_column(row::size_type col_num, PQXX_LOC loc) const
 {
   auto const n{row::size_type(PQftablecol(m_data.get(), col_num))};
   if (n != 0) [[likely]]
@@ -461,16 +468,21 @@ pqxx::row::size_type pqxx::result::table_column(row::size_type col_num, PQXX_LOC
   auto const col_str{to_string(col_num)};
   if (col_num > columns())
     throw range_error{
-      internal::concat("Invalid column index in table_column(): ", col_str), loc};
+      internal::concat("Invalid column index in table_column(): ", col_str),
+      loc};
 
   if (m_data.get() == nullptr)
-    throw usage_error{internal::concat(
-      "Can't query origin of column ", col_str,
-      ": result is not initialized."), loc};
+    throw usage_error{
+      internal::concat(
+        "Can't query origin of column ", col_str,
+        ": result is not initialized."),
+      loc};
 
-  throw usage_error{internal::concat(
-    "Can't query origin of column ", col_str,
-    ": not derived from table column."), loc};
+  throw usage_error{
+    internal::concat(
+      "Can't query origin of column ", col_str,
+      ": not derived from table column."),
+    loc};
 }
 
 
@@ -487,16 +499,19 @@ int pqxx::result::errorposition() const
 }
 
 
-char const *pqxx::result::column_name(pqxx::row::size_type number, PQXX_LOC loc) const &
+char const *
+pqxx::result::column_name(pqxx::row::size_type number, PQXX_LOC loc) const &
 {
   auto const n{PQfname(m_data.get(), number)};
   if (n == nullptr) [[unlikely]]
   {
     if (m_data.get() == nullptr)
       throw usage_error{"Queried column name on null result.", loc};
-    throw range_error{internal::concat(
-      "Invalid column number: ", number, " (maximum is ", (columns() - 1),
-      ")."), loc};
+    throw range_error{
+      internal::concat(
+        "Invalid column number: ", number, " (maximum is ", (columns() - 1),
+        ")."),
+      loc};
   }
   return n;
 }

--- a/src/result.cxx
+++ b/src/result.cxx
@@ -159,7 +159,7 @@ pqxx::field pqxx::result::operator[](
 #endif // PQXX_HAVE_MULTIDIM
 
 
-pqxx::row pqxx::result::at(pqxx::result::size_type i, PQXX_LOC loc) const
+pqxx::row pqxx::result::at(pqxx::result::size_type i, sl loc) const
 {
   if (i >= size())
     throw range_error{"Row number out of range.", loc};
@@ -168,8 +168,7 @@ pqxx::row pqxx::result::at(pqxx::result::size_type i, PQXX_LOC loc) const
 
 
 pqxx::field pqxx::result::at(
-  pqxx::result_size_type row_num, pqxx::row_size_type col_num,
-  PQXX_LOC loc) const
+  pqxx::result_size_type row_num, pqxx::row_size_type col_num, sl loc) const
 {
   if (row_num >= size())
     throw range_error{"Row number out of range.", loc};
@@ -189,7 +188,7 @@ inline bool equal(char const lhs[], char const rhs[])
 } // namespace
 
 void PQXX_COLD pqxx::result::throw_sql_error(
-  std::string const &Err, std::string const &Query, PQXX_LOC loc) const
+  std::string const &Err, std::string const &Query, sl loc) const
 {
   // Try to establish more precise error type, and throw corresponding
   // type of exception.
@@ -304,7 +303,7 @@ void PQXX_COLD pqxx::result::throw_sql_error(
   throw sql_error{Err, Query, code, loc};
 }
 
-void pqxx::result::check_status(std::string_view desc, PQXX_LOC loc) const
+void pqxx::result::check_status(std::string_view desc, sl loc) const
 {
   if (auto err{status_error(loc)}; not std::empty(err)) [[unlikely]]
   {
@@ -315,7 +314,7 @@ void pqxx::result::check_status(std::string_view desc, PQXX_LOC loc) const
 }
 
 
-std::string pqxx::result::status_error(PQXX_LOC loc) const
+std::string pqxx::result::status_error(sl loc) const
 {
   if (m_data.get() == nullptr)
     throw failure{"No result set given.", loc};
@@ -376,7 +375,7 @@ std::string const &pqxx::result::query() const & noexcept
 }
 
 
-pqxx::oid pqxx::result::inserted_oid(PQXX_LOC loc) const
+pqxx::oid pqxx::result::inserted_oid(sl loc) const
 {
   if (m_data.get() == nullptr)
     throw usage_error{
@@ -418,7 +417,7 @@ pqxx::field::size_type pqxx::result::get_length(
 }
 
 
-pqxx::oid pqxx::result::column_type(row::size_type col_num, PQXX_LOC loc) const
+pqxx::oid pqxx::result::column_type(row::size_type col_num, sl loc) const
 {
   oid const t{PQftype(m_data.get(), col_num)};
   if (t == oid_none)
@@ -431,8 +430,7 @@ pqxx::oid pqxx::result::column_type(row::size_type col_num, PQXX_LOC loc) const
 }
 
 
-pqxx::row::size_type
-pqxx::result::column_number(zview col_name, PQXX_LOC loc) const
+pqxx::row::size_type pqxx::result::column_number(zview col_name, sl loc) const
 {
   auto const n{PQfnumber(m_data.get(), col_name.c_str())};
   if (n == -1)
@@ -443,8 +441,7 @@ pqxx::result::column_number(zview col_name, PQXX_LOC loc) const
 }
 
 
-pqxx::oid
-pqxx::result::column_table(row::size_type col_num, PQXX_LOC loc) const
+pqxx::oid pqxx::result::column_table(row::size_type col_num, sl loc) const
 {
   oid const t{PQftable(m_data.get(), col_num)};
 
@@ -463,7 +460,7 @@ pqxx::result::column_table(row::size_type col_num, PQXX_LOC loc) const
 
 
 pqxx::row::size_type
-pqxx::result::table_column(row::size_type col_num, PQXX_LOC loc) const
+pqxx::result::table_column(row::size_type col_num, sl loc) const
 {
   auto const n{row::size_type(PQftablecol(m_data.get(), col_num))};
   if (n != 0) [[likely]]
@@ -505,7 +502,7 @@ int pqxx::result::errorposition() const
 
 
 char const *
-pqxx::result::column_name(pqxx::row::size_type number, PQXX_LOC loc) const &
+pqxx::result::column_name(pqxx::row::size_type number, sl loc) const &
 {
   auto const n{PQfname(m_data.get(), number)};
   if (n == nullptr) [[unlikely]]
@@ -528,8 +525,7 @@ pqxx::row::size_type pqxx::result::columns() const noexcept
 }
 
 
-int pqxx::result::column_storage(
-  pqxx::row::size_type number, PQXX_LOC loc) const
+int pqxx::result::column_storage(pqxx::row::size_type number, sl loc) const
 {
   int const out{PQfsize(m_data.get(), number)};
   if (out == 0)
@@ -556,7 +552,7 @@ int pqxx::result::column_type_modifier(
 }
 
 
-pqxx::row pqxx::result::one_row(PQXX_LOC loc) const
+pqxx::row pqxx::result::one_row(sl loc) const
 {
   auto const sz{size()};
   if (sz != 1)
@@ -576,14 +572,14 @@ pqxx::row pqxx::result::one_row(PQXX_LOC loc) const
 }
 
 
-pqxx::field pqxx::result::one_field(PQXX_LOC loc) const
+pqxx::field pqxx::result::one_field(sl loc) const
 {
   expect_columns(1, loc);
   return one_row(loc)[0];
 }
 
 
-std::optional<pqxx::row> pqxx::result::opt_row(PQXX_LOC loc) const
+std::optional<pqxx::row> pqxx::result::opt_row(sl loc) const
 {
   auto const sz{size()};
   if (sz > 1)

--- a/src/robusttransaction.cxx
+++ b/src/robusttransaction.cxx
@@ -84,7 +84,7 @@ tx_stat query_status(
   auto const status_field{status_row[0]};
   if (std::size(status_field) == 0)
     throw pqxx::internal_error{"Transaction status string is empty.", loc};
-  auto const status{parse_status(status_field.as<std::string_view>())};
+  auto const status{parse_status(status_field.as<std::string_view>(loc))};
   if (status == tx_unknown)
     throw pqxx::internal_error{
       pqxx::internal::concat(

--- a/src/robusttransaction.cxx
+++ b/src/robusttransaction.cxx
@@ -74,7 +74,7 @@ constexpr tx_stat parse_status(std::string_view text) noexcept
 
 tx_stat query_status(
   std::string const &xid, std::string const &conn_str,
-  PQXX_LOC loc = PQXX_LOC::current())
+  pqxx::sl loc = pqxx::sl::current())
 {
   static std::string const name{"robusttxck"sv};
   auto const query{pqxx::internal::concat("SELECT txid_status(", xid, ")")};
@@ -95,8 +95,7 @@ tx_stat query_status(
 } // namespace
 
 
-void pqxx::internal::basic_robusttransaction::init(
-  zview begin_command, PQXX_LOC loc)
+void pqxx::internal::basic_robusttransaction::init(zview begin_command, sl loc)
 {
   static auto const txid_q{
     std::make_shared<std::string>("SELECT txid_current()"sv)};
@@ -107,7 +106,7 @@ void pqxx::internal::basic_robusttransaction::init(
 
 
 pqxx::internal::basic_robusttransaction::basic_robusttransaction(
-  connection &cx, zview begin_command, std::string_view tname, PQXX_LOC loc) :
+  connection &cx, zview begin_command, std::string_view tname, sl loc) :
         dbtransaction(cx, tname), m_conn_string{cx.connection_string()}
 {
   init(begin_command, loc);
@@ -115,7 +114,7 @@ pqxx::internal::basic_robusttransaction::basic_robusttransaction(
 
 
 pqxx::internal::basic_robusttransaction::basic_robusttransaction(
-  connection &cx, zview begin_command, PQXX_LOC loc) :
+  connection &cx, zview begin_command, sl loc) :
         dbtransaction(cx), m_conn_string{cx.connection_string()}
 {
   init(begin_command, loc);
@@ -125,7 +124,7 @@ pqxx::internal::basic_robusttransaction::basic_robusttransaction(
 pqxx::internal::basic_robusttransaction::~basic_robusttransaction() = default;
 
 
-void pqxx::internal::basic_robusttransaction::do_commit(PQXX_LOC loc)
+void pqxx::internal::basic_robusttransaction::do_commit(sl loc)
 {
   static auto const check_constraints_q{
     std::make_shared<std::string>("SET CONSTRAINTS ALL IMMEDIATE"sv)},

--- a/src/row.cxx
+++ b/src/row.cxx
@@ -114,7 +114,8 @@ pqxx::row::reference pqxx::row::operator[](size_type i) const noexcept
 
 pqxx::row::reference pqxx::row::operator[](zview col_name) const
 {
-  return at(col_name);
+  sl loc{sl::current()};
+  return at(col_name, loc);
 }
 
 

--- a/src/row.cxx
+++ b/src/row.cxx
@@ -130,42 +130,44 @@ void pqxx::row::swap(row &rhs) noexcept
 }
 
 
-pqxx::field pqxx::row::at(zview col_name) const
+pqxx::field pqxx::row::at(zview col_name, PQXX_LOC loc) const
 {
-  return {m_result, m_index, column_number(col_name)};
+  return {m_result, m_index, column_number(col_name, loc)};
 }
 
 
-pqxx::field pqxx::row::at(pqxx::row::size_type i) const
+pqxx::field pqxx::row::at(pqxx::row::size_type i, PQXX_LOC loc) const
 {
   if (i >= size())
-    throw range_error{"Invalid field number."};
+    throw range_error{"Invalid field number.", loc};
 
   return operator[](i);
 }
 
 
-pqxx::oid pqxx::row::column_type(size_type col_num) const
+pqxx::oid pqxx::row::column_type(size_type col_num, PQXX_LOC loc) const
 {
-  return m_result.column_type(col_num);
+  return m_result.column_type(col_num, loc);
 }
 
 
-pqxx::oid pqxx::row::column_table(size_type col_num) const
+pqxx::oid pqxx::row::column_table(size_type col_num, PQXX_LOC loc) const
 {
-  return m_result.column_table(col_num);
+  return m_result.column_table(col_num, loc);
 }
 
 
-pqxx::row::size_type pqxx::row::table_column(size_type col_num) const
+pqxx::row::size_type
+pqxx::row::table_column(size_type col_num, PQXX_LOC loc) const
 {
-  return m_result.table_column(col_num);
+  return m_result.table_column(col_num, loc);
 }
 
 
-pqxx::row::size_type pqxx::row::column_number(zview col_name) const
+pqxx::row::size_type
+pqxx::row::column_number(zview col_name, PQXX_LOC loc) const
 {
-  return m_result.column_number(col_name);
+  return m_result.column_number(col_name, loc);
 }
 
 

--- a/src/row.cxx
+++ b/src/row.cxx
@@ -114,7 +114,7 @@ pqxx::row::reference pqxx::row::operator[](size_type i) const noexcept
 
 pqxx::row::reference pqxx::row::operator[](zview col_name) const
 {
-  sl loc{sl::current()};
+  sl const loc{sl::current()};
   return at(col_name, loc);
 }
 

--- a/src/row.cxx
+++ b/src/row.cxx
@@ -130,13 +130,13 @@ void pqxx::row::swap(row &rhs) noexcept
 }
 
 
-pqxx::field pqxx::row::at(zview col_name, PQXX_LOC loc) const
+pqxx::field pqxx::row::at(zview col_name, sl loc) const
 {
   return {m_result, m_index, column_number(col_name, loc)};
 }
 
 
-pqxx::field pqxx::row::at(pqxx::row::size_type i, PQXX_LOC loc) const
+pqxx::field pqxx::row::at(pqxx::row::size_type i, sl loc) const
 {
   if (i >= size())
     throw range_error{"Invalid field number.", loc};
@@ -145,27 +145,25 @@ pqxx::field pqxx::row::at(pqxx::row::size_type i, PQXX_LOC loc) const
 }
 
 
-pqxx::oid pqxx::row::column_type(size_type col_num, PQXX_LOC loc) const
+pqxx::oid pqxx::row::column_type(size_type col_num, sl loc) const
 {
   return m_result.column_type(col_num, loc);
 }
 
 
-pqxx::oid pqxx::row::column_table(size_type col_num, PQXX_LOC loc) const
+pqxx::oid pqxx::row::column_table(size_type col_num, sl loc) const
 {
   return m_result.column_table(col_num, loc);
 }
 
 
-pqxx::row::size_type
-pqxx::row::table_column(size_type col_num, PQXX_LOC loc) const
+pqxx::row::size_type pqxx::row::table_column(size_type col_num, sl loc) const
 {
   return m_result.table_column(col_num, loc);
 }
 
 
-pqxx::row::size_type
-pqxx::row::column_number(zview col_name, PQXX_LOC loc) const
+pqxx::row::size_type pqxx::row::column_number(zview col_name, sl loc) const
 {
   return m_result.column_number(col_name, loc);
 }

--- a/src/sql_cursor.cxx
+++ b/src/sql_cursor.cxx
@@ -58,7 +58,7 @@ inline bool useless_trail(char c)
  * The query must be nonempty.
  */
 std::string::size_type find_query_end(
-  std::string_view query, pqxx::internal::encoding_group enc, PQXX_LOC loc)
+  std::string_view query, pqxx::internal::encoding_group enc, pqxx::sl loc)
 {
   auto const text{std::data(query)};
   auto const size{std::size(query)};
@@ -92,7 +92,7 @@ std::string::size_type find_query_end(
 pqxx::internal::sql_cursor::sql_cursor(
   transaction_base &t, std::string_view query, std::string_view cname,
   cursor_base::access_policy ap, cursor_base::update_policy up,
-  cursor_base::ownership_policy op, bool hold, PQXX_LOC loc) :
+  cursor_base::ownership_policy op, bool hold, sl loc) :
         cursor_base{t.conn(), cname}, m_home{t.conn()}, m_at_end{-1}, m_pos{0}
 {
   if (&t.conn() != &m_home)
@@ -135,7 +135,7 @@ pqxx::internal::sql_cursor::sql_cursor(
 {}
 
 
-void pqxx::internal::sql_cursor::close(PQXX_LOC loc) noexcept
+void pqxx::internal::sql_cursor::close(sl loc) noexcept
 {
   if (m_ownership == cursor_base::owned)
   {
@@ -217,7 +217,7 @@ pqxx::internal::sql_cursor::difference_type pqxx::internal::sql_cursor::adjust(
 
 
 pqxx::result pqxx::internal::sql_cursor::fetch(
-  difference_type rows, difference_type &displacement, PQXX_LOC loc)
+  difference_type rows, difference_type &displacement, sl loc)
 {
   if (rows == 0)
   {
@@ -233,7 +233,7 @@ pqxx::result pqxx::internal::sql_cursor::fetch(
 
 
 pqxx::cursor_base::difference_type pqxx::internal::sql_cursor::move(
-  difference_type rows, difference_type &displacement, PQXX_LOC loc)
+  difference_type rows, difference_type &displacement, sl loc)
 {
   if (rows == 0)
   {

--- a/src/sql_cursor.cxx
+++ b/src/sql_cursor.cxx
@@ -135,14 +135,14 @@ pqxx::internal::sql_cursor::sql_cursor(
 {}
 
 
-void pqxx::internal::sql_cursor::close() noexcept
+void pqxx::internal::sql_cursor::close(PQXX_LOC loc) noexcept
 {
   if (m_ownership == cursor_base::owned)
   {
     try
     {
       gate::connection_sql_cursor{m_home}.exec(
-        internal::concat("CLOSE "sv, m_home.quote_name(name())).c_str());
+        internal::concat("CLOSE "sv, m_home.quote_name(name())).c_str(), loc);
     }
     catch (std::exception const &)
     {}
@@ -217,7 +217,7 @@ pqxx::internal::sql_cursor::difference_type pqxx::internal::sql_cursor::adjust(
 
 
 pqxx::result pqxx::internal::sql_cursor::fetch(
-  difference_type rows, difference_type &displacement)
+  difference_type rows, difference_type &displacement, PQXX_LOC loc)
 {
   if (rows == 0)
   {
@@ -226,14 +226,14 @@ pqxx::result pqxx::internal::sql_cursor::fetch(
   }
   auto const query{pqxx::internal::concat(
     "FETCH "sv, stridestring(rows), " IN "sv, m_home.quote_name(name()))};
-  auto r{gate::connection_sql_cursor{m_home}.exec(query.c_str())};
+  auto r{gate::connection_sql_cursor{m_home}.exec(query.c_str(), loc)};
   displacement = adjust(rows, difference_type(std::size(r)));
   return r;
 }
 
 
 pqxx::cursor_base::difference_type pqxx::internal::sql_cursor::move(
-  difference_type rows, difference_type &displacement)
+  difference_type rows, difference_type &displacement, PQXX_LOC loc)
 {
   if (rows == 0)
   {
@@ -243,7 +243,7 @@ pqxx::cursor_base::difference_type pqxx::internal::sql_cursor::move(
 
   auto const query{pqxx::internal::concat(
     "MOVE "sv, stridestring(rows), " IN "sv, m_home.quote_name(name()))};
-  auto const r{gate::connection_sql_cursor{m_home}.exec(query.c_str())};
+  auto const r{gate::connection_sql_cursor{m_home}.exec(query.c_str(), loc)};
   auto d{static_cast<difference_type>(r.affected_rows())};
   displacement = adjust(rows, d);
   return d;

--- a/src/sql_cursor.cxx
+++ b/src/sql_cursor.cxx
@@ -100,7 +100,7 @@ pqxx::internal::sql_cursor::sql_cursor(
 
   if (std::empty(query))
     throw usage_error{"Cursor has empty query.", loc};
-  auto const enc{enc_group(t.conn().encoding_id(), loc)};
+  auto const enc{enc_group(t.conn().encoding_id(loc), loc)};
   auto const qend{find_query_end(query, enc, loc)};
   if (qend == 0)
     throw usage_error{"Cursor has effectively empty query.", loc};
@@ -112,13 +112,13 @@ pqxx::internal::sql_cursor::sql_cursor(
     (hold ? "WITH HOLD "sv : ""sv), "FOR "sv, query, " "sv,
     ((up == cursor_base::update) ? "FOR UPDATE "sv : "FOR READ ONLY "sv))};
 
-  t.exec(cq);
+  t.exec(cq, loc);
 
   // Now that we're here in the starting position, keep a copy of an empty
   // result.  That may come in handy later, because we may not be able to
   // construct an empty result with all the right metadata due to the weird
   // meaning of "FETCH 0."
-  init_empty_result(t);
+  init_empty_result(t, loc);
 
   m_ownership = op;
 }
@@ -151,12 +151,12 @@ void pqxx::internal::sql_cursor::close(sl loc) noexcept
 }
 
 
-void pqxx::internal::sql_cursor::init_empty_result(transaction_base &t)
+void pqxx::internal::sql_cursor::init_empty_result(transaction_base &t, sl loc)
 {
   if (pos() != 0)
-    throw internal_error{"init_empty_result() from bad pos()."};
+    throw internal_error{"init_empty_result() from bad pos().", loc};
   m_empty_result =
-    t.exec(internal::concat("FETCH 0 IN "sv, m_home.quote_name(name())));
+    t.exec(internal::concat("FETCH 0 IN "sv, m_home.quote_name(name())), loc);
 }
 
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -234,15 +234,17 @@ std::string demangle_type_name(char const raw[])
 
 
 // TODO: Equivalents for converting a null in the other direction.
-void PQXX_COLD throw_null_conversion(std::string const &type)
+void PQXX_COLD throw_null_conversion(std::string const &type, sl loc)
 {
-  throw conversion_error{concat("Attempt to convert SQL null to ", type, ".")};
+  throw conversion_error{
+    concat("Attempt to convert SQL null to ", type, "."), loc};
 }
 
 
-void PQXX_COLD throw_null_conversion(std::string_view type)
+void PQXX_COLD throw_null_conversion(std::string_view type, sl loc)
 {
-  throw conversion_error{concat("Attempt to convert SQL null to ", type, ".")};
+  throw conversion_error{
+    concat("Attempt to convert SQL null to ", type, "."), loc};
 }
 
 

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -29,7 +29,7 @@ namespace
 pqxx::internal::char_finder_func *get_finder(pqxx::transaction_base const &tx)
 {
   pqxx::sl const loc{pqxx::sl::current()};
-  auto const group{pqxx::internal::enc_group(tx.conn().encoding_id(), loc)};
+  auto const group{pqxx::internal::enc_group(tx.conn().encoding_id(loc), loc)};
   return pqxx::internal::get_char_finder<'\t', '\\'>(group, loc);
 }
 

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -28,7 +28,7 @@ namespace
 {
 pqxx::internal::char_finder_func *get_finder(pqxx::transaction_base const &tx)
 {
-  PQXX_LOC const loc{PQXX_LOC::current()};
+  pqxx::sl const loc{pqxx::sl::current()};
   auto const group{pqxx::internal::enc_group(tx.conn().encoding_id(), loc)};
   return pqxx::internal::get_char_finder<'\t', '\\'>(group, loc);
 }
@@ -42,7 +42,7 @@ pqxx::stream_from::stream_from(
   transaction_base &tx, from_query_t, std::string_view query) :
         transaction_focus{tx, class_name}, m_char_finder{get_finder(tx)}
 {
-  PQXX_LOC const loc{PQXX_LOC::current()};
+  sl const loc{sl::current()};
   tx.exec(internal::concat("COPY ("sv, query, ") TO STDOUT"sv), loc)
     .no_rows(loc);
   register_me();
@@ -53,7 +53,7 @@ pqxx::stream_from::stream_from(
   transaction_base &tx, from_table_t, std::string_view table) :
         transaction_focus{tx, class_name, table}, m_char_finder{get_finder(tx)}
 {
-  PQXX_LOC const loc{PQXX_LOC::current()};
+  sl const loc{sl::current()};
   tx.exec(
       internal::concat("COPY "sv, tx.quote_name(table), " TO STDOUT"sv), loc)
     .no_rows(loc);
@@ -66,7 +66,7 @@ pqxx::stream_from::stream_from(
   from_table_t) :
         transaction_focus{tx, class_name, table}, m_char_finder{get_finder(tx)}
 {
-  PQXX_LOC const loc{PQXX_LOC::current()};
+  sl const loc{sl::current()};
   if (std::empty(columns)) [[unlikely]]
     tx.exec(internal::concat("COPY "sv, table, " TO STDOUT"sv), loc)
       .no_rows(loc);
@@ -183,7 +183,7 @@ void pqxx::stream_from::complete()
 }
 
 
-void pqxx::stream_from::parse_line(PQXX_LOC loc)
+void pqxx::stream_from::parse_line(sl loc)
 {
   if (m_finished) [[unlikely]]
     return;
@@ -297,7 +297,7 @@ void pqxx::stream_from::parse_line(PQXX_LOC loc)
 }
 
 
-std::vector<pqxx::zview> const *pqxx::stream_from::read_row(PQXX_LOC loc) &
+std::vector<pqxx::zview> const *pqxx::stream_from::read_row(sl loc) &
 {
   parse_line(loc);
   return m_finished ? nullptr : &m_fields;

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -107,11 +107,12 @@ pqxx::stream_to &pqxx::stream_to::operator<<(stream_from &tr)
 
 
 pqxx::stream_to::stream_to(
-  transaction_base &tx, std::string_view path, std::string_view columns) :
+  transaction_base &tx, std::string_view path, std::string_view columns,
+  PQXX_LOC loc) :
         transaction_focus{tx, s_classname, path},
         m_finder{pqxx::internal::get_char_finder<
           '\b', '\f', '\n', '\r', '\t', '\v', '\\'>(
-          pqxx::internal::enc_group(tx.conn().encoding_id()))}
+          pqxx::internal::enc_group(tx.conn().encoding_id(), loc), loc)}
 {
   begin_copy(tx, path, columns);
   register_me();
@@ -136,7 +137,7 @@ void pqxx::stream_to::escape_field_to_buffer(
   std::size_t here{0};
   while (here < end)
   {
-    auto const stop_char{m_finder(data, here)};
+    auto const stop_char{m_finder(data, here, loc)};
     // Append any unremarkable we just skipped over.
     m_buffer.append(std::data(data) + here, stop_char - here);
     if (stop_char < end)

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -25,14 +25,16 @@ namespace
 using namespace std::literals;
 
 void begin_copy(
-  pqxx::transaction_base &tx, std::string_view table, std::string_view columns)
+  pqxx::transaction_base &tx, std::string_view table, std::string_view columns,
+  pqxx::sl loc)
 {
   tx.exec(
       std::empty(columns) ?
         pqxx::internal::concat("COPY "sv, table, " FROM STDIN"sv) :
         pqxx::internal::concat(
-          "COPY "sv, table, "("sv, columns, ") FROM STDIN"sv))
-    .no_rows();
+          "COPY "sv, table, "("sv, columns, ") FROM STDIN"sv),
+      loc)
+    .no_rows(loc);
 }
 
 
@@ -112,9 +114,9 @@ pqxx::stream_to::stream_to(
         transaction_focus{tx, s_classname, path},
         m_finder{pqxx::internal::get_char_finder<
           '\b', '\f', '\n', '\r', '\t', '\v', '\\'>(
-          pqxx::internal::enc_group(tx.conn().encoding_id(), loc), loc)}
+          pqxx::internal::enc_group(tx.conn().encoding_id(loc), loc), loc)}
 {
-  begin_copy(tx, path, columns);
+  begin_copy(tx, path, columns, loc);
   register_me();
 }
 

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -37,7 +37,7 @@ void begin_copy(
 
 
 /// Return the escape character for escaping the given special character.
-char escape_char(char special, PQXX_LOC loc)
+char escape_char(char special, pqxx::sl loc)
 {
   switch (special)
   {
@@ -72,14 +72,14 @@ pqxx::stream_to::~stream_to() noexcept
 }
 
 
-void pqxx::stream_to::write_raw_line(std::string_view text, PQXX_LOC loc)
+void pqxx::stream_to::write_raw_line(std::string_view text, sl loc)
 {
   internal::gate::connection_stream_to{m_trans->conn()}.write_copy_line(
     text, loc);
 }
 
 
-void pqxx::stream_to::write_buffer(PQXX_LOC loc)
+void pqxx::stream_to::write_buffer(sl loc)
 {
   if (not std::empty(m_buffer))
   {
@@ -100,7 +100,7 @@ pqxx::stream_to &pqxx::stream_to::operator<<(stream_from &tr)
     const auto [line, size] = tr.get_raw_line();
     if (line.get() == nullptr)
       break;
-    write_raw_line(std::string_view{line.get(), size}, PQXX_LOC::current());
+    write_raw_line(std::string_view{line.get(), size}, sl::current());
   }
   return *this;
 }
@@ -108,7 +108,7 @@ pqxx::stream_to &pqxx::stream_to::operator<<(stream_from &tr)
 
 pqxx::stream_to::stream_to(
   transaction_base &tx, std::string_view path, std::string_view columns,
-  PQXX_LOC loc) :
+  sl loc) :
         transaction_focus{tx, s_classname, path},
         m_finder{pqxx::internal::get_char_finder<
           '\b', '\f', '\n', '\r', '\t', '\v', '\\'>(
@@ -130,8 +130,7 @@ void pqxx::stream_to::complete()
 }
 
 
-void pqxx::stream_to::escape_field_to_buffer(
-  std::string_view data, PQXX_LOC loc)
+void pqxx::stream_to::escape_field_to_buffer(std::string_view data, sl loc)
 {
   std::size_t const end{std::size(data)};
   std::size_t here{0};

--- a/src/subtransaction.cxx
+++ b/src/subtransaction.cxx
@@ -30,7 +30,7 @@ constexpr std::string_view class_name{"subtransaction"sv};
 
 
 pqxx::subtransaction::subtransaction(
-  dbtransaction &t, std::string_view tname) :
+  dbtransaction &t, std::string_view tname, PQXX_LOC loc) :
         transaction_focus{t, class_name, t.conn().adorn_name(tname)},
         // We can't initialise the rollback command here, because we don't yet
         // have a full object to implement quoted_name().
@@ -38,8 +38,10 @@ pqxx::subtransaction::subtransaction(
 {
   set_rollback_cmd(std::make_shared<std::string>(
     internal::concat("ROLLBACK TO SAVEPOINT ", quoted_name())));
-  direct_exec(std::make_shared<std::string>(
-    internal::concat("SAVEPOINT ", quoted_name())));
+  direct_exec(
+    std::make_shared<std::string>(
+      internal::concat("SAVEPOINT ", quoted_name())),
+    loc);
 }
 
 
@@ -61,8 +63,10 @@ pqxx::subtransaction::~subtransaction() noexcept
 }
 
 
-void pqxx::subtransaction::do_commit()
+void pqxx::subtransaction::do_commit(PQXX_LOC loc)
 {
-  direct_exec(std::make_shared<std::string>(
-    internal::concat("RELEASE SAVEPOINT ", quoted_name())));
+  direct_exec(
+    std::make_shared<std::string>(
+      internal::concat("RELEASE SAVEPOINT ", quoted_name())),
+    loc);
 }

--- a/src/subtransaction.cxx
+++ b/src/subtransaction.cxx
@@ -30,7 +30,7 @@ constexpr std::string_view class_name{"subtransaction"sv};
 
 
 pqxx::subtransaction::subtransaction(
-  dbtransaction &t, std::string_view tname, PQXX_LOC loc) :
+  dbtransaction &t, std::string_view tname, sl loc) :
         transaction_focus{t, class_name, t.conn().adorn_name(tname)},
         // We can't initialise the rollback command here, because we don't yet
         // have a full object to implement quoted_name().
@@ -63,7 +63,7 @@ pqxx::subtransaction::~subtransaction() noexcept
 }
 
 
-void pqxx::subtransaction::do_commit(PQXX_LOC loc)
+void pqxx::subtransaction::do_commit(sl loc)
 {
   direct_exec(
     std::make_shared<std::string>(

--- a/src/subtransaction.cxx
+++ b/src/subtransaction.cxx
@@ -52,14 +52,15 @@ using dbtransaction_ref = pqxx::dbtransaction &;
 
 
 pqxx::subtransaction::subtransaction(
-  subtransaction &t, std::string_view tname) :
-        subtransaction(dbtransaction_ref(t), tname)
+  subtransaction &t, std::string_view tname, sl loc) :
+        subtransaction(dbtransaction_ref(t), tname, loc)
 {}
 
 
 pqxx::subtransaction::~subtransaction() noexcept
 {
-  close();
+  sl loc{sl::current()};
+  close(loc);
 }
 
 

--- a/src/subtransaction.cxx
+++ b/src/subtransaction.cxx
@@ -59,7 +59,7 @@ pqxx::subtransaction::subtransaction(
 
 pqxx::subtransaction::~subtransaction() noexcept
 {
-  sl loc{sl::current()};
+  sl const loc{sl::current()};
   close(loc);
 }
 

--- a/src/time.cxx
+++ b/src/time.cxx
@@ -75,17 +75,17 @@ year_into_buf(char *begin, char *end, std::chrono::year const &value)
 
 
 /// Parse the numeric part of a year value.
-inline int year_from_buf(std::string_view text)
+inline int year_from_buf(std::string_view text, PQXX_LOC loc)
 {
   if (std::size(text) < 4)
     throw pqxx::conversion_error{
-      pqxx::internal::concat("Year field is too small: '", text, "'.")};
+      pqxx::internal::concat("Year field is too small: '", text, "'."), loc};
   // Parse as int, so we can accommodate 32768 BC which won't fit in a short
   // as-is, but equates to 32767 BCE which will.
   int const year{pqxx::string_traits<int>::from_string(text)};
   if (year <= 0)
     throw pqxx::conversion_error{
-      pqxx::internal::concat("Bad year: '", text, "'.")};
+      pqxx::internal::concat("Bad year: '", text, "'."), loc};
   return year;
 }
 
@@ -110,13 +110,14 @@ inline char *month_into_buf(char *begin, std::chrono::month const &value)
 
 
 /// Parse a 1-based month value.
-inline std::chrono::month month_from_string(std::string_view text)
+inline std::chrono::month
+month_from_string(std::string_view text, PQXX_LOC loc)
 {
   if (
     not pqxx::internal::is_digit(text[0]) or
     not pqxx::internal::is_digit(text[1]))
     throw pqxx::conversion_error{
-      pqxx::internal::concat("Invalid month: '", text, "'.")};
+      pqxx::internal::concat("Invalid month: '", text, "'."), loc};
   return std::chrono::month{unsigned(
     (ten * pqxx::internal::digit_to_number(text[0])) +
     pqxx::internal::digit_to_number(text[1]))};
@@ -134,19 +135,19 @@ inline char *day_into_buf(char *begin, std::chrono::day const &value)
 
 
 /// Parse a 1-based day-of-month value.
-inline std::chrono::day day_from_string(std::string_view text)
+inline std::chrono::day day_from_string(std::string_view text, PQXX_LOC loc)
 {
   if (
     not pqxx::internal::is_digit(text[0]) or
     not pqxx::internal::is_digit(text[1]))
     throw pqxx::conversion_error{
-      pqxx::internal::concat("Bad day in date: '", text, "'.")};
+      pqxx::internal::concat("Bad day in date: '", text, "'."), loc};
   std::chrono::day const d{unsigned(
     (ten * pqxx::internal::digit_to_number(text[0])) +
     pqxx::internal::digit_to_number(text[1]))};
   if (not d.ok())
     throw pqxx::conversion_error{
-      pqxx::internal::concat("Bad day in date: '", text, "'.")};
+      pqxx::internal::concat("Bad day in date: '", text, "'."), loc};
   return d;
 }
 
@@ -177,10 +178,11 @@ std::string make_parse_error(std::string_view text)
 namespace pqxx
 {
 char *string_traits<std::chrono::year_month_day>::into_buf(
-  char *begin, char *end, std::chrono::year_month_day const &value)
+  char *begin, char *end, std::chrono::year_month_day const &value,
+  PQXX_LOC loc)
 {
   if (std::size_t(end - begin) < size_buffer(value))
-    throw conversion_overrun{"Not enough room in buffer for date."};
+    throw conversion_overrun{"Not enough room in buffer for date.", loc};
   begin = year_into_buf(begin, end, value.year());
   *begin++ = '-';
   begin = month_into_buf(begin, value.month());
@@ -194,30 +196,31 @@ char *string_traits<std::chrono::year_month_day>::into_buf(
 
 
 std::chrono::year_month_day
-string_traits<std::chrono::year_month_day>::from_string(std::string_view text)
+string_traits<std::chrono::year_month_day>::from_string(
+  std::string_view text, PQXX_LOC loc)
 {
   // We can't just re-use the std::chrono::year conversions, because the "BC"
   // suffix comes at the very end.
   if (std::size(text) < 9)
-    throw conversion_error{make_parse_error(text)};
+    throw conversion_error{make_parse_error(text), loc};
   bool const is_bc{text.ends_with(s_bc)};
   if (is_bc) [[unlikely]]
     text = text.substr(0, std::size(text) - std::size(s_bc));
   auto const ymsep{find_year_month_separator(text)};
   if ((std::size(text) - ymsep) != 6)
-    throw conversion_error{make_parse_error(text)};
+    throw conversion_error{make_parse_error(text), loc};
   auto const base_year{
-    year_from_buf(std::string_view{std::data(text), ymsep})};
+    year_from_buf(std::string_view{std::data(text), ymsep}, loc)};
   if (base_year == 0)
-    throw conversion_error{"Year zero conversion."};
+    throw conversion_error{"Year zero conversion.", loc};
   std::chrono::year const y{is_bc ? (-base_year + 1) : base_year};
-  auto const m{month_from_string(text.substr(ymsep + 1, 2))};
+  auto const m{month_from_string(text.substr(ymsep + 1, 2), loc)};
   if (text[ymsep + 3] != '-')
-    throw conversion_error{make_parse_error(text)};
-  auto const d{day_from_string(text.substr(ymsep + 4, 2))};
+    throw conversion_error{make_parse_error(text), loc};
+  auto const d{day_from_string(text.substr(ymsep + 4, 2), loc)};
   std::chrono::year_month_day const date{y, m, d};
   if (not date.ok())
-    throw conversion_error{make_parse_error(text)};
+    throw conversion_error{make_parse_error(text), loc};
   return date;
 }
 } // namespace pqxx

--- a/src/time.cxx
+++ b/src/time.cxx
@@ -75,7 +75,7 @@ year_into_buf(char *begin, char *end, std::chrono::year const &value)
 
 
 /// Parse the numeric part of a year value.
-inline int year_from_buf(std::string_view text, PQXX_LOC loc)
+inline int year_from_buf(std::string_view text, pqxx::sl loc)
 {
   if (std::size(text) < 4)
     throw pqxx::conversion_error{
@@ -111,7 +111,7 @@ inline char *month_into_buf(char *begin, std::chrono::month const &value)
 
 /// Parse a 1-based month value.
 inline std::chrono::month
-month_from_string(std::string_view text, PQXX_LOC loc)
+month_from_string(std::string_view text, pqxx::sl loc)
 {
   if (
     not pqxx::internal::is_digit(text[0]) or
@@ -135,7 +135,7 @@ inline char *day_into_buf(char *begin, std::chrono::day const &value)
 
 
 /// Parse a 1-based day-of-month value.
-inline std::chrono::day day_from_string(std::string_view text, PQXX_LOC loc)
+inline std::chrono::day day_from_string(std::string_view text, pqxx::sl loc)
 {
   if (
     not pqxx::internal::is_digit(text[0]) or
@@ -178,8 +178,7 @@ std::string make_parse_error(std::string_view text)
 namespace pqxx
 {
 char *string_traits<std::chrono::year_month_day>::into_buf(
-  char *begin, char *end, std::chrono::year_month_day const &value,
-  PQXX_LOC loc)
+  char *begin, char *end, std::chrono::year_month_day const &value, sl loc)
 {
   if (std::size_t(end - begin) < size_buffer(value))
     throw conversion_overrun{"Not enough room in buffer for date.", loc};
@@ -197,7 +196,7 @@ char *string_traits<std::chrono::year_month_day>::into_buf(
 
 std::chrono::year_month_day
 string_traits<std::chrono::year_month_day>::from_string(
-  std::string_view text, PQXX_LOC loc)
+  std::string_view text, sl loc)
 {
   // We can't just re-use the std::chrono::year conversions, because the "BC"
   // suffix comes at the very end.

--- a/src/transaction.cxx
+++ b/src/transaction.cxx
@@ -22,7 +22,7 @@
 
 
 pqxx::internal::basic_transaction::basic_transaction(
-  connection &cx, zview begin_command, std::string_view tname, PQXX_LOC loc) :
+  connection &cx, zview begin_command, std::string_view tname, sl loc) :
         dbtransaction(cx, tname)
 {
   register_transaction();
@@ -31,7 +31,7 @@ pqxx::internal::basic_transaction::basic_transaction(
 
 
 pqxx::internal::basic_transaction::basic_transaction(
-  connection &cx, zview begin_command, std::string &&tname, PQXX_LOC loc) :
+  connection &cx, zview begin_command, std::string &&tname, sl loc) :
         dbtransaction(cx, std::move(tname))
 {
   register_transaction();
@@ -40,7 +40,7 @@ pqxx::internal::basic_transaction::basic_transaction(
 
 
 pqxx::internal::basic_transaction::basic_transaction(
-  connection &cx, zview begin_command, PQXX_LOC loc) :
+  connection &cx, zview begin_command, sl loc) :
         dbtransaction(cx)
 {
   register_transaction();
@@ -57,7 +57,7 @@ pqxx::internal::basic_transaction::basic_transaction(
 pqxx::internal::basic_transaction::~basic_transaction() noexcept = default;
 
 
-void pqxx::internal::basic_transaction::do_commit(PQXX_LOC loc)
+void pqxx::internal::basic_transaction::do_commit(sl loc)
 {
   static auto const commit_q{std::make_shared<std::string>("COMMIT"sv)};
   try

--- a/src/transaction.cxx
+++ b/src/transaction.cxx
@@ -70,6 +70,7 @@ void pqxx::internal::basic_transaction::do_commit(PQXX_LOC loc)
     // resulting state of the database.
     process_notice(internal::concat(e.what(), "\n"));
 
+    // XXX: Log source location?
     std::string msg{internal::concat(
       "WARNING: Commit status of transaction '", name(),
       "' is unknown. "

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -165,7 +165,7 @@ void pqxx::transaction_base::commit(sl loc)
     throw;
   }
 
-  close();
+  close(loc);
 }
 
 
@@ -214,7 +214,7 @@ void pqxx::transaction_base::abort(sl loc)
   }
 
   m_status = status::aborted;
-  close();
+  close(loc);
 }
 
 
@@ -353,7 +353,7 @@ std::string pqxx::transaction_base::get_variable(std::string_view var)
 }
 
 
-void pqxx::transaction_base::close() noexcept
+void pqxx::transaction_base::close(sl loc) noexcept
 {
   try
   {
@@ -384,7 +384,7 @@ void pqxx::transaction_base::close() noexcept
 
     try
     {
-      abort();
+      abort(loc);
     }
     catch (std::exception const &e)
     {

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -95,7 +95,7 @@ void pqxx::transaction_base::register_transaction()
 }
 
 
-void pqxx::transaction_base::commit(PQXX_LOC loc)
+void pqxx::transaction_base::commit(sl loc)
 {
   check_pending_error();
 
@@ -169,14 +169,14 @@ void pqxx::transaction_base::commit(PQXX_LOC loc)
 }
 
 
-void pqxx::transaction_base::do_abort(PQXX_LOC loc)
+void pqxx::transaction_base::do_abort(sl loc)
 {
   if (m_rollback_cmd)
     direct_exec(m_rollback_cmd, loc);
 }
 
 
-void pqxx::transaction_base::abort(PQXX_LOC loc)
+void pqxx::transaction_base::abort(sl loc)
 {
   // Check previous status code.  Quietly accept multiple aborts to
   // simplify emergency bailout code.
@@ -243,7 +243,7 @@ public:
 };
 } // namespace
 
-pqxx::result pqxx::transaction_base::exec(std::string_view query, PQXX_LOC loc)
+pqxx::result pqxx::transaction_base::exec(std::string_view query, sl loc)
 {
   check_pending_error();
 
@@ -268,7 +268,7 @@ pqxx::result pqxx::transaction_base::exec(std::string_view query, PQXX_LOC loc)
 
 
 pqxx::result pqxx::transaction_base::exec(
-  std::string_view query, std::string_view desc, PQXX_LOC loc)
+  std::string_view query, std::string_view desc, sl loc)
 {
   check_pending_error();
 
@@ -309,7 +309,7 @@ pqxx::result pqxx::transaction_base::exec_n(
 
 
 pqxx::result pqxx::transaction_base::internal_exec_prepared(
-  std::string_view statement, internal::c_params const &args, PQXX_LOC loc)
+  std::string_view statement, internal::c_params const &args, sl loc)
 {
   command const cmd{*this, statement};
   return pqxx::internal::gate::connection_transaction{conn()}.exec_prepared(
@@ -318,7 +318,7 @@ pqxx::result pqxx::transaction_base::internal_exec_prepared(
 
 
 pqxx::result pqxx::transaction_base::internal_exec_params(
-  std::string_view query, internal::c_params const &args, PQXX_LOC loc)
+  std::string_view query, internal::c_params const &args, sl loc)
 {
   command const cmd{*this, query};
   return pqxx::internal::gate::connection_transaction{conn()}.exec_params(
@@ -327,7 +327,7 @@ pqxx::result pqxx::transaction_base::internal_exec_params(
 
 
 void pqxx::transaction_base::notify(
-  std::string_view channel, std::string_view payload, PQXX_LOC loc)
+  std::string_view channel, std::string_view payload, sl loc)
 {
   // For some reason, NOTIFY does not work as a parameterised statement,
   // even just for the payload (which is supposed to be a normal string).
@@ -450,7 +450,7 @@ void pqxx::transaction_base::unregister_focus(
 
 
 pqxx::result pqxx::transaction_base::direct_exec(
-  std::string_view cmd, std::string_view desc, PQXX_LOC loc)
+  std::string_view cmd, std::string_view desc, sl loc)
 {
   check_pending_error();
   return pqxx::internal::gate::connection_transaction{conn()}.exec(
@@ -459,7 +459,7 @@ pqxx::result pqxx::transaction_base::direct_exec(
 
 
 pqxx::result pqxx::transaction_base::direct_exec(
-  std::shared_ptr<std::string> cmd, std::string_view desc, PQXX_LOC loc)
+  std::shared_ptr<std::string> cmd, std::string_view desc, sl loc)
 {
   check_pending_error();
   return pqxx::internal::gate::connection_transaction{conn()}.exec(

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -95,7 +95,7 @@ void pqxx::transaction_base::register_transaction()
 }
 
 
-void pqxx::transaction_base::commit()
+void pqxx::transaction_base::commit(PQXX_LOC loc)
 {
   check_pending_error();
 
@@ -107,8 +107,9 @@ void pqxx::transaction_base::commit()
     break;
 
   case status::aborted:
-    throw usage_error{internal::concat(
-      "Attempt to commit previously aborted ", description())};
+    throw usage_error{
+      internal::concat("Attempt to commit previously aborted ", description()),
+      loc};
 
   case status::committed:
     // Transaction has been committed already.  This is not exactly proper
@@ -134,9 +135,11 @@ void pqxx::transaction_base::commit()
   // commit is premature.  Punish this swiftly and without fail to discourage
   // the habit from forming.
   if (m_focus != nullptr)
-    throw failure{internal::concat(
-      "Attempt to commit ", description(), " with ", m_focus->description(),
-      " still open.")};
+    throw failure{
+      internal::concat(
+        "Attempt to commit ", description(), " with ", m_focus->description(),
+        " still open."),
+      loc};
 
   // Check that we're still connected (as far as we know--this is not an
   // absolute thing!) before trying to commit.  If the connection was broken
@@ -144,11 +147,11 @@ void pqxx::transaction_base::commit()
   // remain in-doubt as to whether the backend got the commit order at all.
   if (not m_conn.is_open())
     throw broken_connection{
-      "Broken connection to backend; cannot complete transaction."};
+      "Broken connection to backend; cannot complete transaction.", loc};
 
   try
   {
-    do_commit();
+    do_commit(loc);
     m_status = status::committed;
   }
   catch (in_doubt_error const &)
@@ -166,14 +169,14 @@ void pqxx::transaction_base::commit()
 }
 
 
-void pqxx::transaction_base::do_abort()
+void pqxx::transaction_base::do_abort(PQXX_LOC loc)
 {
   if (m_rollback_cmd)
-    direct_exec(m_rollback_cmd);
+    direct_exec(m_rollback_cmd, loc);
 }
 
 
-void pqxx::transaction_base::abort()
+void pqxx::transaction_base::abort(PQXX_LOC loc)
 {
   // Check previous status code.  Quietly accept multiple aborts to
   // simplify emergency bailout code.
@@ -182,7 +185,7 @@ void pqxx::transaction_base::abort()
   case status::active:
     try
     {
-      do_abort();
+      do_abort(loc);
     }
     catch (std::exception const &e)
     {
@@ -193,8 +196,10 @@ void pqxx::transaction_base::abort()
   case status::aborted: return;
 
   case status::committed:
-    throw usage_error{internal::concat(
-      "Attempt to abort previously committed ", description())};
+    throw usage_error{
+      internal::concat(
+        "Attempt to abort previously committed ", description()),
+      loc};
 
   case status::in_doubt:
     // Aborting an in-doubt transaction is probably a reasonably sane response
@@ -238,7 +243,7 @@ public:
 };
 } // namespace
 
-pqxx::result pqxx::transaction_base::exec(std::string_view query)
+pqxx::result pqxx::transaction_base::exec(std::string_view query, PQXX_LOC loc)
 {
   check_pending_error();
 
@@ -253,17 +258,17 @@ pqxx::result pqxx::transaction_base::exec(std::string_view query)
   case status::in_doubt:
     // TODO: Pass query.
     throw usage_error{
-      "Could not execute command: transaction is already closed."};
+      "Could not execute command: transaction is already closed.", loc};
 
   default: PQXX_UNREACHABLE;
   }
 
-  return direct_exec(query);
+  return direct_exec(query, loc);
 }
 
 
-pqxx::result
-pqxx::transaction_base::exec(std::string_view query, std::string_view desc)
+pqxx::result pqxx::transaction_base::exec(
+  std::string_view query, std::string_view desc, PQXX_LOC loc)
 {
   check_pending_error();
 
@@ -279,14 +284,16 @@ pqxx::transaction_base::exec(std::string_view query, std::string_view desc)
     std::string const n{
       std::empty(desc) ? "" : internal::concat("'", desc, "' ")};
 
-    throw usage_error{internal::concat(
-      "Could not execute command ", n, ": transaction is already closed.")};
+    throw usage_error{
+      internal::concat(
+        "Could not execute command ", n, ": transaction is already closed."),
+      loc};
   }
 
   default: PQXX_UNREACHABLE;
   }
 
-  return direct_exec(query, desc);
+  return direct_exec(query, desc, loc);
 }
 
 
@@ -311,11 +318,11 @@ pqxx::result pqxx::transaction_base::internal_exec_prepared(
 
 
 pqxx::result pqxx::transaction_base::internal_exec_params(
-  std::string_view query, internal::c_params const &args)
+  std::string_view query, internal::c_params const &args, PQXX_LOC loc)
 {
   command const cmd{*this, query};
   return pqxx::internal::gate::connection_transaction{conn()}.exec_params(
-    query, args);
+    query, args, loc);
 }
 
 
@@ -443,19 +450,20 @@ void pqxx::transaction_base::unregister_focus(
 
 
 pqxx::result pqxx::transaction_base::direct_exec(
-  std::string_view cmd, std::string_view desc)
+  std::string_view cmd, std::string_view desc, PQXX_LOC loc)
 {
   check_pending_error();
-  return pqxx::internal::gate::connection_transaction{conn()}.exec(cmd, desc);
+  return pqxx::internal::gate::connection_transaction{conn()}.exec(
+    cmd, desc, loc);
 }
 
 
 pqxx::result pqxx::transaction_base::direct_exec(
-  std::shared_ptr<std::string> cmd, std::string_view desc)
+  std::shared_ptr<std::string> cmd, std::string_view desc, PQXX_LOC loc)
 {
   check_pending_error();
   return pqxx::internal::gate::connection_transaction{conn()}.exec(
-    std::move(cmd), desc);
+    std::move(cmd), desc, loc);
 }
 
 

--- a/src/transaction_base.cxx
+++ b/src/transaction_base.cxx
@@ -479,6 +479,7 @@ void pqxx::transaction_base::register_pending_error(zview err) noexcept
     {
       try
       {
+        // XXX: Log source location?
         [[unlikely]] process_notice("UNABLE TO PROCESS ERROR\n");
         // TODO: Make at least an attempt to append a newline.
         process_notice(e.what());

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -110,7 +110,6 @@ constexpr std::array<char, 16u> hex_digits{
 constexpr char hex_digit(int c) noexcept
 {
   PQXX_ASSUME(c >= 0);
-  PQXX_ASSUME(c < std::ssize(hex_digits));
   return hex_digits.at(static_cast<unsigned int>(c));
 }
 

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -165,7 +165,7 @@ std::string pqxx::internal::esc_bin(bytes_view binary_data)
 
 
 void pqxx::internal::unesc_bin(
-  std::string_view escaped_data, std::byte buffer[], PQXX_LOC loc)
+  std::string_view escaped_data, std::byte buffer[], sl loc)
 {
   auto const in_size{std::size(escaped_data)};
   if (in_size < 2)
@@ -193,8 +193,7 @@ void pqxx::internal::unesc_bin(
 }
 
 
-pqxx::bytes
-pqxx::internal::unesc_bin(std::string_view escaped_data, PQXX_LOC loc)
+pqxx::bytes pqxx::internal::unesc_bin(std::string_view escaped_data, sl loc)
 {
   auto const bytes{size_unesc_bin(std::size(escaped_data))};
   pqxx::bytes buf;

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -14,7 +14,7 @@
 
 namespace pqxx::test
 {
-test_failure::test_failure(std::string const &desc, std::source_location loc) :
+test_failure::test_failure(std::string const &desc, sl loc) :
         std::logic_error{desc}, m_loc{loc}
 {}
 
@@ -28,15 +28,13 @@ inline void drop_table(transaction_base &t, std::string const &table)
 }
 
 
-[[noreturn]] void check_notreached(std::string desc, std::source_location loc)
+[[noreturn]] void check_notreached(std::string desc, sl loc)
 {
   throw test_failure{desc, loc};
 }
 
 
-void check(
-  bool condition, char const text[], std::string const &desc,
-  std::source_location loc)
+void check(bool condition, char const text[], std::string const &desc, sl loc)
 {
   if (not condition)
     throw test_failure{desc + " (failed expression: " + text + ")", loc};

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -22,9 +22,9 @@ test_failure::~test_failure() noexcept = default;
 
 
 /// Drop table, if it exists.
-inline void drop_table(transaction_base &t, std::string const &table)
+inline void drop_table(transaction_base &t, std::string const &table, sl loc)
 {
-  t.exec("DROP TABLE IF EXISTS " + table);
+  t.exec("DROP TABLE IF EXISTS " + table, loc);
 }
 
 

--- a/test/test07.cxx
+++ b/test/test07.cxx
@@ -30,7 +30,7 @@ int To4Digits(int Y)
   else if (Y < 100)
     Result += 1900;
   else if (Y < 1970)
-    PQXX_CHECK_NOTREACHED("Unexpected year: " + to_string(Y));
+    pqxx::test::check_notreached("Unexpected year: " + to_string(Y));
 
   return Result;
 }

--- a/test/test07.cxx
+++ b/test/test07.cxx
@@ -81,9 +81,11 @@ void test_007()
     {
       int Y{0};
 
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
       // Read year, and if it is non-null, note its converted value
       if (r[0] >> Y)
         conversions[Y] = To4Digits(Y);
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 
       // See if type identifiers are consistent
       oid const tctype{r.column_type(0)};

--- a/test/test_array.cxx
+++ b/test/test_array.cxx
@@ -15,6 +15,7 @@ struct nullness<array_parser::juncture> : no_null<array_parser::juncture>
 
 inline std::string to_string(pqxx::array_parser::juncture const &j)
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   using junc = pqxx::array_parser::juncture;
   switch (j)
   {
@@ -25,6 +26,7 @@ inline std::string to_string(pqxx::array_parser::juncture const &j)
   case junc::done: return "done";
   default: return "UNKNOWN JUNCTURE: " + to_string(static_cast<int>(j));
   }
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 } // namespace pqxx
 
@@ -33,6 +35,7 @@ namespace
 {
 void test_empty_arrays()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
 
   // Parsing a null pointer just immediately returns "done".
@@ -68,11 +71,13 @@ void test_empty_arrays()
     output.first, pqxx::array_parser::juncture::done,
     "Empty array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_array_null_value()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser containing_null("{NULL}");
 
@@ -99,11 +104,13 @@ void test_array_null_value()
     output.first, pqxx::array_parser::juncture::done,
     "Array containing null did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_array_double_quoted_string()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{\"item\"}");
 
@@ -129,11 +136,13 @@ void test_array_double_quoted_string()
     output.first, pqxx::array_parser::juncture::done,
     "Array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_array_double_quoted_escaping()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser(R"--({"don''t\\ care"})--");
 
@@ -159,12 +168,14 @@ void test_array_double_quoted_escaping()
     output.first, pqxx::array_parser::juncture::done,
     "Array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 // A pair of double quotes in a double-quoted string is an escaped quote.
 void test_array_double_double_quoted_string()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser{R"--({"3"" steel"})--"};
 
@@ -179,11 +190,13 @@ void test_array_double_double_quoted_string()
     "Array did not return string_value.");
 
   PQXX_CHECK_EQUAL(output.second, "3\" steel", "Unexpected string value.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_array_unquoted_string()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{item}");
 
@@ -209,11 +222,13 @@ void test_array_unquoted_string()
     output.first, pqxx::array_parser::juncture::done,
     "Array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_array_multiple_values()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{1,2}");
 
@@ -245,11 +260,13 @@ void test_array_multiple_values()
     output.first, pqxx::array_parser::juncture::done,
     "Array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_nested_array()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{{item}}");
 
@@ -286,11 +303,13 @@ void test_nested_array()
     output.first, pqxx::array_parser::juncture::done,
     "Array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_nested_array_with_multiple_entries()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::pair<pqxx::array_parser::juncture, std::string> output;
   pqxx::array_parser parser("{{1,2},{3,4}}");
 
@@ -356,6 +375,7 @@ void test_nested_array_with_multiple_entries()
     output.first, pqxx::array_parser::juncture::done,
     "Array did not conclude with done.");
   PQXX_CHECK_EQUAL(output.second, "", "Unexpected nonempty output.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
@@ -493,6 +513,7 @@ void test_array_generate()
 
 void test_array_roundtrip()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   pqxx::connection cx;
   pqxx::work tx{cx};
 
@@ -526,11 +547,13 @@ void test_array_roundtrip()
   PQXX_CHECK_EQUAL(
     item.first, pqxx::array_parser::juncture::done,
     "Array did not end in done.");
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 
 void test_array_strings()
 {
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
   std::vector<std::string_view> inputs{
     "",    "null", "NULL", "\\N", "'",    "''", "\\", "\n\t",
     "\\n", "\"",   "\"\"", "a b", "a<>b", "{",  "}",  "{}",
@@ -552,6 +575,7 @@ void test_array_strings()
       "Bad value juncture.");
     PQXX_CHECK_EQUAL(value, input, "Bad array value roundtrip.");
   }
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 }
 
 

--- a/test/test_encodings.cxx
+++ b/test/test_encodings.cxx
@@ -8,14 +8,14 @@ namespace
 void test_scan_ascii()
 {
   auto const scan{pqxx::internal::get_glyph_scanner(
-    pqxx::internal::encoding_group::MONOBYTE, PQXX_LOC::current())};
+    pqxx::internal::encoding_group::MONOBYTE, pqxx::sl::current())};
   std::string const text{"hello"};
 
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 0, PQXX_LOC::current()), 1ul,
+    scan(text.c_str(), std::size(text), 0, pqxx::sl::current()), 1ul,
     "Monobyte scanner acting up.");
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 1, PQXX_LOC::current()), 2ul,
+    scan(text.c_str(), std::size(text), 1, pqxx::sl::current()), 2ul,
     "Monobyte scanner is inconsistent.");
 }
 
@@ -23,15 +23,15 @@ void test_scan_ascii()
 void test_scan_utf8()
 {
   auto const scan{pqxx::internal::get_glyph_scanner(
-    pqxx::internal::encoding_group::UTF8, PQXX_LOC::current())};
+    pqxx::internal::encoding_group::UTF8, pqxx::sl::current())};
 
   // Thai: "Khrab".
   std::string const text{"\xe0\xb8\x95\xe0\xb8\xa3\xe0\xb8\xb1\xe0\xb8\x9a"};
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 0, PQXX_LOC::current()), 3ul,
+    scan(text.c_str(), std::size(text), 0, pqxx::sl::current()), 3ul,
     "UTF-8 scanner mis-scanned Thai khor khwai.");
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 3, PQXX_LOC::current()), 6ul,
+    scan(text.c_str(), std::size(text), 3, pqxx::sl::current()), 6ul,
     "UTF-8 scanner mis-scanned Thai ror reua.");
 }
 
@@ -42,7 +42,7 @@ void test_for_glyphs_empty()
   pqxx::internal::for_glyphs(
     pqxx::internal::encoding_group::MONOBYTE,
     [&iterated](char const *, char const *) { iterated = true; }, "", 0, 0,
-    PQXX_LOC::current());
+    pqxx::sl::current());
   PQXX_CHECK(!iterated, "Empty string went through an iteration.");
 }
 
@@ -57,7 +57,7 @@ void test_for_glyphs_ascii()
     [&points](char const *gbegin, char const *gend) {
       points.push_back(gend - gbegin);
     },
-    text.c_str(), std::size(text), 0, PQXX_LOC::current());
+    text.c_str(), std::size(text), 0, pqxx::sl::current());
 
   PQXX_CHECK_EQUAL(std::size(points), 2u, "Wrong number of ASCII iterations.");
   PQXX_CHECK_EQUAL(points[0], 1u, "ASCII iteration started off wrong.");
@@ -76,7 +76,7 @@ void test_for_glyphs_utf8()
     [&points](char const *gbegin, char const *gend) {
       points.push_back(gend - gbegin);
     },
-    text.c_str(), std::size(text), 0, PQXX_LOC::current());
+    text.c_str(), std::size(text), 0, pqxx::sl::current());
 
   PQXX_CHECK_EQUAL(std::size(points), 2u, "Wrong number of UTF-8 iterations.");
   PQXX_CHECK_EQUAL(points[0], 2u, "UTF-8 iteration started off wrong.");
@@ -91,7 +91,7 @@ void test_for_glyphs_utf8()
     [&points](char const *gbegin, char const *gend) {
       points.push_back(gend - gbegin);
     },
-    mix.c_str(), std::size(mix), 0, PQXX_LOC::current());
+    mix.c_str(), std::size(mix), 0, pqxx::sl::current());
 
   PQXX_CHECK_EQUAL(std::size(points), 3u, "Mixed UTF-8 iteration is broken.");
   PQXX_CHECK_EQUAL(points[0], 2u, "Mixed UTF-8 iteration started off wrong.");

--- a/test/test_encodings.cxx
+++ b/test/test_encodings.cxx
@@ -8,30 +8,30 @@ namespace
 void test_scan_ascii()
 {
   auto const scan{pqxx::internal::get_glyph_scanner(
-    pqxx::internal::encoding_group::MONOBYTE)};
+    pqxx::internal::encoding_group::MONOBYTE, PQXX_LOC::current())};
   std::string const text{"hello"};
 
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 0), 1ul,
+    scan(text.c_str(), std::size(text), 0, PQXX_LOC::current()), 1ul,
     "Monobyte scanner acting up.");
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 1), 2ul,
+    scan(text.c_str(), std::size(text), 1, PQXX_LOC::current()), 2ul,
     "Monobyte scanner is inconsistent.");
 }
 
 
 void test_scan_utf8()
 {
-  auto const scan{
-    pqxx::internal::get_glyph_scanner(pqxx::internal::encoding_group::UTF8)};
+  auto const scan{pqxx::internal::get_glyph_scanner(
+    pqxx::internal::encoding_group::UTF8, PQXX_LOC::current())};
 
   // Thai: "Khrab".
   std::string const text{"\xe0\xb8\x95\xe0\xb8\xa3\xe0\xb8\xb1\xe0\xb8\x9a"};
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 0), 3ul,
+    scan(text.c_str(), std::size(text), 0, PQXX_LOC::current()), 3ul,
     "UTF-8 scanner mis-scanned Thai khor khwai.");
   PQXX_CHECK_EQUAL(
-    scan(text.c_str(), std::size(text), 3), 6ul,
+    scan(text.c_str(), std::size(text), 3, PQXX_LOC::current()), 6ul,
     "UTF-8 scanner mis-scanned Thai ror reua.");
 }
 
@@ -41,7 +41,8 @@ void test_for_glyphs_empty()
   bool iterated{false};
   pqxx::internal::for_glyphs(
     pqxx::internal::encoding_group::MONOBYTE,
-    [&iterated](char const *, char const *) { iterated = true; }, "", 0);
+    [&iterated](char const *, char const *) { iterated = true; }, "", 0, 0,
+    PQXX_LOC::current());
   PQXX_CHECK(!iterated, "Empty string went through an iteration.");
 }
 
@@ -56,7 +57,7 @@ void test_for_glyphs_ascii()
     [&points](char const *gbegin, char const *gend) {
       points.push_back(gend - gbegin);
     },
-    text.c_str(), std::size(text));
+    text.c_str(), std::size(text), 0, PQXX_LOC::current());
 
   PQXX_CHECK_EQUAL(std::size(points), 2u, "Wrong number of ASCII iterations.");
   PQXX_CHECK_EQUAL(points[0], 1u, "ASCII iteration started off wrong.");
@@ -75,7 +76,7 @@ void test_for_glyphs_utf8()
     [&points](char const *gbegin, char const *gend) {
       points.push_back(gend - gbegin);
     },
-    text.c_str(), std::size(text));
+    text.c_str(), std::size(text), 0, PQXX_LOC::current());
 
   PQXX_CHECK_EQUAL(std::size(points), 2u, "Wrong number of UTF-8 iterations.");
   PQXX_CHECK_EQUAL(points[0], 2u, "UTF-8 iteration started off wrong.");
@@ -90,7 +91,7 @@ void test_for_glyphs_utf8()
     [&points](char const *gbegin, char const *gend) {
       points.push_back(gend - gbegin);
     },
-    mix.c_str(), std::size(mix));
+    mix.c_str(), std::size(mix), 0, PQXX_LOC::current());
 
   PQXX_CHECK_EQUAL(std::size(points), 3u, "Mixed UTF-8 iteration is broken.");
   PQXX_CHECK_EQUAL(points[0], 2u, "Mixed UTF-8 iteration started off wrong.");

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -11,9 +11,7 @@ namespace test
 class test_failure : public std::logic_error
 {
 public:
-  test_failure(
-    std::string const &desc,
-    std::source_location loc = std::source_location::current());
+  test_failure(std::string const &desc, sl loc = sl::current());
 
   ~test_failure() noexcept override;
 
@@ -21,7 +19,7 @@ public:
   constexpr auto line() const noexcept { return m_loc.line(); }
 
 private:
-  std::source_location m_loc;
+  sl m_loc;
 };
 
 
@@ -55,16 +53,14 @@ struct registrar
 
 // Unconditional test failure.
 #define PQXX_CHECK_NOTREACHED(desc) pqxx::test::check_notreached((desc))
-[[noreturn]] void check_notreached(
-  std::string desc,
-  std::source_location loc = std::source_location::current());
+[[noreturn]] void check_notreached(std::string desc, sl loc = sl::current());
 
 // Verify that a condition is met, similar to assert()
 #define PQXX_CHECK(condition, desc)                                           \
   pqxx::test::check((condition), #condition, (desc))
 void check(
   bool condition, char const text[], std::string const &desc,
-  std::source_location loc = std::source_location::current());
+  sl loc = sl::current());
 
 // Verify that variable has the expected value.
 #define PQXX_CHECK_EQUAL(actual, expected, desc)                              \
@@ -72,8 +68,7 @@ void check(
 template<typename ACTUAL, typename EXPECTED>
 inline void check_equal(
   ACTUAL actual, char const actual_text[], EXPECTED expected,
-  char const expected_text[], std::string const &desc,
-  std::source_location loc = std::source_location::current())
+  char const expected_text[], std::string const &desc, sl loc = sl::current())
 {
   if (expected == actual)
     return;
@@ -94,8 +89,7 @@ inline void check_equal(
 template<typename VALUE1, typename VALUE2>
 inline void check_not_equal(
   VALUE1 value1, char const text1[], VALUE2 value2, char const text2[],
-  std::string const &desc,
-  std::source_location loc = std::source_location::current())
+  std::string const &desc, sl loc = sl::current())
 {
   if (value1 != value2)
     return;
@@ -116,8 +110,7 @@ inline void check_not_equal(
 template<typename VALUE1, typename VALUE2>
 inline void check_less(
   VALUE1 value1, char const text1[], VALUE2 value2, char const text2[],
-  std::string const &desc,
-  std::source_location loc = std::source_location::current())
+  std::string const &desc, sl loc = sl::current())
 {
   if (value1 < value2)
     return;
@@ -141,8 +134,7 @@ inline void check_less(
 template<typename VALUE1, typename VALUE2>
 inline void check_less_equal(
   VALUE1 value1, char const text1[], VALUE2 value2, char const text2[],
-  std::string const &desc,
-  std::source_location loc = std::source_location::current())
+  std::string const &desc, sl loc = sl::current())
 {
   if (value1 <= value2)
     return;
@@ -252,7 +244,7 @@ template<typename VALUE, typename LOWER, typename UPPER>
 inline void check_bounds(
   VALUE value, char const text[], LOWER lower, char const lower_text[],
   UPPER upper, char const upper_text[], std::string const &desc,
-  std::source_location loc = std::source_location::current())
+  sl loc = sl::current())
 {
   std::string const range_check = std::string{lower_text} + " < " + upper_text,
                     lower_check =

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -24,7 +24,8 @@ private:
 
 
 /// Drop a table, if it exists.
-void drop_table(transaction_base &, std::string const &table);
+void drop_table(
+  transaction_base &, std::string const &table, sl loc = sl::current());
 
 
 using testfunc = void (*)();

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -52,8 +52,7 @@ struct registrar
 
 
 // Unconditional test failure.
-#define PQXX_CHECK_NOTREACHED(desc) pqxx::test::check_notreached((desc))
-[[noreturn]] void check_notreached(std::string desc, sl loc = sl::current());
+[[noreturn]] void check_notreached(std::string desc = "Execution was never supposed to reach this point.", sl loc = sl::current());
 
 // Verify that a condition is met, similar to assert()
 #define PQXX_CHECK(condition, desc)                                           \
@@ -169,13 +168,13 @@ inline void end_of_statement() {}
     }                                                                         \
     catch (std::exception const &e)                                           \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} + " - \"" +                                         \
         #action "\" threw exception: " + e.what());                           \
     }                                                                         \
     catch (...)                                                               \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} + " - \"" + #action "\" threw a non-exception!");   \
     }                                                                         \
   }                                                                           \
@@ -191,14 +190,14 @@ inline void end_of_statement() {}
     }                                                                         \
     catch (pqxx::test::failure_to_fail const &)                               \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} + " (\"" #action "\" did not throw)");              \
     }                                                                         \
     catch (std::exception const &)                                            \
     {}                                                                        \
     catch (...)                                                               \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} + " (\"" #action "\" threw non-exception type)");   \
     }                                                                         \
   }                                                                           \
@@ -214,7 +213,7 @@ inline void end_of_statement() {}
     }                                                                         \
     catch (pqxx::test::failure_to_fail const &)                               \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} + " (\"" #action                                    \
                             "\" did not throw " #exception_type ")");         \
     }                                                                         \
@@ -222,7 +221,7 @@ inline void end_of_statement() {}
     {}                                                                        \
     catch (std::exception const &e)                                           \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} +                                                   \
         " (\"" #action                                                        \
         "\" "                                                                 \
@@ -231,7 +230,7 @@ inline void end_of_statement() {}
     }                                                                         \
     catch (...)                                                               \
     {                                                                         \
-      PQXX_CHECK_NOTREACHED(                                                  \
+      pqxx::test::check_notreached(                                           \
         std::string{desc} + " (\"" #action "\" threw non-exception type)");   \
     }                                                                         \
   }                                                                           \

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -52,7 +52,9 @@ struct registrar
 
 
 // Unconditional test failure.
-[[noreturn]] void check_notreached(std::string desc = "Execution was never supposed to reach this point.", sl loc = sl::current());
+[[noreturn]] void check_notreached(
+  std::string desc = "Execution was never supposed to reach this point.",
+  sl loc = sl::current());
 
 // Verify that a condition is met, similar to assert()
 #define PQXX_CHECK(condition, desc)                                           \
@@ -138,8 +140,8 @@ inline void check_less_equal(
   if (value1 <= value2)
     return;
   std::string const fulldesc = pqxx::internal::concat(
-    desc, " (", text1, " > ", text2, ": \"lower\"=", value1, ", \"upper\"=",
-    value2, ")");
+    desc, " (", text1, " > ", text2, ": \"lower\"=", value1,
+    ", \"upper\"=", value2, ")");
   throw test_failure{fulldesc, loc};
 }
 
@@ -156,23 +158,30 @@ inline void end_of_statement() {}
 
 
 // Verify that "action" does not throw an exception.
-#define PQXX_CHECK_SUCCEEDS(action, desc) \
-  pqxx::test::check_succeeds(([&](){ action; }), #action, (desc))
+#define PQXX_CHECK_SUCCEEDS(action, desc)                                     \
+  pqxx::test::check_succeeds(([&]() { action; }), #action, (desc))
 
 template<std::invocable F>
-inline void check_succeeds(F &&f, char const text[], std::string desc = "Expected this to succeed.", sl loc = sl::current())
+inline void check_succeeds(
+  F &&f, char const text[], std::string desc = "Expected this to succeed.",
+  sl loc = sl::current())
 {
   try
   {
     f();
   }
-  catch(std::exception const &e)
+  catch (std::exception const &e)
   {
-    pqxx::test::check_notreached(pqxx::internal::concat(desc, " - \"", text, "\" threw exception: ", e.what()), loc);
+    pqxx::test::check_notreached(
+      pqxx::internal::concat(
+        desc, " - \"", text, "\" threw exception: ", e.what()),
+      loc);
   }
   catch (...)
   {
-    pqxx::test::check_notreached(pqxx::internal::concat(desc, " - \"", text, "\" threw a non-exception!"), loc);
+    pqxx::test::check_notreached(
+      pqxx::internal::concat(desc, " - \"", text, "\" threw a non-exception!"),
+      loc);
   }
 }
 

--- a/test/test_sql_cursor.cxx
+++ b/test/test_sql_cursor.cxx
@@ -23,45 +23,45 @@ void test_forward_sql_cursor()
   PQXX_CHECK_EQUAL(std::size(empty_result), 0, "Empty result not empty");
 
   auto displacement{0};
-  auto one{forward.fetch(1, displacement, PQXX_LOC::current())};
+  auto one{forward.fetch(1, displacement, pqxx::sl::current())};
   PQXX_CHECK_EQUAL(std::size(one), 1, "Fetched wrong number of rows");
   PQXX_CHECK_EQUAL(one[0][0].as<std::string>(), "1", "Unexpected result");
   PQXX_CHECK_EQUAL(displacement, 1, "Wrong displacement");
   PQXX_CHECK_EQUAL(forward.pos(), 1, "In wrong position");
 
-  auto offset{forward.move(1, displacement, PQXX_LOC::current())};
+  auto offset{forward.move(1, displacement, pqxx::sl::current())};
   PQXX_CHECK_EQUAL(offset, 1, "Unexpected offset from move()");
   PQXX_CHECK_EQUAL(displacement, 1, "Unexpected displacement after move()");
   PQXX_CHECK_EQUAL(forward.pos(), 2, "Wrong position after move()");
   PQXX_CHECK_EQUAL(forward.endpos(), -1, "endpos() unexpectedly set");
 
-  auto row{forward.fetch(0, displacement, PQXX_LOC::current())};
+  auto row{forward.fetch(0, displacement, pqxx::sl::current())};
   PQXX_CHECK_EQUAL(std::size(row), 0, "fetch(0, displacement) returns rows");
   PQXX_CHECK_EQUAL(displacement, 0, "Unexpected displacement after fetch(0)");
   PQXX_CHECK_EQUAL(forward.pos(), 2, "fetch(0, displacement) affected pos()");
 
-  row = forward.fetch(0, PQXX_LOC::current());
+  row = forward.fetch(0, pqxx::sl::current());
   PQXX_CHECK_EQUAL(std::size(row), 0, "fetch(0) fetched wrong number of rows");
   PQXX_CHECK_EQUAL(forward.pos(), 2, "fetch(0) moved cursor");
   PQXX_CHECK_EQUAL(forward.pos(), 2, "fetch(0) affected pos()");
 
-  offset = forward.move(1, PQXX_LOC::current());
+  offset = forward.move(1, pqxx::sl::current());
   PQXX_CHECK_EQUAL(offset, 1, "move(1) returned unexpected value");
   PQXX_CHECK_EQUAL(forward.pos(), 3, "move(1) after fetch(0) broke");
 
-  row = forward.fetch(1, PQXX_LOC::current());
+  row = forward.fetch(1, pqxx::sl::current());
   PQXX_CHECK_EQUAL(
     std::size(row), 1, "fetch(1) returned wrong number of rows");
   PQXX_CHECK_EQUAL(forward.pos(), 4, "fetch(1) results in bad pos()");
   PQXX_CHECK_EQUAL(row[0][0].as<std::string>(), "4", "pos() is lying");
 
-  empty_result = forward.fetch(1, displacement, PQXX_LOC::current());
+  empty_result = forward.fetch(1, displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(std::size(empty_result), 0, "Got rows at end of cursor");
   PQXX_CHECK_EQUAL(forward.pos(), 5, "Not at one-past-end position");
   PQXX_CHECK_EQUAL(forward.endpos(), 5, "Failed to notice end position");
   PQXX_CHECK_EQUAL(displacement, 1, "Wrong displacement at end position");
 
-  offset = forward.move(5, displacement, PQXX_LOC::current());
+  offset = forward.move(5, displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(offset, 0, "move() lied at end of result set");
   PQXX_CHECK_EQUAL(forward.pos(), 5, "pos() is beyond end");
   PQXX_CHECK_EQUAL(forward.endpos(), 5, "endpos() changed after end position");
@@ -75,7 +75,7 @@ void test_forward_sql_cursor()
 
   // Move through entire result set at once.
   offset =
-    forward2.move(pqxx::cursor_base::all(), displacement, PQXX_LOC::current());
+    forward2.move(pqxx::cursor_base::all(), displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(offset, 4, "Unexpected number of rows in result set");
   PQXX_CHECK_EQUAL(displacement, 5, "displacement != rows+1");
   PQXX_CHECK_EQUAL(forward2.pos(), 5, "Bad pos() after skipping all rows");
@@ -88,7 +88,7 @@ void test_forward_sql_cursor()
 
   // Fetch entire result set at once.
   auto rows{forward3.fetch(
-    pqxx::cursor_base::all(), displacement, PQXX_LOC::current())};
+    pqxx::cursor_base::all(), displacement, pqxx::sl::current())};
   PQXX_CHECK_EQUAL(
     std::size(rows), 4, "Unexpected number of rows in result set");
   PQXX_CHECK_EQUAL(displacement, 5, "displacement != rows+1");
@@ -100,7 +100,7 @@ void test_forward_sql_cursor()
     pqxx::cursor_base::forward_only, pqxx::cursor_base::read_only,
     pqxx::cursor_base::owned, false);
 
-  offset = forward_empty.move(3, displacement, PQXX_LOC::current());
+  offset = forward_empty.move(3, displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(forward_empty.pos(), 1, "Bad pos() at end of result");
   PQXX_CHECK_EQUAL(forward_empty.endpos(), 1, "Bad endpos() in empty result");
   PQXX_CHECK_EQUAL(displacement, 1, "Bad displacement in empty result");
@@ -119,7 +119,7 @@ void test_scroll_sql_cursor()
   PQXX_CHECK_EQUAL(scroll.pos(), 0, "Scroll cursor's initial pos() is wrong");
   PQXX_CHECK_EQUAL(scroll.endpos(), -1, "New scroll cursor has endpos() set");
 
-  auto rows{scroll.fetch(pqxx::cursor_base::next(), PQXX_LOC::current())};
+  auto rows{scroll.fetch(pqxx::cursor_base::next(), pqxx::sl::current())};
   PQXX_CHECK_EQUAL(std::size(rows), 1, "Scroll cursor is broken");
   PQXX_CHECK_EQUAL(scroll.pos(), 1, "Scroll cursor's pos() is broken");
   PQXX_CHECK_EQUAL(scroll.endpos(), -1, "endpos() set prematurely");
@@ -127,7 +127,7 @@ void test_scroll_sql_cursor()
   // Turn cursor around.  This is where we begin to feel SQL cursors'
   // semantics: we pre-decrement, ending up on the position in front of the
   // first row and returning no rows.
-  rows = scroll.fetch(pqxx::cursor_base::prior(), PQXX_LOC::current());
+  rows = scroll.fetch(pqxx::cursor_base::prior(), pqxx::sl::current());
   PQXX_CHECK_EQUAL(std::empty(rows), true, "Turning around on fetch() broke");
   PQXX_CHECK_EQUAL(scroll.pos(), 0, "pos() is not back at zero");
   PQXX_CHECK_EQUAL(
@@ -136,7 +136,7 @@ void test_scroll_sql_cursor()
   // Bounce off the left-hand side of the result set.  Can't move before the
   // starting position.
   auto offset{0}, displacement{0};
-  offset = scroll.move(-3, displacement, PQXX_LOC::current());
+  offset = scroll.move(-3, displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(offset, 0, "Rows found before beginning");
   PQXX_CHECK_EQUAL(displacement, 0, "Failed to bounce off beginning");
   PQXX_CHECK_EQUAL(scroll.pos(), 0, "pos() moved back from zero");
@@ -144,27 +144,27 @@ void test_scroll_sql_cursor()
 
   // Try bouncing off the left-hand side a little harder.  Take 4 paces away
   // from the boundary and run into it.
-  offset = scroll.move(4, displacement, PQXX_LOC::current());
+  offset = scroll.move(4, displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(offset, 4, "Offset mismatch");
   PQXX_CHECK_EQUAL(displacement, 4, "Displacement mismatch");
   PQXX_CHECK_EQUAL(scroll.pos(), 4, "Position mismatch");
   PQXX_CHECK_EQUAL(scroll.endpos(), -1, "endpos() set at weird time");
 
-  offset = scroll.move(-10, displacement, PQXX_LOC::current());
+  offset = scroll.move(-10, displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(offset, 3, "Offset mismatch");
   PQXX_CHECK_EQUAL(displacement, -4, "Displacement mismatch");
   PQXX_CHECK_EQUAL(scroll.pos(), 0, "Hard bounce failed");
   PQXX_CHECK_EQUAL(scroll.endpos(), -1, "endpos() set during hard bounce");
 
-  rows = scroll.fetch(3, PQXX_LOC::current());
+  rows = scroll.fetch(3, pqxx::sl::current());
   PQXX_CHECK_EQUAL(scroll.pos(), 3, "Bad pos()");
   PQXX_CHECK_EQUAL(std::size(rows), 3, "Wrong number of rows");
   PQXX_CHECK_EQUAL(rows[2][0].as<int>(), 3, "pos() does not match data");
-  rows = scroll.fetch(-1, PQXX_LOC::current());
+  rows = scroll.fetch(-1, pqxx::sl::current());
   PQXX_CHECK_EQUAL(scroll.pos(), 2, "Bad pos()");
   PQXX_CHECK_EQUAL(rows[0][0].as<int>(), 2, "pos() does not match data");
 
-  rows = scroll.fetch(1, PQXX_LOC::current());
+  rows = scroll.fetch(1, pqxx::sl::current());
   PQXX_CHECK_EQUAL(scroll.pos(), 3, "Bad pos() after inverse turnaround");
   PQXX_CHECK_EQUAL(rows[0][0].as<int>(), 3, "Data position mismatch");
 }
@@ -185,7 +185,7 @@ void test_adopted_sql_cursor()
 
   auto displacement{0};
   auto rows{adopted.fetch(
-    pqxx::cursor_base::all(), displacement, PQXX_LOC::current())};
+    pqxx::cursor_base::all(), displacement, pqxx::sl::current())};
   PQXX_CHECK_EQUAL(std::size(rows), 3, "Wrong number of rows in result");
   PQXX_CHECK_EQUAL(rows[0][0].as<int>(), 1, "Wrong result data");
   PQXX_CHECK_EQUAL(rows[2][0].as<int>(), 3, "Wrong result data");
@@ -195,7 +195,7 @@ void test_adopted_sql_cursor()
   PQXX_CHECK_EQUAL(adopted.endpos(), -1, "endpos() set too early");
 
   rows = adopted.fetch(
-    pqxx::cursor_base::backward_all(), displacement, PQXX_LOC::current());
+    pqxx::cursor_base::backward_all(), displacement, pqxx::sl::current());
   PQXX_CHECK_EQUAL(std::size(rows), 3, "Wrong number of rows in result");
   PQXX_CHECK_EQUAL(rows[0][0].as<int>(), 3, "Wrong result data");
   PQXX_CHECK_EQUAL(rows[2][0].as<int>(), 1, "Wrong result data");
@@ -203,7 +203,7 @@ void test_adopted_sql_cursor()
   PQXX_CHECK_EQUAL(adopted.pos(), 0, "Failed to recognize starting position");
   PQXX_CHECK_EQUAL(adopted.endpos(), -1, "endpos() set too early");
 
-  auto offset{adopted.move(pqxx::cursor_base::all(), PQXX_LOC::current())};
+  auto offset{adopted.move(pqxx::cursor_base::all(), pqxx::sl::current())};
   PQXX_CHECK_EQUAL(offset, 3, "Unexpected move() offset");
   PQXX_CHECK_EQUAL(adopted.pos(), 4, "Bad position on adopted cursor");
   PQXX_CHECK_EQUAL(adopted.endpos(), 4, "endpos() not set properly");
@@ -248,7 +248,7 @@ void test_hold_cursor()
     pqxx::cursor_base::owned, true);
   tx.commit();
   pqxx::work tx2(cx, "tx2");
-  auto rows{with_hold.fetch(1, PQXX_LOC::current())};
+  auto rows{with_hold.fetch(1, pqxx::sl::current())};
   PQXX_CHECK_EQUAL(
     std::size(rows), 1, "Did not get 1 row from with-hold cursor");
 
@@ -260,7 +260,7 @@ void test_hold_cursor()
   tx2.commit();
   pqxx::work tx3(cx, "tx3");
   PQXX_CHECK_THROWS(
-    no_hold.fetch(1, PQXX_LOC::current()), pqxx::sql_error,
+    no_hold.fetch(1, pqxx::sl::current()), pqxx::sql_error,
     "Cursor not closed on commit");
 }
 

--- a/test/test_stream_from.cxx
+++ b/test/test_stream_from.cxx
@@ -31,7 +31,7 @@ void test_nonoptionals(pqxx::connection &connection)
     // We can't read the "910" row -- it contains nulls, which our tuple does
     // not accept.
     extractor >> got_tuple;
-    PQXX_CHECK_NOTREACHED(
+    pqxx::test::check_notreached(
       "Failed to fail to stream null values into null-less fields.");
   }
   catch (pqxx::conversion_error const &e)
@@ -86,7 +86,7 @@ void test_nonoptionals(pqxx::connection &connection)
   try
   {
     ex2 >> null_tup;
-    PQXX_CHECK_NOTREACHED(
+    pqxx::test::check_notreached(
       "stream_from should have refused to convert non-null value to "
       "nullptr_t.");
   }
@@ -116,7 +116,7 @@ void test_bad_tuples(pqxx::connection &cx)
   try
   {
     extractor >> got_tuple_too_short;
-    PQXX_CHECK_NOTREACHED("stream_from improperly read first row");
+    pqxx::test::check_notreached("stream_from improperly read first row");
   }
   catch (pqxx::usage_error const &e)
   {
@@ -133,7 +133,7 @@ void test_bad_tuples(pqxx::connection &cx)
   try
   {
     extractor >> got_tuple_too_long;
-    PQXX_CHECK_NOTREACHED("stream_from improperly read first row");
+    pqxx::test::check_notreached("stream_from improperly read first row");
   }
   catch (pqxx::usage_error const &e)
   {

--- a/test/test_stream_to.cxx
+++ b/test/test_stream_to.cxx
@@ -148,7 +148,7 @@ void test_too_few_fields(pqxx::connection &connection)
     inserter << std::make_tuple(1234, "now", 4321, ipv4{8, 8, 8, 8});
     inserter.complete();
     tx.commit();
-    PQXX_CHECK_NOTREACHED("stream_from improperly inserted row");
+    pqxx::test::check_notreached("stream_from improperly inserted row");
   }
   catch (pqxx::sql_error const &e)
   {
@@ -171,7 +171,7 @@ void test_too_few_fields_fold(pqxx::connection &connection)
     inserter.write_values(1234, "now", 4321, ipv4{8, 8, 8, 8});
     inserter.complete();
     tx.commit();
-    PQXX_CHECK_NOTREACHED("stream_from_fold improperly inserted row");
+    pqxx::test::check_notreached("stream_from_fold improperly inserted row");
   }
   catch (pqxx::sql_error const &e)
   {
@@ -197,7 +197,7 @@ void test_too_many_fields(pqxx::connection &connection)
       bytea{'\x00', '\x01', '\x02'}, 5678);
     inserter.complete();
     tx.commit();
-    PQXX_CHECK_NOTREACHED("stream_from improperly inserted row");
+    pqxx::test::check_notreached("stream_from improperly inserted row");
   }
   catch (pqxx::sql_error const &e)
   {
@@ -222,7 +222,7 @@ void test_too_many_fields_fold(pqxx::connection &connection)
       bytea{'\x00', '\x01', '\x02'}, 5678);
     inserter.complete();
     tx.commit();
-    PQXX_CHECK_NOTREACHED("stream_from_fold improperly inserted row");
+    pqxx::test::check_notreached("stream_from_fold improperly inserted row");
   }
   catch (pqxx::sql_error const &e)
   {

--- a/test/test_test_helpers.cxx
+++ b/test/test_test_helpers.cxx
@@ -7,11 +7,11 @@ void empty() {}
 
 void test_check_notreached()
 {
-  // At a minimum, PQXX_CHECK_NOTREACHED must work.
+  // At a minimum, check_notreached() must work.
   bool failed{true};
   try
   {
-    PQXX_CHECK_NOTREACHED("(expected)");
+    pqxx::test::check_notreached("(expected)");
     failed = false;
   }
   catch (pqxx::test::test_failure const &)
@@ -19,7 +19,7 @@ void test_check_notreached()
     // This is what we expect.
   }
   if (not failed)
-    throw pqxx::test::test_failure{"PQXX_CHECK_NOTREACHED is broken."};
+    throw pqxx::test::test_failure{"check_notreached is broken."};
 }
 
 
@@ -37,7 +37,7 @@ void test_check()
   catch (pqxx::test::test_failure const &)
   {}
   if (not failed)
-    PQXX_CHECK_NOTREACHED("PQXX_CHECK failed to notice failure.");
+    pqxx::test::check_notreached("PQXX_CHECK failed to notice failure.");
 }
 
 
@@ -156,8 +156,8 @@ void test_test_helpers()
 
   // Test other helpers against PQXX_CHECK_THROWS.
   PQXX_CHECK_THROWS(
-    PQXX_CHECK_NOTREACHED("(expected)"), pqxx::test::test_failure,
-    "PQXX_CHECK_THROWS did not catch PQXX_CHECK_NOTREACHED.");
+    pqxx::test::check_notreached("(expected)"), pqxx::test::test_failure,
+    "PQXX_CHECK_THROWS did not catch check_notreached().");
 
   PQXX_CHECK_THROWS(
     PQXX_CHECK(false, "(expected)"), pqxx::test::test_failure,

--- a/test/test_types.hxx
+++ b/test/test_types.hxx
@@ -87,11 +87,11 @@ template<> struct string_traits<ipv4>
   static constexpr bool converts_to_string{true};
   static constexpr bool converts_from_string{true};
 
-  static ipv4 from_string(std::string_view text)
+  static ipv4 from_string(std::string_view text, sl loc = sl::current())
   {
     ipv4 ts;
     if (std::data(text) == nullptr)
-      internal::throw_null_conversion(type_name<ipv4>);
+      internal::throw_null_conversion(type_name<ipv4>, loc);
     std::vector<std::size_t> ends;
     for (std::size_t i{0}; i < std::size(text); ++i)
       if (text[i] == '.')


### PR DESCRIPTION
I'm trying to add std::source_location parameters to every libpqxx function that may throw, and pass the value on whenever those functions call other libpqxx functions that may throw. The ideal end state would be one where every exception coming out of libpqxx would convey the location of the original call into libpqxx that ultimately triggered the exception.

In practice this ideal does not look fully attainable, because as far as I can see...
1.  there's no way to add a parameter with a default value to the end of a template function with a variable number of parameters.
2.  we have no reasonable way of dealing with exceptions that the standard library may throw when we call it.
3. destructors and overloaded operators don't generally let you add parameters.