### PR TITLE
992: Support spaces in connection string params.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 7.10.2
  - CMake: Drop unneeded, broken `PostgreSQL_INCLUDE_DIRS` definition. (#981)
+ - Handle spaces and single quotes in `connection::connection_string()` (#992)
 7.10.1
  - Fix string conversion buffer budget for arrays containing nulls. (#921)
  - Remove `-fanalyzer` option again; gcc is still broken.

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -1281,8 +1281,9 @@ std::string pqxx::connection::connection_string() const
           buf.push_back(' ');
         buf += param.keyword;
         buf.push_back('=');
-        // XXX: Do we need encoding support to read param.val properly?
-        // XXX: Do we need to percent-encode?
+	// There is no particular encoding support for connection strings in
+	// libpq, not even percent-encoding.  They just have to be in ASCII or
+	// some ASCII-safe encoding.
         buf += quote_connect_param(param.val);
       }
     }

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -1231,6 +1231,26 @@ void pqconninfofree(PQconninfoOption *ptr)
 {
   PQconninfoFree(ptr);
 }
+
+
+/// Quote and escape a connection string parameter as needed.
+std::string quote_connect_param(std::string_view val)
+{
+  std::string buf;
+  buf.reserve(2 * std::size(val) + 2);
+
+  // C++23: Use contains().
+  bool const quote{(val.find(' ') != std::string_view::npos) or (val.find('\'') != std::string_view::npos)};
+
+  if (quote) buf += '\'';
+  for (auto c : val)
+  {
+    if ((c == '\\') or (c == '\'')) buf += '\\';
+    buf += c;
+  }
+  if (quote) buf += '\'';
+  return buf;
+}
 } // namespace
 
 
@@ -1253,6 +1273,7 @@ std::string pqxx::connection::connection_string() const
     if (param.val != nullptr)
     {
       auto const default_val{get_default(param)};
+      // Skip over parameters that have the default value.
       if (
         (default_val == nullptr) or (std::strcmp(param.val, default_val) != 0))
       {
@@ -1260,7 +1281,9 @@ std::string pqxx::connection::connection_string() const
           buf.push_back(' ');
         buf += param.keyword;
         buf.push_back('=');
-        buf += param.val;
+        // XXX: Do we need encoding support to read param.val properly?
+        // XXX: Do we need to percent-encode?
+        buf += quote_connect_param(param.val);
       }
     }
   }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -78,6 +78,7 @@ runner_SOURCES = \
   test88.cxx \
   test89.cxx \
   test90.cxx \
+  test_connection.cxx \
   unit/test_array.cxx \
   unit/test_binarystring.cxx \
   unit/test_blob.cxx \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -78,7 +78,7 @@ runner_SOURCES = \
   test88.cxx \
   test89.cxx \
   test90.cxx \
-  test_connection.cxx \
+  test_connection_string.cxx \
   unit/test_array.cxx \
   unit/test_binarystring.cxx \
   unit/test_blob.cxx \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -138,12 +138,12 @@ am_runner_OBJECTS = test00.$(OBJEXT) test01.$(OBJEXT) test02.$(OBJEXT) \
 	test75.$(OBJEXT) test76.$(OBJEXT) test77.$(OBJEXT) \
 	test78.$(OBJEXT) test79.$(OBJEXT) test82.$(OBJEXT) \
 	test84.$(OBJEXT) test87.$(OBJEXT) test88.$(OBJEXT) \
-	test89.$(OBJEXT) test90.$(OBJEXT) test_connection.$(OBJEXT) \
-	unit/test_array.$(OBJEXT) unit/test_binarystring.$(OBJEXT) \
-	unit/test_blob.$(OBJEXT) unit/test_cancel_query.$(OBJEXT) \
-	unit/test_column.$(OBJEXT) unit/test_composite.$(OBJEXT) \
-	unit/test_connection.$(OBJEXT) unit/test_cursor.$(OBJEXT) \
-	unit/test_encodings.$(OBJEXT) \
+	test89.$(OBJEXT) test90.$(OBJEXT) \
+	test_connection_string.$(OBJEXT) unit/test_array.$(OBJEXT) \
+	unit/test_binarystring.$(OBJEXT) unit/test_blob.$(OBJEXT) \
+	unit/test_cancel_query.$(OBJEXT) unit/test_column.$(OBJEXT) \
+	unit/test_composite.$(OBJEXT) unit/test_connection.$(OBJEXT) \
+	unit/test_cursor.$(OBJEXT) unit/test_encodings.$(OBJEXT) \
 	unit/test_error_verbosity.$(OBJEXT) \
 	unit/test_errorhandler.$(OBJEXT) unit/test_escape.$(OBJEXT) \
 	unit/test_exceptions.$(OBJEXT) unit/test_field.$(OBJEXT) \
