### PR TITLE
Fix a bug `get_target_property(PostgreSQL_INCLUDE_DIRS PostgreSQL::PostgreSQL)` does not working

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 # happens to contain autoconf-generated config headers, we should still prefer
 # the ones in the binary tree.
 macro(library_target_setup tgt)
-    get_target_property (PostgreSQL_INCLUDE_DIRS PostgreSQL::PostgreSQL INTERFACE_INCLUDE_DIRECTORIES)
     target_include_directories(${tgt}
     	PUBLIC
     		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>


### PR DESCRIPTION
`get_target_property(PostgreSQL_INCLUDE_DIRS PostgreSQL::PostgreSQL INTERFACE_INCLUDE_DIRECTORIES)` is not guaranteed to work.

It is not mentioned anywhere in the documentation as a property of the `PostgreSQL::PostgreSQL` target. `PostgreSQL_INCLUDE_DIRS` is a variable automatically defined by `find_package(PostgreSQL)`.

It should be removed because if it cannot be retrieved for a property, the build will fail.