### PR TITLE
#961: Introduce `copy_chars()` helper.

### DIFF
--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -137,7 +137,7 @@ inline std::size_t composite_into_buf(std::span<char> buf, T const &...fields)
   if constexpr (num_fields == 0)
   {
     constexpr std::string_view empty{"()"};
-    return empty.copy(std::data(buf), std::size(empty));
+    return pqxx::internal::copy_chars(empty, buf, 0, false, loc);
   }
 
   std::size_t pos{0};

--- a/include/pqxx/composite.hxx
+++ b/include/pqxx/composite.hxx
@@ -137,7 +137,7 @@ inline std::size_t composite_into_buf(std::span<char> buf, T const &...fields)
   if constexpr (num_fields == 0)
   {
     constexpr std::string_view empty{"()"};
-    return pqxx::internal::copy_chars(empty, buf, 0, false, loc);
+    return pqxx::internal::copy_chars<false>(empty, buf, 0, loc);
   }
 
   std::size_t pos{0};

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -700,12 +700,7 @@ template<> struct string_traits<std::string_view>
   static std::size_t
   into_buf(std::span<char> buf, std::string_view const &value, ctx c = {})
   {
-    if (std::cmp_greater_equal(std::size(value), std::size(buf)))
-      throw conversion_overrun{
-        "Could not store string_view: too long for buffer.", c.loc};
-    value.copy(std::data(buf), std::size(value));
-    buf[std::size(value)] = '\0';
-    return std::size(value) + 1;
+    return pqxx::internal::copy_chars(value, buf, 0, true, c.loc);
   }
 
   static zview to_buf(char *begin, char *end, std::string_view const &value)
