### PR TITLE
Use Debian testing instead of unstable for CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,20 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:unstable
+      - image: debian:testing
     environment:
       - PGHOST: "/tmp"
     steps:
       - checkout
       - run:
           name: Configure apt archives
-          command: apt update
+          command: apt-get update && apt-get -y upgrade
       - run:
           name: Install
-          command: apt install -y lsb-release python3 cmake postgresql libpq-dev
-            postgresql-server-dev-all build-essential autoconf dh-autoreconf
-            autoconf-archive automake cppcheck clang shellcheck
-            python3-virtualenv
+          command: DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y
+            lsb-release python3 postgresql libpq-dev postgresql-server-dev-all
+            build-essential autoconf autoconf-archive automake cppcheck clang
+            shellcheck python3-virtualenv libtool
       - run:
           name: Identify
           command: lsb_release -a && c++ --version && clang++ --version


### PR DESCRIPTION
For some reason running Debian unstable in CircleCI has been failing for a while now, at the stage where we install packages.

Backporting these changes from the `start-8` branch.