@@ -211,7 +211,8 @@ am__depfiles_remade = ./$(DEPDIR)/runner.Po ./$(DEPDIR)/test00.Po \
 	./$(DEPDIR)/test82.Po ./$(DEPDIR)/test84.Po \
 	./$(DEPDIR)/test87.Po ./$(DEPDIR)/test88.Po \
 	./$(DEPDIR)/test89.Po ./$(DEPDIR)/test90.Po \
-	./$(DEPDIR)/test_connection.Po unit/$(DEPDIR)/test_array.Po \
+	./$(DEPDIR)/test_connection_string.Po \
+	unit/$(DEPDIR)/test_array.Po \
 	unit/$(DEPDIR)/test_binarystring.Po \
 	unit/$(DEPDIR)/test_blob.Po \
 	unit/$(DEPDIR)/test_cancel_query.Po \
@@ -511,7 +512,7 @@ runner_SOURCES = \
   test88.cxx \
   test89.cxx \
   test90.cxx \
-  test_connection.cxx \
+  test_connection_string.cxx \
   unit/test_array.cxx \
   unit/test_binarystring.cxx \
   unit/test_blob.cxx \
@@ -752,7 +753,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test88.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test89.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test90.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_connection.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_connection_string.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_array.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_binarystring.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_blob.Po@am__quote@ # am--include-marker
@@ -1100,7 +1101,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test88.Po
 	-rm -f ./$(DEPDIR)/test89.Po
 	-rm -f ./$(DEPDIR)/test90.Po
-	-rm -f ./$(DEPDIR)/test_connection.Po
+	-rm -f ./$(DEPDIR)/test_connection_string.Po
 	-rm -f unit/$(DEPDIR)/test_array.Po
 	-rm -f unit/$(DEPDIR)/test_binarystring.Po
 	-rm -f unit/$(DEPDIR)/test_blob.Po
@@ -1233,7 +1234,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test88.Po
 	-rm -f ./$(DEPDIR)/test89.Po
 	-rm -f ./$(DEPDIR)/test90.Po
-	-rm -f ./$(DEPDIR)/test_connection.Po
+	-rm -f ./$(DEPDIR)/test_connection_string.Po
 	-rm -f unit/$(DEPDIR)/test_array.Po
 	-rm -f unit/$(DEPDIR)/test_binarystring.Po
 	-rm -f unit/$(DEPDIR)/test_blob.Po

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -138,11 +138,12 @@ am_runner_OBJECTS = test00.$(OBJEXT) test01.$(OBJEXT) test02.$(OBJEXT) \
 	test75.$(OBJEXT) test76.$(OBJEXT) test77.$(OBJEXT) \
 	test78.$(OBJEXT) test79.$(OBJEXT) test82.$(OBJEXT) \
 	test84.$(OBJEXT) test87.$(OBJEXT) test88.$(OBJEXT) \
-	test89.$(OBJEXT) test90.$(OBJEXT) unit/test_array.$(OBJEXT) \
-	unit/test_binarystring.$(OBJEXT) unit/test_blob.$(OBJEXT) \
-	unit/test_cancel_query.$(OBJEXT) unit/test_column.$(OBJEXT) \
-	unit/test_composite.$(OBJEXT) unit/test_connection.$(OBJEXT) \
-	unit/test_cursor.$(OBJEXT) unit/test_encodings.$(OBJEXT) \
+	test89.$(OBJEXT) test90.$(OBJEXT) test_connection.$(OBJEXT) \
+	unit/test_array.$(OBJEXT) unit/test_binarystring.$(OBJEXT) \
+	unit/test_blob.$(OBJEXT) unit/test_cancel_query.$(OBJEXT) \
+	unit/test_column.$(OBJEXT) unit/test_composite.$(OBJEXT) \
+	unit/test_connection.$(OBJEXT) unit/test_cursor.$(OBJEXT) \
+	unit/test_encodings.$(OBJEXT) \
 	unit/test_error_verbosity.$(OBJEXT) \
 	unit/test_errorhandler.$(OBJEXT) unit/test_escape.$(OBJEXT) \
 	unit/test_exceptions.$(OBJEXT) unit/test_field.$(OBJEXT) \
