### PR TITLE
Fix ranges checks

### DIFF
--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -120,7 +120,7 @@ public:
   }
 #endif // PQXX_HAVE_SPAN
 
-#if defined(PQXX_HAVE_CONCEPTS) && defined(PQXX_HAVE_SPAN)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>) && defined(PQXX_HAVE_SPAN)
   /// Read up to `std::size(buf)` bytes from the object.
   /** Retrieves bytes from the blob, at the current position, until `buf` is
    * full or there are no more bytes to read, whichever comes first.
@@ -151,7 +151,7 @@ public:
   }
 #endif // PQXX_HAVE_CONCEPTS && PQXX_HAVE_SPAN
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Write `data` to large object, at the current position.
   /** If the writing position is at the end of the object, this will append
    * `data` to the object's contents and move the writing position so that

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -80,7 +80,7 @@ namespace pqxx::internal
 {
 class sql_cursor;
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 /// Concept: T is a range of pairs of zero-terminated strings.
 template<typename T>
 concept ZKey_ZValues = std::ranges::input_range<T> and requires(T t) {
@@ -301,7 +301,7 @@ public:
    */
   connection(connection &&rhs);
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Connect to a database, passing options as a range of key/value pairs.
   /** @warning Experimental.  Requires C++20 "concepts" support.  Define
    * `PQXX_HAVE_CONCEPTS` to enable it.
@@ -880,7 +880,7 @@ public:
    */
   [[nodiscard]] std::string esc(std::string_view text) const;
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Escape binary string for use as SQL string literal on this connection.
   /** This is identical to `esc_raw(data)`. */
   template<binary DATA> [[nodiscard]] std::string esc(DATA const &data) const
@@ -935,7 +935,7 @@ public:
   [[nodiscard]] std::string esc_raw(bytes_view, std::span<char> buffer) const;
 #endif
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Escape binary string for use as SQL string literal on this connection.
   /** You can also just use @ref esc with a binary string. */
   template<binary DATA>
@@ -974,7 +974,7 @@ public:
   /// Escape and quote a string of binary data.
   std::string quote_raw(bytes_view) const;
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Escape and quote a string of binary data.
   /** You can also just use @ref quote with binary data. */
   template<binary DATA>
@@ -1496,7 +1496,7 @@ inline std::string connection::quote_columns(STRINGS const &columns) const
 }
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 template<internal::ZKey_ZValues MAPPING>
 inline connection::connection(MAPPING const &params)
 {

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -899,7 +899,7 @@ template<> struct nullness<bytes> : no_null<bytes>
 {};
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 template<binary DATA> struct nullness<DATA> : no_null<DATA>
 {};
 

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -93,7 +93,7 @@ public:
    */
   void append(bytes const &) &;
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Append a non-null binary parameter.
   /** The `data` object must stay in place and unchanged, for as long as the
    * `params` remains active.
@@ -147,7 +147,7 @@ public:
   /// Append all elements of `range` as parameters.
   template<PQXX_RANGE_ARG RANGE> void append_multi(RANGE const &range) &
   {
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
     if constexpr (std::ranges::sized_range<RANGE>)
       reserve(std::size(*this) + std::size(range));
 #endif

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -596,7 +596,7 @@ inline zview generic_to_buf(char *begin, char *end, TYPE const &value)
 }
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 /// Concept: Binary string, akin to @c std::string for binary data.
 /** Any type that satisfies this concept can represent an SQL BYTEA value.
  *

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -276,7 +276,7 @@ public:
   [[deprecated("Use quote(pqxx::bytes_view).")]] std::string
   quote_raw(zview bin) const;
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
   /// Binary-escape and quote a binary string for use as an SQL constant.
   /** For binary data you can also just use @ref quote(data). */
   template<binary DATA>

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -80,7 +80,7 @@ template<typename TYPE>
 using strip_t = std::remove_cv_t<std::remove_reference_t<TYPE>>;
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 /// The type of a container's elements.
 /** At the time of writing there's a similar thing in `std::experimental`,
  * which we may or may not end up using for this.
@@ -97,7 +97,7 @@ using value_type = strip_t<decltype(*std::begin(std::declval<CONTAINER>()))>;
 #endif // PQXX_HAVE_CONCEPTS
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 /// Concept: Any type that we can read as a string of `char`.
 template<typename STRING>
 concept char_string = std::ranges::contiguous_range<STRING> and
@@ -116,7 +116,7 @@ concept potential_binary =
 
 
 // C++20: Retire these compatibility definitions.
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 
 /// Template argument type for a range.
 /** This is a concept, so only available in C++20 or better.  In pre-C++20

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -276,7 +276,7 @@ struct PQXX_LIBEXPORT thread_safety_model
 [[nodiscard]] PQXX_LIBEXPORT thread_safety_model describe_thread_safety();
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 #  define PQXX_POTENTIAL_BINARY_ARG pqxx::potential_binary
 #else
 #  define PQXX_POTENTIAL_BINARY_ARG typename

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -115,7 +115,7 @@ constexpr zview operator""_zv(char const str[], std::size_t len) noexcept
 } // namespace pqxx
 
 
-#if defined(PQXX_HAVE_CONCEPTS)
+#if defined(PQXX_HAVE_CONCEPTS) && __has_include(<ranges>)
 /// A zview is a view.
 template<> inline constexpr bool std::ranges::enable_view<pqxx::zview>{true};
 


### PR DESCRIPTION
Useful for new compiler with old C++ library.

My env is clang 20.1.8 with Ubuntu 20.04 libstdc++.

See #1017 for the discussion