@@ -1004,9 +999,7 @@ std::size_t array_into_buf(
     static constexpr zview s_null{"NULL"};
     if (is_null(elt))
     {
-      assert(std::cmp_less(here + std::size(s_null) + 1, std::size(buf)));
-      s_null.copy(std::data(buf) + here, std::size(s_null));
-      here += std::size(s_null);
+      here = copy_chars(s_null, buf, here, false, c.loc);
     }
     else if constexpr (is_sql_array<elt_type>)
     {

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -700,7 +700,7 @@ template<> struct string_traits<std::string_view>
   static std::size_t
   into_buf(std::span<char> buf, std::string_view const &value, ctx c = {})
   {
-    return pqxx::internal::copy_chars(value, buf, 0, true, c.loc);
+    return pqxx::internal::copy_chars<true>(value, buf, 0, c.loc);
   }
 
   static zview to_buf(char *begin, char *end, std::string_view const &value)
@@ -999,7 +999,7 @@ std::size_t array_into_buf(
     static constexpr zview s_null{"NULL"};
     if (is_null(elt))
     {
-      here = copy_chars(s_null, buf, here, false, c.loc);
+      here = copy_chars<false>(s_null, buf, here, c.loc);
     }
     else if constexpr (is_sql_array<elt_type>)
     {

--- a/include/pqxx/separated_list.hxx
+++ b/include/pqxx/separated_list.hxx
@@ -66,7 +66,7 @@ separated_list(std::string_view sep, ITER begin, ITER end, ACCESS access)
   std::size_t here{pqxx::into_buf({data, stop}, access(begin)) - 1};
   for (++begin; begin != end; ++begin)
   {
-    here = pqxx::internal::copy_chars(sep, result, here, false, sl::current());
+    here = pqxx::internal::copy_chars<false>(sep, result, here, sl::current());
     here += pqxx::into_buf({data + here, stop}, access(begin)) - 1;
   }
   result.resize(here);

--- a/include/pqxx/separated_list.hxx
+++ b/include/pqxx/separated_list.hxx
@@ -66,7 +66,7 @@ separated_list(std::string_view sep, ITER begin, ITER end, ACCESS access)
   std::size_t here{pqxx::into_buf({data, stop}, access(begin)) - 1};
   for (++begin; begin != end; ++begin)
   {
-    here += sep.copy(data + here, std::size(sep));
+    here = pqxx::internal::copy_chars(sep, result, here, false, sl::current());
     here += pqxx::into_buf({data + here, stop}, access(begin)) - 1;
   }
   result.resize(here);

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -630,9 +630,9 @@ inline std::string source_loc(sl loc)
  *
  * If `terminate` is true, also writes a terminating zero.
  */
+template<bool terminate>
 inline std::size_t copy_chars(
-  std::string_view src, std::span<char> dst, std::size_t dst_offset,
-  bool terminate, sl loc)
+  std::string_view src, std::span<char> dst, std::size_t dst_offset, sl loc)
 {
   auto const sz{std::size(src)};
   if (std::cmp_greater(
@@ -644,7 +644,7 @@ inline std::size_t copy_chars(
         sz, src, std::size(dst), dst_offset),
       loc};
   auto at{dst_offset + src.copy(std::data(dst) + dst_offset, sz)};
-  if (terminate)
+  if constexpr (terminate)
     dst[at++] = '\0';
   return at;
 }

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -612,6 +612,42 @@ inline std::string source_loc(sl loc)
     return std::string{loc.file_name()};
   }
 }
+
+
+/// Copy text from `src` into `buf` at offset `dst_offset`.
+/** This is a wrapper for `std::string_view::copy()` with a few changes.
+ *
+ * First, it checks for overruns and throws @ref pqxx::conversion_overrun if
+ * needed.  (To that end, the destination is a `std::span`, not a raw pointer.)
+ *
+ * Second, it takes an offset _into the destination buffer,_ i.e. you can tell
+ * it where in the destination buffer the copy should write, but there's no
+ * parameter to influence which part of `src` you want to copy.  You always
+ * copy the whole thing.
+ *
+ * Third, it returns not the number of bytes it copied, but rather, the offset
+ * into `dst` that's right behind the last copied byte.
+ *
+ * If `terminate` is true, also writes a terminating zero.
+ */
+inline std::size_t copy_chars(
+  std::string_view src, std::span<char> dst, std::size_t dst_offset,
+  bool terminate, sl loc)
+{
+  auto const sz{std::size(src)};
+  if (std::cmp_greater(
+        dst_offset + sz + std::size_t(terminate), std::size(dst)))
+    throw conversion_overrun{
+      std::format(
+        "Text copy exceeded buffer space: tried to copy {} bytes '{}' into a "
+        "buffer of {} bytes, at offset {}.",
+        sz, src, std::size(dst), dst_offset),
+      loc};
+  auto at{dst_offset + src.copy(std::data(dst) + dst_offset, sz)};
+  if (terminate)
+    dst[at++] = '\0';
+  return at;
+}
 } // namespace pqxx::internal
 
 

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -90,8 +90,8 @@ inline void check_equal(
   pqxx::test::check_not_equal((value1), #value1, (value2), #value2, (desc))
 template<typename VALUE1, typename VALUE2>
 inline void check_not_equal(
-  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
-  std::string const &desc, sl loc = sl::current())
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2,
+  char const text2[], std::string const &desc, sl loc = sl::current())
 {
   if (value1 != value2)
     return;
@@ -111,8 +111,8 @@ inline void check_not_equal(
   pqxx::test::check_less((value1), #value1, (value2), #value2, (desc))
 template<typename VALUE1, typename VALUE2>
 inline void check_less(
-  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
-  std::string const &desc, sl loc = sl::current())
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2,
+  char const text2[], std::string const &desc, sl loc = sl::current())
 {
   if (value1 < value2)
     return;
@@ -135,8 +135,8 @@ inline void check_less(
   pqxx::test::check_less_equal((value1), #value1, (value2), #value2, (desc))
 template<typename VALUE1, typename VALUE2>
 inline void check_less_equal(
-  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
-  std::string const &desc, sl loc = sl::current())
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2,
+  char const text2[], std::string const &desc, sl loc = sl::current())
 {
   if (value1 <= value2)
     return;
@@ -258,9 +258,9 @@ inline void check_throws_exception(
     (value), #value, (lower), #lower, (upper), #upper, (desc))
 template<typename VALUE, typename LOWER, typename UPPER>
 inline void check_bounds(
-  VALUE const &value, char const text[], LOWER const &lower, char const lower_text[],
-  UPPER const &upper, char const upper_text[], std::string const &desc,
-  sl loc = sl::current())
+  VALUE const &value, char const text[], LOWER const &lower,
+  char const lower_text[], UPPER const &upper, char const upper_text[],
+  std::string const &desc, sl loc = sl::current())
 {
   std::string const range_check = std::string{lower_text} + " < " + upper_text,
                     lower_check =


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/961

This is something I kept needing: a bounds-checking version of
std::string_view::copy(), which writes into a std::span<char>
instead of a raw pointer; which just copies the entire string without
needing an argument to say so; and which accepts an offset into the
destination buffer (not one into the source),

As I upgrade more string conversions to the libpqxx 8.0 API, I expect to
need this in many more places.