### PR TITLE
#959: Replace `type_name` template with `name_type()`.

### DIFF
--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -427,7 +427,7 @@ private:
                 std::format(
                   "Array contains a null {}.  Consider making it an array of "
                   "std::optional<{}> instead.",
-                  type_name<ELEMENT>, type_name<ELEMENT>),
+                  name_type<ELEMENT>(), name_type<ELEMENT>()),
                 loc};
           }
           else

--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -74,10 +74,11 @@ First off, of course, you need a C++ type.  It may be your own, but it doesn't
 have to be.  It could be a type from a third-party library, or even one from
 the standard library that libpqxx does not yet support.
 
-First thing to do is specialise the `pqxx::type_name` variable to give the type
-a human-readable name.  That allows libpqxx error messages and such to talk
-about the type.  If you don't define a name, libpqxx will try to figure one out
-with some help from the compiler, but it may not always be easy to read.
+First thing to do is specialise the `pqxx::name_type()` function to give the
+type a human-readable name.  That allows libpqxx error messages and such to
+talk about the type.  If you don't define a name, libpqxx will try to figure
+one out with some help from the compiler, but it may not always be easy to
+read.
 
 Then, does your type have a built-in null value?  For example, a `char *` can
 be null on the C++ side.  Or some types are _always_ null, such as `nullptr`.
@@ -112,8 +113,8 @@ The library also provides specialisations for `std::optional<T>`,
 have conversions for `T`, you'll also automatically have conversions for those.
 
 
-Specialise `type_name`
-----------------------
+Specialise `name_type()`
+------------------------
 
 (This is a feature that should disappear once we have introspection in the C++
 language.)
@@ -122,15 +123,16 @@ When errors happen during conversion, libpqxx will compose error messages for
 the user.  Sometimes these will include the name of the type that's being
 converted.
 
-To tell libpqxx the name of each type, there's a template variable called
-`pqxx::type_name`.  For any given type `T`, it should have a specialisation
+To tell libpqxx the name of each type, there's a function template called
+`pqxx::name_type()`.  For any given type `T`, it should have a specialisation
 that provides that `T`'s human-readable name:
 
 ```cxx
     // T is your type.
     namespace pqxx
     {
-    template<> std::string const type_name<T>{"My T type's name"};
+    template<> inline std::string_view
+    name_type<T>(){ return "My T type's name"; };
     }
 ```
 

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -227,7 +227,7 @@ public:
     if (is_null())
     {
       if constexpr (not nullness<T>::has_null)
-        internal::throw_null_conversion(type_name<T>, c.loc);
+        internal::throw_null_conversion(name_type<T>(), c.loc);
       else
         return nullness<T>::null();
     }
@@ -255,7 +255,7 @@ public:
 
     // There's no such thing as a null SQL array.
     if (is_null())
-      internal::throw_null_conversion(type_name<array_type>, loc);
+      internal::throw_null_conversion(name_type<array_type>(), loc);
     else
       return array_type{this->view(), this->m_home.m_encoding, loc};
   }
@@ -366,7 +366,7 @@ inline bool field::to<zview>(zview &obj, zview const &default_value, ctx) const
 template<> inline zview field::as<zview>(ctx c) const
 {
   if (is_null())
-    internal::throw_null_conversion(type_name<zview>, c.loc);
+    internal::throw_null_conversion(name_type<zview>(), c.loc);
   return zview{c_str(), size()};
 }
 
@@ -505,7 +505,7 @@ template<typename T> inline T from_string(field const &value, ctx c = {})
     if constexpr (nullness<T>::has_null)
       return nullness<T>::null();
     else
-      internal::throw_null_conversion(type_name<T>, c.loc);
+      internal::throw_null_conversion(name_type<T>(), c.loc);
   }
   else
   {

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -202,7 +202,7 @@ inline void parse_composite_field(
       throw conversion_error{
         std::format(
           "Can't read composite field {}: C++ type {} does not support nulls.",
-          to_string(index), type_name<T>),
+          to_string(index), name_type<T>()),
         loc};
     break;
 

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -841,7 +841,7 @@ struct string_traits<std::unique_ptr<T, Args...>>
     ctx c = {})
   {
     if (not value)
-      internal::throw_null_conversion(name_type<std::unique_ptr<T>()>, c.loc);
+      internal::throw_null_conversion(name_type<std::unique_ptr<T>>(), c.loc);
     return begin + pqxx::into_buf({begin, end}, *value);
   }
 
