### PR TITLE
Mark test registration object as maybe-unused.

### DIFF
--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -46,7 +46,7 @@ struct registrar
 
 // Register a test function, so the runner will run it.
 #define PQXX_REGISTER_TEST(func)                                              \
-  pqxx::test::registrar tst_##func                                            \
+  [[maybe_unused]] pqxx::test::registrar tst_##func                           \
   {                                                                           \
     #func, func                                                               \
   }


### PR DESCRIPTION
Perhaps this will shut up those misleading static analysis warnings
about the test functions being unused.  And most of all, that insane
AI helpfully trying to delete them.