### PR TITLE
Fix some errors on Mac clang17.

### DIFF
--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -302,7 +302,7 @@ inline bool PQXX_COLD from_dumb_stringstream(
 
 // These are hard, and some popular compilers still lack std::from_chars.
 template<typename T>
-inline T PQXX_COLD from_string_awful_float(std::string_view text, ctx c)
+inline T PQXX_COLD from_string_awful_float(std::string_view text, pqxx::ctx c)
 {
   if (std::empty(text))
     throw pqxx::conversion_error{

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -466,7 +466,7 @@ char *float_string_traits<T>::into_buf(char *begin, char *end, T const &value)
 #if defined(PQXX_HAVE_CHARCONV_FLOAT)
   return wrap_to_chars({begin, end}, value);
 #else
-  return generic_into_buf({begin, end}, value);
+  return begin + generic_into_buf({begin, end}, value);
 #endif
 }
 


### PR DESCRIPTION
Ran into a few unexpected problems compiling on a Mac with clang 17.  (This version did not have a working floating-point `charconv`, for one, so the build exercised code that my usual build environment does not.)