### PR TITLE
Fixed result::affected_rows for SET queries

### DIFF
--- a/src/result.cxx
+++ b/src/result.cxx
@@ -391,7 +391,9 @@ pqxx::result::size_type pqxx::result::affected_rows() const
   std::string_view const rows_str{
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     PQcmdTuples(const_cast<internal::pq::PGresult *>(m_data.get()))};
-  return from_string<size_type>(rows_str);
+
+  // rows_str may be empty in case the query executed was a `SET <variable> = ''`
+  return rows_str.empty() ? 0 : from_string<size_type>(rows_str);
 }
 
 


### PR DESCRIPTION
SET queries result in a completely empty PGresult. The expected output of affected_rows in that case is 0.

This fixes #1018