### PR TITLE
Avoid deprecation warning for `<ciso646>`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@
  - Fix `result::affected_rows()` for empty results. (#1018)
  - Fix error message in `result::expect_columns()`. (#1020)
  - Fix for compilers that support concepts but not ranges. (#1017)
+ - Avoid deprecation warning for `<ciso646>`. (#1023)
 7.10.1
  - Fix string conversion buffer budget for arrays containing nulls. (#921)
  - Remove `-fanalyzer` option again; gcc is still broken.

--- a/include/pqxx/internal/header-pre.hxx
+++ b/include/pqxx/internal/header-pre.hxx
@@ -65,8 +65,8 @@
 
 // C++20: No longer needed.
 // Enable ISO-646 alternative operaotr representations: "and" instead of "&&"
-// etc. on older compilers.  C++20 removes this header.
-#if PQXX_CPLUSPLUS <= 201703L && __has_include(<ciso646>)
+// etc. on older compilers.  C++17 deprecates this header; C++20 removes it.
+#if PQXX_CPLUSPLUS < 201703L && __has_include(<ciso646>)
 #  include <ciso646>
 #endif
 


### PR DESCRIPTION
Fixes: #1023 

I was being too conservative in removing the use of this header.  True, it was still a part of the standard in C++17.  But it was already deprecated at that point!