### PR TITLE
#972: Enable `-Wdeprecated-literal-operator` if supported.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:testing
+      - image: debian:stable
     environment:
       - PGHOST: "/tmp"
     steps:

--- a/configure
+++ b/configure
@@ -17164,6 +17164,7 @@ then
 			-Wanalyzer-write-to-string-literal \
 			-fnothrow-opt \
 			-Wattribute-alias=2 \
+			-Wdeprecated-literal-operator \
 			-Wlogical-op \
 			-Wmismatched-tags \
 			-Wredundant-tags \

--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,7 @@ then
 			-Wanalyzer-write-to-string-literal \
 			-fnothrow-opt \
 			-Wattribute-alias=2 \
+			-Wdeprecated-literal-operator \
 			-Wlogical-op \
 			-Wmismatched-tags \
 			-Wredundant-tags \

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -108,7 +108,7 @@ public:
  * using pqxx::operator"" _zv;
  * ```
  */
-constexpr zview operator"" _zv(char const str[], std::size_t len) noexcept
+constexpr zview operator""_zv(char const str[], std::size_t len) noexcept
 {
   return zview{str, len};
 }

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -172,7 +172,8 @@ int main(int argc, char const *argv[])
 {
   // TODO: Accept multiple names.
   std::string_view test_name;
-  if (argc > 1) test_name = argv[1];
+  if (argc > 1)
+    test_name = argv[1];
 
   auto const num_tests{std::size(*all_test_names)};
   std::map<std::string_view, pqxx::test::testfunc> all_tests;
@@ -200,8 +201,7 @@ int main(int argc, char const *argv[])
       catch (pqxx::test::test_failure const &e)
       {
         std::cerr << "Test failure in " << e.file() << " line "
-                  << pqxx::to_string(e.line()) << ": " << e.what()
-                  << '\n';
+                  << pqxx::to_string(e.line()) << ": " << e.what() << '\n';
       }
       catch (std::bad_alloc const &)
       {

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -157,8 +157,8 @@ inline void check_not_equal(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
-  std::string const &desc
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2,
+  char const text2[], std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
   std::source_location loc = std::source_location::current()
@@ -201,8 +201,8 @@ inline void check_less(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
-  std::string const &desc
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2,
+  char const text2[], std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
   std::source_location loc = std::source_location::current()
@@ -248,8 +248,8 @@ inline void check_less_equal(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE1 const &value1, char const text1[], VALUE2 const &value2, char const text2[],
-  std::string const &desc
+  VALUE1 const &value1, char const text1[], VALUE2 const &value2,
+  char const text2[], std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
   std::source_location loc = std::source_location::current()
@@ -376,8 +376,9 @@ inline void check_bounds(
 #if !defined(PQXX_HAVE_SOURCE_LOCATION)
   char const file[], int line,
 #endif
-  VALUE const &value, char const text[], LOWER const &lower, char const lower_text[],
-  UPPER const &upper, char const upper_text[], std::string const &desc
+  VALUE const &value, char const text[], LOWER const &lower,
+  char const lower_text[], UPPER const &upper, char const upper_text[],
+  std::string const &desc
 #if defined(PQXX_HAVE_SOURCE_LOCATION)
   ,
   std::source_location loc = std::source_location::current()

--- a/test/unit/test_row.cxx
+++ b/test/unit/test_row.cxx
@@ -60,7 +60,7 @@ void test_row_iterator()
 
 void test_row_as()
 {
-  using pqxx::operator"" _zv;
+  using pqxx::operator""_zv;
 
   pqxx::connection cx;
   pqxx::work tx{cx};

--- a/test/unit/test_zview.cxx
+++ b/test/unit/test_zview.cxx
@@ -7,7 +7,7 @@ namespace
 {
 void test_zview_literal()
 {
-  using pqxx::operator"" _zv;
+  using pqxx::operator""_zv;
 
   PQXX_CHECK_EQUAL(("foo"_zv), pqxx::zview{"foo"}, "zview literal is broken.");
 }
@@ -15,7 +15,7 @@ void test_zview_literal()
 
 void test_zview_converts_to_string()
 {
-  using pqxx::operator"" _zv;
+  using pqxx::operator""_zv;
   using traits = pqxx::string_traits<pqxx::zview>;
 
   PQXX_CHECK_EQUAL(


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/972