### PR TITLE
Params on streaming queries are not supported.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 7.10.2
  - CMake: Drop unneeded, broken `PostgreSQL_INCLUDE_DIRS` definition. (#981)
  - Handle spaces and single quotes in `connection::connection_string()` (#992)
+ - _I said,_ can't pass parameters to streaming query.  Remove support. (#997)
 7.10.1
  - Fix string conversion buffer budget for arrays containing nulls. (#921)
  - Remove `-fanalyzer` option again; gcc is still broken.

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -124,7 +124,7 @@ am__can_run_installinfo = \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in compile config.guess \
-	config.sub install-sh ltmain.sh missing mkinstalldirs
+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -21,22 +21,6 @@ inline stream_query<TYPE...>::stream_query(
 
 
 template<typename... TYPE>
-inline stream_query<TYPE...>::stream_query(
-  transaction_base &tx, std::string_view query, params const &parms) :
-        transaction_focus{tx, "stream_query"}, m_char_finder{get_finder(tx)}
-{
-  auto const r{tx.exec(internal::concat("COPY (", query, ") TO STDOUT"), parms)
-                 .no_rows()};
-  if (r.columns() != sizeof...(TYPE))
-    throw usage_error{concat(
-      "Parsing query stream with wrong number of columns: "
-      "code expects ",
-      sizeof...(TYPE), " but query returns ", r.columns(), ".")};
-  register_me();
-}
-
-
-template<typename... TYPE>
 inline char_finder_func *
 stream_query<TYPE...>::get_finder(transaction_base const &tx)
 {

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -571,15 +571,6 @@ public:
     return pqxx::internal::stream_query<TYPE...>{*this, query};
   }
 
-  /// Execute a query, in streaming fashion; loop over the results row by row.
-  /** Like @ref stream(std::string_view), but with parameters.
-   */
-  template<typename... TYPE>
-  [[nodiscard]] auto stream(std::string_view query, params parms) &
-  {
-    return pqxx::internal::stream_query<TYPE...>{*this, query, parms};
-  }
-
   // C++20: Concept like std::invocable, but without specifying param types.
   /// Perform a streaming query, and for each result row, call `func`.
   /** Here, `func` can be a function, a `std::function`, a lambda, or an
@@ -958,9 +949,6 @@ public:
   {
     exec(statement, parms).for_each(std::forward<CALLABLE>(func));
   }
-
-  // TODO: stream() with prepped.
-  // TODO: stream_like() with prepped.
 
   /// Execute a prepared statement with parameters.
   result exec(prepped statement, params const &parms)


### PR DESCRIPTION
Fixes #997.

I could have sworn I'd already done this in 7.10.1, but evidently I had not.  Dropping the function, because the frontend/backend protocol does not seem to support this.