@@ -850,7 +850,7 @@ struct string_traits<std::unique_ptr<T, Args...>>
     ctx c = {})
   {
     if (not value)
-      internal::throw_null_conversion(name_type<std::unique_ptr<T>()>, c.loc);
+      internal::throw_null_conversion(name_type<std::unique_ptr<T>>(), c.loc);
     return pqxx::to_buf({begin, end}, *value);
   }
 

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -101,7 +101,7 @@ generic_into_buf(char *begin, char *end, T const &value, ctx c = {})
   auto const len = std::size(text) + 1;
   if (std::cmp_greater(len, space))
     throw conversion_overrun{
-      std::format("Not enough buffer space to insert {}.  ", type_name<T>) +
+      std::format("Not enough buffer space to insert {}.  ", name_type<T>()) +
         state_buffer_overrun(space, len),
       c.loc};
   std::memmove(begin, std::data(text), len);
@@ -121,7 +121,7 @@ generic_into_buf(std::span<char> buf, T const &value, ctx c = {})
   auto const len = std::size(text) + 1;
   if (std::cmp_greater(len, space))
     throw conversion_overrun{
-      std::format("Not enough buffer space to insert {}.  ", type_name<T>) +
+      std::format("Not enough buffer space to insert {}.  ", name_type<T>()) +
         state_buffer_overrun(space, len),
       c.loc};
   std::memmove(begin, std::data(text), len);
@@ -841,7 +841,7 @@ struct string_traits<std::unique_ptr<T, Args...>>
     ctx c = {})
   {
     if (not value)
-      internal::throw_null_conversion(type_name<std::unique_ptr<T>>, c.loc);
+      internal::throw_null_conversion(name_type<std::unique_ptr<T>()>, c.loc);
     return begin + pqxx::into_buf({begin, end}, *value);
   }
 
@@ -850,7 +850,7 @@ struct string_traits<std::unique_ptr<T, Args...>>
     ctx c = {})
   {
     if (not value)
-      internal::throw_null_conversion(type_name<std::unique_ptr<T>>, c.loc);
+      internal::throw_null_conversion(name_type<std::unique_ptr<T>()>, c.loc);
     return pqxx::to_buf({begin, end}, *value);
   }
 
@@ -905,14 +905,14 @@ template<typename T> struct string_traits<std::shared_ptr<T>>
   to_buf(char *begin, char *end, std::shared_ptr<T> const &value, ctx c = {})
   {
     if (not value)
-      internal::throw_null_conversion(type_name<std::shared_ptr<T>>, c.loc);
+      internal::throw_null_conversion(name_type<std::shared_ptr<T>>(), c.loc);
     return pqxx::to_buf({begin, end}, *value, c);
   }
   static char *
   into_buf(char *begin, char *end, std::shared_ptr<T> const &value, ctx c = {})
   {
     if (not value)
-      internal::throw_null_conversion(type_name<std::shared_ptr<T>>, c.loc);
+      internal::throw_null_conversion(name_type<std::shared_ptr<T>>(), c.loc);
     return begin + pqxx::into_buf({begin, end}, *value, c);
   }
   static std::size_t size_buffer(std::shared_ptr<T> const &value) noexcept
