### PR TITLE
Use imported target.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # happens to contain autoconf-generated config headers, we should still prefer
 # the ones in the binary tree.
 macro(library_target_setup tgt)
+    get_target_property (PostgreSQL_INCLUDE_DIRS PostgreSQL::PostgreSQL INTERFACE_INCLUDE_DIRECTORIES)
     target_include_directories(${tgt}
     	PUBLIC
     		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
@@ -26,7 +27,7 @@ macro(library_target_setup tgt)
     	PRIVATE
     		${PostgreSQL_INCLUDE_DIRS}
     )
-    target_link_libraries(${tgt} PRIVATE ${PostgreSQL_LIBRARIES})
+    target_link_libraries(${tgt} PRIVATE PostgreSQL::PostgreSQL)
     if(WIN32)
         target_link_libraries(${tgt} PUBLIC wsock32 ws2_32)
     endif()


### PR DESCRIPTION
This fixes the absolute path being in the CMake config file.