@@ -210,7 +211,7 @@ am__depfiles_remade = ./$(DEPDIR)/runner.Po ./$(DEPDIR)/test00.Po \
 	./$(DEPDIR)/test82.Po ./$(DEPDIR)/test84.Po \
 	./$(DEPDIR)/test87.Po ./$(DEPDIR)/test88.Po \
 	./$(DEPDIR)/test89.Po ./$(DEPDIR)/test90.Po \
-	unit/$(DEPDIR)/test_array.Po \
+	./$(DEPDIR)/test_connection.Po unit/$(DEPDIR)/test_array.Po \
 	unit/$(DEPDIR)/test_binarystring.Po \
 	unit/$(DEPDIR)/test_blob.Po \
 	unit/$(DEPDIR)/test_cancel_query.Po \
@@ -510,6 +511,7 @@ runner_SOURCES = \
   test88.cxx \
   test89.cxx \
   test90.cxx \
+  test_connection.cxx \
   unit/test_array.cxx \
   unit/test_binarystring.cxx \
   unit/test_blob.cxx \
@@ -750,6 +752,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test88.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test89.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test90.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_connection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_array.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_binarystring.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_blob.Po@am__quote@ # am--include-marker
@@ -1097,6 +1100,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test88.Po
 	-rm -f ./$(DEPDIR)/test89.Po
 	-rm -f ./$(DEPDIR)/test90.Po
+	-rm -f ./$(DEPDIR)/test_connection.Po
 	-rm -f unit/$(DEPDIR)/test_array.Po
 	-rm -f unit/$(DEPDIR)/test_binarystring.Po
 	-rm -f unit/$(DEPDIR)/test_blob.Po
@@ -1229,6 +1233,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test88.Po
 	-rm -f ./$(DEPDIR)/test89.Po
 	-rm -f ./$(DEPDIR)/test90.Po
+	-rm -f ./$(DEPDIR)/test_connection.Po
 	-rm -f unit/$(DEPDIR)/test_array.Po
 	-rm -f unit/$(DEPDIR)/test_binarystring.Po
 	-rm -f unit/$(DEPDIR)/test_blob.Po

--- a/test/test_connection.cxx
+++ b/test/test_connection.cxx
@@ -1,0 +1,64 @@
+#include <format>
+
+#include <pqxx/pqxx>
+
+#include "test_helpers.hxx"
+
+
+namespace
+{
+constexpr std::string_view const marker{"application_name="};
+
+
+/// Connect to the database, passing `app_name` for its `application_name`.
+/** Does not do any quoting or escaping.  The caller will have to do that.
+ */
+pqxx::connection connect(std::string const &app_name)
+{
+  return pqxx::connection{std::format("{}{}", marker, app_name)};
+}
+
+
+/// Extract the application name from a connection's connection string.
+/** Does not do any un-escaping, does not remove quotes.  This is deliberate.
+ *
+ * Also does not handle much in the way of weird inputs.  It just looks for
+ * the first instance of "application_name=" and goes from there.  This is
+ * because I'm lazy and I see no substantial security risks in this.
+ */
+std::string app_name(pqxx::connection const &cx)
+{
+  std::string const &all{cx.connection_string()};
+
+  auto const intro{all.find(marker)};
+  auto const start{intro + std::size(marker)};
+  if (start == std::string::npos or all.at(start) == ' ') return "";
+  auto here{start};
+  if (all.at(here) == '\'')
+  {
+    // Quoted string.  Be prepared for escaping.
+    ++here;
+    for (bool esc{false}; (here < std::size(all)) and ((all.at(here) != '\'') or esc); ++here) esc = (all.at(here) == '\\' and not esc);
+  }
+  else
+  {
+    // Simple string.  Just stop at the next space, or end of string.
+    // This find() can return npos, but that's fine here.
+    here = all.find(' ', start);
+  }
+    return all.substr(start, all.find(' ', start) - start);
+}
+
+
+void test_connection_string_escapes()
+{
+  PQXX_CHECK_EQUAL(app_name(connect("pqxxtest")), "pqxxtest", "Simple connection param came back wrong.");
+  PQXX_CHECK_EQUAL(app_name(connect("'hello'")), "hello", "Quoted connection param came back wrong.");
+  PQXX_CHECK_EQUAL(app_name(connect("'a b c'")), "'a b c'", "Spaces in param went bad.");
+  PQXX_CHECK_EQUAL(app_name(connect("'x\\\\y'")), "'x\\y'", "Backslash escaping failed.");
+  PQXX_CHECK_EQUAL(app_name(connect("'don\\'t'")), "'don\\'t'", "Unexpected backslash escaping.");
+}
+
+
+PQXX_REGISTER_TEST(test_connection_string_escapes);
+} // namespace