@@ -1140,7 +1140,7 @@ template<typename TYPE> inline std::string to_string(TYPE const &value, ctx c)
 {
   if (is_null(value))
     throw conversion_error{
-      std::format("Attempt to convert null to a string.", type_name<TYPE>),
+      std::format("Attempt to convert null to a string.", name_type<TYPE>()),
       c.loc};
 
   if constexpr (nullness<std::remove_cvref_t<TYPE>>::always_null)
@@ -1187,7 +1187,7 @@ inline void into_string(T const &value, std::string &out, ctx c = {})
 {
   if (is_null(value))
     throw conversion_error{
-      std::format("Attempt to convert null {} to a string.", type_name<T>),
+      std::format("Attempt to convert null {} to a string.", name_type<T>()),
       c.loc};
 
   // We can't just reserve() data; modifying the terminating zero leads to

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -282,14 +282,14 @@ private:
       if (std::data(text) != nullptr)
         throw conversion_error{std::format(
           "Streaming a non-null value into a {}, which must always be null.",
-          type_name<field_type>)};
+          name_type<field_type>())};
     }
     else if (std::data(text) == nullptr)
     {
       if constexpr (nullity::has_null)
         return nullity::null();
       else
-        internal::throw_null_conversion(type_name<field_type>, loc);
+        internal::throw_null_conversion(name_type<field_type>(), loc);
     }
     else
     {

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -30,13 +30,6 @@
 #include "pqxx/zview.hxx"
 
 
-namespace pqxx::internal
-{
-/// Attempt to demangle @c std::type_info::name() to something human-readable.
-PQXX_LIBEXPORT std::string demangle_type_name(char const[]);
-} // namespace pqxx::internal
-
-
 namespace pqxx
 {
 /**
@@ -63,18 +56,6 @@ namespace pqxx
  * types.  The conversion will represent enumeration values as numeric strings.
  */
 //@{
-
-/// A human-readable name for a type, used in error messages and such.
-/** Actually this may not always be very user-friendly.  It uses
- * @c std::type_info::name().  On gcc-like compilers we try to demangle its
- * output.  Visual Studio produces human-friendly names out of the box.
- *
- * This variable is not inline.  Inlining it gives rise to "memory leak"
- * warnings from asan, the address sanitizer, possibly from use of
- * @c std::type_info::name.
- */
-template<typename TYPE>
-std::string const type_name{internal::demangle_type_name(typeid(TYPE).name())};
 
 
 /// Traits describing a type's "null value," if any.

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -594,13 +594,9 @@ private:
 } // namespace pqxx::internal
 
 
-// We used to inline type_name<ENUM>, but this triggered a "double free" error
-// on program exit, when libpqxx was built as a shared library on Debian with
-// gcc 12.
-
 /// Macro: Define a string conversion for an enum type.
-/** This specialises the @c pqxx::string_traits template, so use it in the
- * @c ::pqxx namespace.
+/** This specialises the @ref pqxx::string_traits and @ref pqxx::name_type
+ * templates, so use it in the @ref pqxx namespace.
  *
  * For example:
  *
@@ -611,12 +607,15 @@ private:
  *      int main() { std::cout << pqxx::to_string(xa) << std::endl; }
  */
 #define PQXX_DECLARE_ENUM_CONVERSION(ENUM)                                    \
-  template<> struct string_traits<ENUM> : pqxx::internal::enum_traits<ENUM>   \
-  {};                                                                         \
-  template<> inline std::string_view const type_name<ENUM>                    \
+  template<>                                                                  \
+  [[maybe_unused, deprecated("Use name_type() instead of type_name.")]]       \
+  inline std::string_view const type_name<ENUM>{#ENUM};                       \
+  template<> constexpr inline std::string_view name_type<ENUM>()              \
   {                                                                           \
-    #ENUM                                                                     \
-  }
+    return #ENUM;                                                             \
+  }                                                                           \
+  template<> struct string_traits<ENUM> : pqxx::internal::enum_traits<ENUM>   \
+  {}
 
 
 namespace pqxx

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -358,7 +358,7 @@ inline void stream_from::extract_value(Tuple &t, sl loc) const
     if constexpr (nullity::has_null)
       std::get<index>(t) = nullity::null();
     else
-      internal::throw_null_conversion(type_name<field_type>, loc);
+      internal::throw_null_conversion(name_type<field_type>(), loc);
   }
   else
   {

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -160,6 +160,79 @@ struct from_query_t
 
 namespace pqxx::internal
 {
+/// Attempt to demangle @c std::type_info::name() to something human-readable.
+PQXX_LIBEXPORT std::string demangle_type_name(char const[]);
+} // namespace pqxx::internal
+
+
+namespace pxx
+{
+/// A human-readable name for a type, used in error messages and such.
+/** Actually this may not always be very user-friendly.  It uses
+ * @c std::type_info::name().  On gcc-like compilers we try to demangle its
+ * output.  Visual Studio produces human-friendly names out of the box.
+ *
+ * This variable is not inline.  Inlining it gives rise to "memory leak"
+ * warnings from asan, the address sanitizer, possibly from use of
+ * @c std::type_info::name.
+ */
+template<typename TYPE> [[deprecated("Use name_type() instead.")]]
+std::string const type_name{pqxx::internal::demangle_type_name(typeid(TYPE).name())};
+
+
+/// Return human-readable name for `TYPE`.
+template<typename TYPE> inline std::string_view name_type()
+{
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
+  return type_name<TYPE>;
+#include "pqxx/internal/ignore-deprecated-post.hxx"
+}
+
+
+/// Specialisation to save on startup work & produce friendlier output.
+template<> constexpr inline std::string_view name_type<std::string>()
+{ return "std::string"; }
+/// Specialisation to save on startup work & produce friendlier output.
+template<> constexpr inline std::string_view name_type<std::string_view>()
+{ return "std::string_view"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<short>()
+{ return "short"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<int>()
+{ return "int"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<long>()
+{ return "long"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<long long>()
+{ return "long long"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<unsigned short>()
+{ return "short"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<unsigned>()
+{ return "unsigned"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<unsigned long>()
+{ return "unsigned long"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<unsigned long long>()
+{ return "unsigned long long"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<float>()
+{ return "float"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<double>()
+{ return "double"; }
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<long double>()
+{ return "long double"; }
+} // namespace pqxx
+
+
+namespace pqxx::internal
+{
 /// Concept: one of the "char" types.
 template<typename T>
 concept char_type = std::same_as<std::remove_cv_t<T>, char> or

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -208,6 +208,11 @@ template<> constexpr inline std::string_view name_type<char const *>()
   return "char const *";
 }
 /// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<bool>()
+{
+  return "bool";
+}
+/// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<short>()
 {
   return "short";
@@ -261,6 +266,16 @@ template<> constexpr inline std::string_view name_type<double>()
 template<> constexpr inline std::string_view name_type<long double>()
 {
   return "long double";
+}
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<std::nullptr_t>()
+{
+  return "std::nullptr_t";
+}
+/// Specialisation to save on startup work.
+template<> constexpr inline std::string_view name_type<std::nullopt_t>()
+{
+  return "std::nullopt_t";
 }
 } // namespace pqxx
 

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -272,11 +272,6 @@ template<> constexpr inline std::string_view name_type<std::nullptr_t>()
 {
   return "std::nullptr_t";
 }
-/// Specialisation to save on startup work.
-template<> constexpr inline std::string_view name_type<std::nullopt_t>()
-{
-  return "std::nullopt_t";
-}
 } // namespace pqxx
 
 

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -165,7 +165,7 @@ PQXX_LIBEXPORT std::string demangle_type_name(char const[]);
 } // namespace pqxx::internal
 
 
-namespace pxx
+namespace pqxx
 {
 /// A human-readable name for a type, used in error messages and such.
 /** Actually this may not always be very user-friendly.  It uses
@@ -176,8 +176,12 @@ namespace pxx
  * warnings from asan, the address sanitizer, possibly from use of
  * @c std::type_info::name.
  */
-template<typename TYPE> [[deprecated("Use name_type() instead.")]]
-std::string const type_name{pqxx::internal::demangle_type_name(typeid(TYPE).name())};
+#include "pqxx/internal/ignore-deprecated-pre.hxx"
+template<typename TYPE>
+[[deprecated("Use name_type() instead.")]]
+std::string const type_name{
+  pqxx::internal::demangle_type_name(typeid(TYPE).name())};
+#include "pqxx/internal/ignore-deprecated-post.hxx"
 
 
 /// Return human-readable name for `TYPE`.
@@ -191,43 +195,73 @@ template<typename TYPE> inline std::string_view name_type()
 
 /// Specialisation to save on startup work & produce friendlier output.
 template<> constexpr inline std::string_view name_type<std::string>()
-{ return "std::string"; }
+{
+  return "std::string";
+}
 /// Specialisation to save on startup work & produce friendlier output.
 template<> constexpr inline std::string_view name_type<std::string_view>()
-{ return "std::string_view"; }
+{
+  return "std::string_view";
+}
+template<> constexpr inline std::string_view name_type<char const *>()
+{
+  return "char const *";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<short>()
-{ return "short"; }
+{
+  return "short";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<int>()
-{ return "int"; }
+{
+  return "int";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<long>()
-{ return "long"; }
+{
+  return "long";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<long long>()
-{ return "long long"; }
+{
+  return "long long";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<unsigned short>()
-{ return "short"; }
+{
+  return "short";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<unsigned>()
-{ return "unsigned"; }
+{
+  return "unsigned";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<unsigned long>()
-{ return "unsigned long"; }
+{
+  return "unsigned long";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<unsigned long long>()
-{ return "unsigned long long"; }
+{
+  return "unsigned long long";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<float>()
-{ return "float"; }
+{
+  return "float";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<double>()
-{ return "double"; }
+{
+  return "double";
+}
 /// Specialisation to save on startup work.
 template<> constexpr inline std::string_view name_type<long double>()
-{ return "long double"; }
+{
+  return "long double";
+}
 } // namespace pqxx
 
 

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -108,6 +108,9 @@ public:
 };
 
 
+template<> constexpr inline std::string_view name_type<zview>(){ return "pqxx::zview"; }
+
+
 /// Support @ref zview literals.
 /** You can "import" this selectively into your namespace, without pulling in
  * all of the @ref pqxx namespace:

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -108,7 +108,10 @@ public:
 };
 
 
-template<> constexpr inline std::string_view name_type<zview>(){ return "pqxx::zview"; }
+template<> constexpr inline std::string_view name_type<zview>()
+{
+  return "pqxx::zview";
+}
 
 
 /// Support @ref zview literals.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,7 @@ libpqxx_la_SOURCES = \
 	transaction.cxx \
 	transaction_base.cxx \
 	row.cxx \
+	types.cxx \
 	util.cxx \
 	version.cxx \
 	wait.cxx

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -139,7 +139,7 @@ am_libpqxx_la_OBJECTS = array.lo blob.lo connection.lo cursor.lo \
 	notification.lo params.lo pipeline.lo result.lo \
 	robusttransaction.lo sql_cursor.lo strconv.lo stream_from.lo \
 	stream_to.lo subtransaction.lo time.lo transaction.lo \
-	transaction_base.lo row.lo util.lo version.lo wait.lo
+	transaction_base.lo row.lo types.lo util.lo version.lo wait.lo
 libpqxx_la_OBJECTS = $(am_libpqxx_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -173,8 +173,9 @@ am__depfiles_remade = ./$(DEPDIR)/array.Plo ./$(DEPDIR)/blob.Plo \
 	./$(DEPDIR)/strconv.Plo ./$(DEPDIR)/stream_from.Plo \
 	./$(DEPDIR)/stream_to.Plo ./$(DEPDIR)/subtransaction.Plo \
 	./$(DEPDIR)/time.Plo ./$(DEPDIR)/transaction.Plo \
-	./$(DEPDIR)/transaction_base.Plo ./$(DEPDIR)/util.Plo \
-	./$(DEPDIR)/version.Plo ./$(DEPDIR)/wait.Plo
+	./$(DEPDIR)/transaction_base.Plo ./$(DEPDIR)/types.Plo \
+	./$(DEPDIR)/util.Plo ./$(DEPDIR)/version.Plo \
+	./$(DEPDIR)/wait.Plo
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -378,6 +379,7 @@ libpqxx_la_SOURCES = \
 	transaction.cxx \
 	transaction_base.cxx \
 	row.cxx \
+	types.cxx \
 	util.cxx \
 	version.cxx \
 	wait.cxx
@@ -496,6 +498,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/time.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/transaction.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/transaction_base.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/types.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/version.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/wait.Plo@am__quote@ # am--include-marker
@@ -687,6 +690,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/time.Plo
 	-rm -f ./$(DEPDIR)/transaction.Plo
 	-rm -f ./$(DEPDIR)/transaction_base.Plo
+	-rm -f ./$(DEPDIR)/types.Plo
 	-rm -f ./$(DEPDIR)/util.Plo
 	-rm -f ./$(DEPDIR)/version.Plo
 	-rm -f ./$(DEPDIR)/wait.Plo
@@ -758,6 +762,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/time.Plo
 	-rm -f ./$(DEPDIR)/transaction.Plo
 	-rm -f ./$(DEPDIR)/transaction_base.Plo
+	-rm -f ./$(DEPDIR)/types.Plo
 	-rm -f ./$(DEPDIR)/util.Plo
 	-rm -f ./$(DEPDIR)/version.Plo
 	-rm -f ./$(DEPDIR)/wait.Plo

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -19,10 +19,6 @@
 #include <string_view>
 #include <system_error>
 
-#if __has_include(<cxxabi.h>)
-#  include <cxxabi.h>
-#endif
-
 #include "pqxx/internal/header-pre.hxx"
 
 #include "pqxx/except.hxx"
@@ -194,40 +190,6 @@ template struct string_traits<unsigned long long>;
 
 namespace pqxx::internal
 {
-std::string demangle_type_name(char const raw[])
-{
-#if defined(PQXX_HAVE_CXA_DEMANGLE)
-  // We've got __cxa_demangle.  Use it to get a friendlier type name.
-  int status{0};
-  std::size_t len{0};
-
-  // We've seen this fail on FreeBSD 11.3 (see #361).  Trying to throw a
-  // meaningful exception only made things worse.  So in case of error, just
-  // fall back to the raw name.
-  //
-  // When __cxa_demangle fails, it's guaranteed to return null.
-  char *str{abi::__cxa_demangle(raw, nullptr, &len, &status)};
-
-  if (str)
-  {
-    try
-    {
-      std::string out{str};
-      // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
-      std::free(str);
-      str = nullptr;
-      return out;
-    }
-    catch (std::exception const &)
-    {
-      // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
-      std::free(str);
-      throw;
-    }
-  }
-#endif
-  return raw;
-}
 
 
 // TODO: Equivalents for converting a null in the other direction.

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -126,10 +126,10 @@ inline char *wrap_to_chars(std::span<char> buf, T const &value)
     case std::errc::value_too_large:
       throw pqxx::conversion_overrun{std::format(
         "Could not convert {} to string: buffer too small ({} bytes).",
-        pqxx::type_name<T>, std::size(buf))};
+        pqxx::name_type<T>(), std::size(buf))};
     default:
       throw pqxx::conversion_error{
-        std::format("Could not convert {} to string.", pqxx::type_name<T>)};
+        std::format("Could not convert {} to string.", pqxx::name_type<T>())};
     }
   // No need to check for overrun here: we never even told to_chars about that
   // last byte in the buffer, so it didn't get used up.
@@ -151,7 +151,7 @@ string_traits<T>::to_buf(char *begin, char *end, T const &value)
     need{static_cast<ptrdiff_t>(size_buffer(value))};
   if (space < need)
     throw conversion_overrun{std::format(
-      "Could not convert {} to string: buffer too small.  {}", type_name<T>,
+      "Could not convert {} to string: buffer too small.  {}", name_type<T>(),
       pqxx::internal::state_buffer_overrun(space, need))};
 
   char *const pos{[end, &value]() {
@@ -250,7 +250,7 @@ inline TYPE from_string_arithmetic(std::string_view in, pqxx::ctx c)
   }
 
   auto const base{std::format(
-    "Could not convert '{}' to {}", std::string(in), pqxx::type_name<TYPE>)};
+    "Could not convert '{}' to {}", std::string(in), pqxx::name_type<TYPE>())};
   if (std::empty(msg))
     throw pqxx::conversion_error{std::format("{}.", base), c.loc};
   else
@@ -306,7 +306,8 @@ inline T PQXX_COLD from_string_awful_float(std::string_view text, ctx c)
 {
   if (std::empty(text))
     throw pqxx::conversion_error{
-      std::format("Trying to convert empty string to {}.", pqxx::type_name<T>),
+      std::format(
+        "Trying to convert empty string to {}.", pqxx::name_type<T>()),
       c.loc};
 
   bool ok{false};

--- a/src/types.cxx
+++ b/src/types.cxx
@@ -1,0 +1,53 @@
+/** Implementation of types-related helpers.
+ *
+ * Copyright (c) 2000-2025, Jeroen T. Vermeulen
+ *
+ * See COPYING for copyright license.  If you did not receive a file called
+ * COPYING with this source code, please notify the distributor of this
+ * mistake, or contact the author.
+ */
+#include "pqxx-source.hxx"
+
+#if __has_include(<cxxabi.h>)
+#  include <cxxabi.h>
+#endif
+
+#include "pqxx/internal/header-pre.hxx"
+#include "pqxx/types.hxx"
+#include "pqxx/internal/header-post.hxx"
+
+
+std::string pqxx::internal::demangle_type_name(char const raw[])
+{
+#if defined(PQXX_HAVE_CXA_DEMANGLE)
+  // We've got __cxa_demangle.  Use it to get a friendlier type name.
+  int status{0};
+  std::size_t len{0};
+
+  // We've seen this fail on FreeBSD 11.3 (see #361).  Trying to throw a
+  // meaningful exception only made things worse.  So in case of error, just
+  // fall back to the raw name.
+  //
+  // When __cxa_demangle fails, it's guaranteed to return null.
+  char *str{abi::__cxa_demangle(raw, nullptr, &len, &status)};
+
+  if (str)
+  {
+    try
+    {
+      std::string out{str};
+      // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
+      std::free(str);
+      str = nullptr;
+      return out;
+    }
+    catch (std::exception const &)
+    {
+      // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
+      std::free(str);
+      throw;
+    }
+  }
+#endif
+  return raw;
+}

--- a/src/types.cxx
+++ b/src/types.cxx
@@ -13,7 +13,9 @@
 #endif
 
 #include "pqxx/internal/header-pre.hxx"
+
 #include "pqxx/types.hxx"
+
 #include "pqxx/internal/header-post.hxx"
 
 

--- a/test/test_strconv.cxx
+++ b/test/test_strconv.cxx
@@ -163,7 +163,7 @@ constexpr char hash_index(std::size_t index)
 template<typename T>
 void check_write(T const &value, std::string_view expected)
 {
-  std::string const name{pqxx::type_name<T>};
+  std::string const name{pqxx::name_type<T>()};
   std::array<char, 100> buf;
   for (auto i{0u}; i < std::size(buf); ++i) buf[i] = hash_index(i);
 

--- a/test/test_type_name.cxx
+++ b/test/test_type_name.cxx
@@ -4,6 +4,7 @@ namespace
 {
 void test_type_name()
 {
+#include <pqxx/internal/ignore-deprecated-pre.hxx>
   // It's hard to test in more detail, because spellings may differ.
   // For instance, one compiler might call "const unsigned int*" what another
   // might call "unsigned const *".  And Visual Studio prefixes "class" to
@@ -12,8 +13,22 @@ void test_type_name()
   PQXX_CHECK_LESS(std::size(i), 5u, "type_name<int> is suspiciously long.");
   PQXX_CHECK_EQUAL(
     i.substr(0, 1), "i", "type_name<int> does not start with 'i'.");
+#include <pqxx/internal/ignore-deprecated-post.hxx>
+}
+
+
+void test_name_type()
+{
+  // We have a few hand-defined type names.
+  PQXX_CHECK_EQUAL(
+    pqxx::name_type<std::string>(), "std::string", "Unexpected type name.");
+  PQXX_CHECK_EQUAL(
+    pqxx::name_type<std::string_view>(), "std::string_view",
+    "Unexpected type name.");
+  PQXX_CHECK_EQUAL(pqxx::name_type<int>(), "int", "Unexpected type name.");
 }
 
 
 PQXX_REGISTER_TEST(test_type_name);
+PQXX_REGISTER_TEST(test_name_type);
 } // namespace

--- a/test/test_types.hxx
+++ b/test/test_types.hxx
@@ -91,7 +91,7 @@ template<> struct string_traits<ipv4>
   {
     ipv4 ts;
     if (std::data(text) == nullptr)
-      internal::throw_null_conversion(type_name<ipv4>, loc);
+      internal::throw_null_conversion(name_type<ipv4>(), loc);
     std::vector<std::size_t> ends;
     for (std::size_t i{0}; i < std::size(text); ++i)
       if (text[i] == '.')

--- a/test/test_util.cxx
+++ b/test/test_util.cxx
@@ -9,7 +9,7 @@ namespace
 {
 template<typename T> void test_for(T const &val)
 {
-  auto const name{pqxx::type_name<T>};
+  auto const name{pqxx::name_type<T>()};
   auto const sz{std::size(val)};
 
   std::span<std::byte const> out{pqxx::binary_cast(val)};


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/959

This should make it easier to override a type name with a manually
written, human-friendly one such as `std::string` instead of the whole
`std::basic_string<char, ...>` incantation; inline those to reduce
duplication; and consistently make it a `std::string_view`.

With that latter point, it abstracts away the underlying storage.  Which does mean that sometimes with template types you may need to construct the names in a separate place just so `name_type()` can return a view.  But that's probably better than storing each individual name in its own `std::string`, and allows for more optimisations.