### PR TITLE
Fix some CodeQL "passing large object" warnings.

### DIFF
--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -110,7 +110,7 @@ std::string list_result(result Obj)
 }
 
 
-std::string list_result_iterator(result::const_iterator Obj)
+std::string list_result_iterator(result::const_iterator const &Obj)
 {
   return "<iterator at " + to_string(Obj.rownumber()) + ">";
 }

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -118,7 +118,7 @@ inline void check_equal(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  ACTUAL actual, char const actual_text[], EXPECTED expected,
+  ACTUAL const &actual, char const actual_text[], EXPECTED const &expected,
   char const expected_text[], std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
@@ -157,7 +157,7 @@ inline void check_not_equal(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE1 value1, char const text1[], VALUE2 value2, char const text2[],
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
   std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
@@ -201,7 +201,7 @@ inline void check_less(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE1 value1, char const text1[], VALUE2 value2, char const text2[],
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
   std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
@@ -248,7 +248,7 @@ inline void check_less_equal(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE1 value1, char const text1[], VALUE2 value2, char const text2[],
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
   std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
@@ -376,8 +376,8 @@ inline void check_bounds(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE value, char const text[], LOWER lower, char const lower_text[],
-  UPPER upper, char const upper_text[], std::string const &desc
+  VALUE const &value, char const text[], LOWER const &lower, char const lower_text[],
+  UPPER const &upper, char const upper_text[], std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
   std::source_location loc = std::source_location::current()
@@ -434,7 +434,7 @@ std::string list_row(row);
 // Represent result as string.
 std::string list_result(result);
 // Represent result iterator as string.
-std::string list_result_iterator(result::const_iterator);
+std::string list_result_iterator(result::const_iterator const &);
 
 
 // @deprecated Set up test data for legacy tests.


### PR DESCRIPTION
The code scan on GitHub was complaining about some slightly large objects were being passed as arguments in test code.

Not a huge deal, since this is test code and we're not talking about stack-threatening amounts, but fixing is better than ignoring.

There were a few others that are a bit harder to fix, and which may be gone anyway in the current 8.0 code.