### PR TITLE
Fix pkgconfig for static linkage

### DIFF
--- a/libpqxx.pc.in
+++ b/libpqxx.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: libpqxx
 Description: C++ client API for the PostgreSQL database management system.
 Version: @VERSION@
+Requires.private: libpq
 Libs: -L${libdir} -lpqxx
 Cflags: -I${includedir}


### PR DESCRIPTION
PostgreSQL link libraries are available via pkg config module libpq.