### PR TITLE
Exlain on `listen()` how/when notifications come in.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
  - Fix warnings on compilers that accept `[[assume]]` with a warning. (#928)
  - Can't pass parameters to streaming query.
  - CMake build: take libpq path from build target, not absolute path. (#964)
+ - Added explanation to `listen()` of when notifications come in. (#963)
 7.10.0
  - Deprecate `errorhandler`; replace with lambda-friendly "notice handlers."
  - Deprecate `notification_receiver`; replace with "notification handlers"

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -685,6 +685,12 @@ public:
   /** Issues a `LISTEN` SQL command for channel `channel`, and stores `handler`
    * as the callback for when a notification comes in on that channel.
    *
+   * The connection can call this handler when you call @ref get_notifs() or
+   * @ref await_notification() on the connection.  Some internal functions may
+   * also call these functions.  The client-side handling is fully synchronous
+   * and notifications only come in while the connection is _not_ in a back-end
+   * transaction.
+   *
    * The handler is a `std::function` (see @ref notification_handler), but you
    * can simply pass in a lambda with the right parameters, or a function, or
    * an object of a type you define that happens to implemnt the right function


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/963

The documentation for the new API didn't actually mntion that the notifications from a `listen()` only come in when the connection's `get_notifs()` or `await_notification()` are called.