### PR TITLE
Improve demangling of identifiers.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@
  - _I said,_ can't pass parameters to streaming query.  Remove support. (#997)
  - Fix pkgconfig for static linkage; use config module `libpq`. (#999)
  - Made `row::as_tuple()` public. (#1003)
+ - Avoid garbage at end of demangled names. (#1007)
 7.10.1
  - Fix string conversion buffer budget for arrays containing nulls. (#921)
  - Remove `-fanalyzer` option again; gcc is still broken.

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -243,8 +243,8 @@ std::string demangle_type_name(char const raw[])
 
   if (str)
   {
-    // (Do not pass `len` to the constructor: it may look like an output
-    // parameter but
+    // (Do not pass `len` to the constructor: it only stores the length of the
+    // buffer, not of the string.)
     std::string out{str.get()};
     // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
     return out;

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -229,31 +229,25 @@ std::string demangle_type_name(char const raw[])
 #if defined(PQXX_HAVE_CXA_DEMANGLE)
   // We've got __cxa_demangle.  Use it to get a friendlier type name.
   int status{0};
-  std::size_t len{0};
 
   // We've seen this fail on FreeBSD 11.3 (see #361).  Trying to throw a
   // meaningful exception only made things worse.  So in case of error, just
   // fall back to the raw name.
   //
   // When __cxa_demangle fails, it's guaranteed to return null.
-  char *str{abi::__cxa_demangle(raw, nullptr, &len, &status)};
+  //
+  // Oh, and don't bother trying to pass in a "length" argument.  That's only
+  // for the length of the buffer, not the length of the string.
+  std::unique_ptr<char[], void (*)(void *) noexcept> str{
+    abi::__cxa_demangle(raw, nullptr, nullptr, &status), std::free};
 
   if (str)
   {
-    try
-    {
-      std::string out{str, len};
-      // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
-      std::free(str);
-      str = nullptr;
-      return out;
-    }
-    catch (std::exception const &)
-    {
-      // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
-      std::free(str);
-      throw;
-    }
+    // (Do not pass `len` to the constructor: it may look like an output
+    // parameter but
+    std::string out{str.get()};
+    // NOLINTNEXTLINE(*-no-malloc,cppcoreguidelines-owning-memory)
+    return out;
   }
 #endif
   return raw;


### PR DESCRIPTION
Improvement suggested in #1007.  Thanks for that @apavenis.

We still don't know what the source of the original problem is, but at
least this is a clear improvement.  It unifies the code paths, making it
easier to guarantee a (single) `free()`.