--- a/test/test_connection_string.cxx
+++ b/test/test_connection_string.cxx
@@ -35,12 +35,14 @@ std::string app_name(pqxx::connection const &cx)
   std::size_t here{start}, end;
   if (all.at(here) == '\'')
   {
-    // Quoted string.  Be prepared for escaping.
+    // Quoted string.
     ++here;
     for (bool esc{false};
          (here < std::size(all)) and ((all.at(here) != '\'') or esc); ++here)
       esc = (all.at(here) == '\\' and not esc);
-    assert(here < std::size(all) - 1);
+    assert(here < std::size(all));
+    assert(all.at(here) == '\'');
+    // Skip closing quote.
     end = here + 1;
   }
   else

--- a/test/test_connection_string.cxx
+++ b/test/test_connection_string.cxx
@@ -56,26 +56,30 @@ std::string app_name(pqxx::connection const &cx)
 }
 
 
+void check_connect_string(std::string const &in, std::string const &expected)
+{
+  auto cx{connect(in)};
+  PQXX_CHECK_EQUAL(app_name(cx), expected, "App name did not come out as expected.");
+
+  // Check that connection_string() produced a valid, more or less equivalent
+  // connection string.
+  pqxx::connection{cx.connection_string()};
+}
+
+
 void test_connection_string_escapes()
 {
   // XXX: Deal with encodings?
   // XXX: Deal with URI encoding?
-  PQXX_CHECK_EQUAL(
-    app_name(connect("pqxxtest")), "pqxxtest",
-    "Simple connection param came back wrong.");
-  PQXX_CHECK_EQUAL(
-    app_name(connect("'hello'")), "hello",
-    "Quoted connection param came back wrong.");
-  PQXX_CHECK_EQUAL(
-    app_name(connect("'a b c'")), "'a b c'", "Spaces in param went bad.");
-  PQXX_CHECK_EQUAL(
-    app_name(connect("'x \\\\y'")), "'x \\\\y'", "Backslash escaping failed.");
-  PQXX_CHECK_EQUAL(app_name(connect("\\\\r\\\\n")), "\\\\r\\\\n", "Unnecessary quotes for backslash?");
+  check_connect_string("pqxxtest", "pqxxtest");
+  check_connect_string("'hello'", "hello");
+  check_connect_string("'a b c'", "'a b c'");
+  check_connect_string("'x \\\\y'", "'x \\\\y'");
+  check_connect_string("\\\\r\\\\n", "\\\\r\\\\n");
+
   // This does seem to get quoted, even though as I read the spec, that's not
-  // actually required.
-  PQXX_CHECK_EQUAL(
-    app_name(connect("don\\'t")), "'don\\'t'",
-    "Unexpected backslash escaping.");
+  // actually required because there's no space in it.
+  check_connect_string("don\\'t", "'don\\'t'");
 }
 
 

--- a/test/test_connection_string.cxx
+++ b/test/test_connection_string.cxx
@@ -1,5 +1,3 @@
-#include <format>
-
 #include <pqxx/pqxx>
 
 #include "test_helpers.hxx"


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/992

This is still just a basic ASCII-oriented solution.  Next challenge: figure out how non-ASCII characters can get encoded.  There's mention of percent-encoding, but I'm not sure yet that that is the whole answer. 

(Would be kind of hard to support other encodings though, since you'd need some kind of shared default between the client and the server to support anything else.  I mean... you _could_ use client encoding but that would get complicated with client encodings specified by the connection string itself.)