### PR TITLE
Drop `string_traits::into_buf()` from string conversion API.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@
  - `pqxx::bytes` is now a vector of bytes, not a string of bytes. (#924)
  - Use `pqxx::bytes::data()` instead of `pqxx::bytes::c_str()`.
  - The string conversion API has changed! (Old API should still work). (#948)
- - "String conversion" to `std::string_view` is now supported. (#694)
+ - "String conversion" to `std::string_view` etc. is now supported. (#694)
  - Simpler to use: `pqxx::from_string()`, `pqxx::to_buf()`, `pqxx::into_bu()`.
  - `to_buf()` and `into_buf()` functions will no longer zero-terminate.
  - **Beware lifetime** when "converting" a string to `std::string_view`!

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -550,9 +550,11 @@ public:
   static constexpr bool converts_to_string{true};
   static constexpr bool converts_from_string{true};
 
-  static zview to_buf(std::span<char> buf, array_type const &value, ctx c = {})
+  static std::string_view
+  to_buf(std::span<char> buf, array_type const &value, ctx c = {})
   {
-    return generic_to_buf(buf, value, c);
+    auto const len{pqxx::internal::array_into_buf(buf, value, c)};
+    return {std::data(buf), len};
   }
 
   static std::size_t

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -554,7 +554,9 @@ public:
   to_buf(std::span<char> buf, array_type const &value, ctx c = {})
   {
     auto const len{pqxx::internal::array_into_buf(buf, value, c)};
-    return {std::data(buf), len};
+    assert(len > 0);
+    assert(buf[len - 1] == '\0');
+    return {std::data(buf), len - 1};
   }
 
   static std::size_t

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -547,9 +547,6 @@ private:
 public:
   using array_type = array<ELEMENT, DIMENSIONS, array_separator<elt_type>>;
 
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static std::string_view
   to_buf(std::span<char> buf, array_type const &value, ctx c = {})
   {

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -559,12 +559,6 @@ public:
     return {std::data(buf), len - 1};
   }
 
-  static std::size_t
-  into_buf(std::span<char> buf, array_type const &value, ctx c = {})
-  {
-    return pqxx::internal::array_into_buf(buf, value, size_buffer(value), c);
-  }
-
   static std::size_t size_buffer(array_type const &value) noexcept
   {
     if constexpr (is_unquoted_safe<elt_type>)

--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -469,9 +469,9 @@ parameter a binary string, or not?  In the normal case it can assume "no," and
 that's what it does.  The text format is always a safe choice; we just try to
 use the binary format where it's faster, and safe.
 
-The `param_format` function template is what drives the decision.  We specialise
-it for types which may be binary strings, and use the default for all other
-types.
+The `param_format` function template is what drives the decision.  We
+specialise it for types which may be binary strings, and use the default for
+all other types.
 
 "Types which _may_ be binary"?  You might think we know whether a type is a
 binary type or not.  But there are some complications with generic types.

--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -272,9 +272,6 @@ As of 8.0, this is what a specialisation of `string_traits` should look like:
       static std::strnig_view to_buf(
         std::span<char>, T const &value, ctx c = {});
 
-      // Write string version into buffer.
-      static char *into_buf(std::span<char>, T const &value, ctx c = {});
-
       // Converting value to string may require this much buffer space at most.
       static std::size_t size_buffer(T const &value) noexcept;
 
@@ -373,22 +370,6 @@ supports, you can use the conversion functions for those: `pqxx::from_string`,
 `pqxx::to_string`, `pqxx::to_buf`.  They in turn will call the `string_traits`
 specialisations for those types.  Or, you can call their `string_traits`
 directly.
-
-
-### `into_buf`
-
-This is a stricter version of `to_buf`.  All the same requirements apply, but
-in addition you must write your string _into the given buffer,_ starting
-_exactly_ at its beginning.
-
-That's why this function returns just an offset: the index of the byte _right
-behind the string._  If the caller wants to use the string, they can find it at
-the beginning of the buffer.  Or if the caller wants to write another value
-into the rest of the buffer, they can continue writing at the location you
-returned.
-
-Apart from that, `into_buf()` is much like `to_buf()`.  Read that section
-carefully before implemnting `into_buf()`.
 
 
 ### `size_buffer`

--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -259,12 +259,7 @@ As of 8.0, this is what a specialisation of `string_traits` should look like:
     // T is your type.
     template<> struct string_traits<T>
     {
-      // Do you support converting T to PostgreSQL string format?
-      static constexpr bool converts_to_string{true};
-      // Do you support converting PostgreSQL string format to T?
-      static constexpr bool converts_from_string{true};
-
-      // If converts_to_string is true:
+      // If you support conversion _to_ string:
 
       // Represent `value` as a string, using `buf` for storage if needed.
       // (But the result may live somewhere outside the buffer, or lie inside
@@ -275,7 +270,7 @@ As of 8.0, this is what a specialisation of `string_traits` should look like:
       // Converting value to string may require this much buffer space at most.
       static std::size_t size_buffer(T const &value) noexcept;
 
-      // If converts_from_string is true:
+      // If you support conversion _from_ string:
 
       // Parse text as a T value.
       static T from_string(std::string_view text, ctx c = {});

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -414,7 +414,8 @@ inline void write_composite_field(
 
 
 /// Write an SQL array representation into `buf`.
-/** @return The number of bytes used, from the beginning of `buf`.
+/** @return The number of bytes used, from the beginning of `buf`, including a
+ * terminating zero.
  */
 template<nonbinary_range TYPE>
 [[nodiscard]] std::size_t array_into_buf(

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -380,8 +380,8 @@ inline void write_composite_field(
   if constexpr (is_unquoted_safe<T>)
   {
     // No need for quoting or escaping.  Convert it straight into its final
-    // place in the buffer, and "backspace" the trailing zero.
-    pos += into_buf(buf.subspan(pos), field, c) - 1;
+    // place in the buffer.
+    pos += into_buf(buf.subspan(pos), field, c);
   }
   else
   {
@@ -414,8 +414,8 @@ inline void write_composite_field(
 
 
 /// Write an SQL array representation into `buf`.
-/** @return The number of bytes used, from the beginning of `buf`, including a
- * terminating zero.
+/** @return The number of bytes used, from the beginning of `buf`.  Writes a
+ * terminating zero but does not include it in the count.
  */
 template<nonbinary_range TYPE>
 [[nodiscard]] std::size_t array_into_buf(
@@ -441,14 +441,14 @@ template<nonbinary_range TYPE>
     }
     else if constexpr (is_sql_array<elt_type>)
     {
-      // Render nested array in-place.  Then erase the trailing zero.
-      here += pqxx::into_buf(buf.subspan(here), elt, c) - 1;
+      // Render nested array in-place.
+      here += pqxx::into_buf(buf.subspan(here), elt, c);
     }
     else if constexpr (is_unquoted_safe<elt_type>)
     {
       // No need to quote or escape.  Just convert the value straight into
-      // its place in the array, and "backspace" the trailing zero.
-      here += pqxx::into_buf(buf.subspan(here), elt, c) - 1;
+      // its place in the array.
+      here += pqxx::into_buf(buf.subspan(here), elt, c);
     }
     else
     {
@@ -505,7 +505,7 @@ template<nonbinary_range TYPE>
 
   // C++26:Use buf.at().
   buf[here++] = '}';
-  buf[here++] = '\0';
+  buf[here] = '\0';
 
   return here;
 }

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -413,8 +413,11 @@ inline void write_composite_field(
 }
 
 
+/// Write an SQL array representation into `buf`.
+/** @return The number of bytes used, from the beginning of `buf`.
+ */
 template<nonbinary_range TYPE>
-std::size_t array_into_buf(
+[[nodiscard]] std::size_t array_into_buf(
   std::span<char> buf, TYPE const &value, std::size_t budget, ctx c)
 {
   using elt_type = std::remove_cvref_t<value_type<TYPE>>;

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -266,7 +266,7 @@ template<> struct string_traits<bool>
     return value ? "true"_zv : "false"_zv;
   }
 
-  static constexpr std::size_t size_buffer(bool const &) noexcept { return 6; }
+  static constexpr std::size_t size_buffer(bool const &) noexcept { return 5; }
 };
 
 
@@ -506,7 +506,7 @@ template<> struct string_traits<char const *>
       return 0;
     else
       // std::char_traits::length() is like std::strlen(), but constexpr.
-      return std::char_traits<char>::length(value) + 1;
+      return std::char_traits<char>::length(value);
   }
 };
 
@@ -616,7 +616,7 @@ template<> struct string_traits<std::string>
 
   static constexpr std::size_t size_buffer(std::string const &value) noexcept
   {
-    return std::size(value) + 1;
+    return std::size(value);
   }
 };
 
@@ -644,7 +644,7 @@ template<> struct string_traits<std::string_view>
   static constexpr std::size_t
   size_buffer(std::string_view const &value) noexcept
   {
-    return std::size(value) + 1;
+    return std::size(value);
   }
 
   static std::string_view
@@ -670,7 +670,7 @@ template<> struct string_traits<zview>
   static constexpr std::size_t
   size_buffer(std::string_view const &value) noexcept
   {
-    return std::size(value) + 1;
+    return std::size(value);
   }
 
   static zview to_buf(char *, char *, zview const &value) { return value; }
@@ -966,14 +966,11 @@ public:
                    std::begin(value), std::end(value), std::size_t{},
                    [](std::size_t acc, elt_type const &elt) {
                      // Opening and closing quotes, plus worst-case escaping,
-                     // and the one byte for the trailing zero becomes room
-                     // for a separator. However, std::size(s_null) doesn't
-                     // account for the terminating zero, so add one to make
-                     // s_null pay for its own separator.
+                     // plus one byte for the separator.
                      std::size_t const elt_size{
-                       pqxx::is_null(elt) ? (std::size(s_null) + 1) :
+                       pqxx::is_null(elt) ? std::size(s_null) :
                                             elt_traits::size_buffer(elt)};
-                     return acc + 2 * elt_size + 2;
+                     return acc + 2 * elt_size + 3;
                    });
   }
 };

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -309,9 +309,11 @@ template<typename T> struct string_traits<std::optional<T>>
   static constexpr bool converts_from_string{
     string_traits<T>::converts_from_string};
 
-  static char *into_buf(char *begin, char *end, std::optional<T> const &value)
+  static std::size_t
+  into_buf(std::span<char> buf, std::optional<T> const &value, ctx c = {})
   {
-    return begin + pqxx::into_buf({begin, end}, *value);
+    // (Assume not null, since null is not a value.)
+    return pqxx::into_buf(buf, *value, c);
   }
 
   static std::string_view

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -599,19 +599,9 @@ template<> struct string_traits<std::string>
   }
 
   static std::string_view
-  to_buf(std::span<char> buf, std::string const &value, ctx c = {})
+  to_buf(std::span<char>, std::string const &value, ctx = {})
   {
-    if (not std::empty(value) && (value[std::size(value) - 1] == '\0'))
-      throw internal_error{
-        std::format(
-          "Embedded zero in {}-byte string: '{}'", std::size(value), value),
-        c.loc}; // XXX: DEBUG
-                // XXX: Do we really need to copy?
-    if (std::cmp_greater(std::size(value), std::size(buf)))
-      throw conversion_overrun{
-        "Could not convert string to string: too long for buffer.", c.loc};
-    value.copy(std::data(buf), std::size(value));
-    return {std::data(buf), std::size(value)};
+    return {std::data(value), std::size(value)};
   }
 
   static constexpr std::size_t size_buffer(std::string const &value) noexcept

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -75,8 +75,6 @@ throw_null_conversion(std::string_view type, sl);
 template<pqxx::internal::char_type CHAR_TYPE>
 struct disallowed_ambiguous_char_conversion
 {
-  static constexpr bool converts_to_string{false};
-  static constexpr bool converts_from_string{false};
   static constexpr zview
   to_buf(char *, char *, CHAR_TYPE const &) noexcept = delete;
 
@@ -141,9 +139,6 @@ generic_into_buf(std::span<char> buf, T const &value, ctx c = {})
  */
 template<std::floating_point T> struct float_string_traits
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static PQXX_LIBEXPORT T from_string(std::string_view text, ctx = {});
 
   static PQXX_LIBEXPORT std::string_view
@@ -219,8 +214,6 @@ struct nullness<T> : no_null<T>
  */
 template<pqxx::internal::integer T> struct string_traits<T>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
   static PQXX_LIBEXPORT T from_string(std::string_view text, ctx = {});
   static PQXX_LIBEXPORT std::string_view
   to_buf(std::span<char> buf, T const &value, ctx c = {});
@@ -256,9 +249,6 @@ struct string_traits<long double>
 
 template<> struct string_traits<bool>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static PQXX_LIBEXPORT bool from_string(std::string_view text);
 
   static constexpr zview to_buf(char *, char *, bool const &value) noexcept
@@ -295,11 +285,6 @@ inline constexpr format param_format(std::optional<T> const &value)
 
 template<typename T> struct string_traits<std::optional<T>>
 {
-  static constexpr bool converts_to_string{
-    string_traits<T>::converts_to_string};
-  static constexpr bool converts_from_string{
-    string_traits<T>::converts_from_string};
-
   static std::string_view
   to_buf(std::span<char> buf, std::optional<T> const &value, ctx c = {})
   {
@@ -353,9 +338,6 @@ template<typename... T> struct nullness<std::variant<T...>>
 
 template<typename... T> struct string_traits<std::variant<T...>>
 {
-  static constexpr bool converts_to_string{
-    (string_traits<T>::converts_to_string and ...)};
-
   static std::string_view
   to_buf(std::span<char> buf, std::variant<T...> const &value, ctx c = {})
   {
@@ -403,9 +385,6 @@ template<typename T> inline T from_string(std::stringstream const &text)
 
 template<> struct string_traits<std::nullptr_t>
 {
-  static constexpr bool converts_to_string{false};
-  static constexpr bool converts_from_string{false};
-
   [[deprecated("Do not convert nulls.")]] static constexpr zview
   to_buf(char *, char *, std::nullptr_t const &) noexcept
   {
@@ -423,9 +402,6 @@ template<> struct string_traits<std::nullptr_t>
 
 template<> struct string_traits<std::nullopt_t>
 {
-  static constexpr bool converts_to_string{false};
-  static constexpr bool converts_from_string{false};
-
   [[deprecated("Do not convert nulls.")]] static constexpr zview
   to_buf(char *, char *, std::nullopt_t const &) noexcept
   {
@@ -443,9 +419,6 @@ template<> struct string_traits<std::nullopt_t>
 
 template<> struct string_traits<std::monostate>
 {
-  static constexpr bool converts_to_string{false};
-  static constexpr bool converts_from_string{false};
-
   [[deprecated("Do not convert nulls.")]] static constexpr zview
   to_buf(char *, char *, std::monostate const &) noexcept
   {
@@ -489,9 +462,6 @@ template<> struct nullness<char const *>
  */
 template<> struct string_traits<char const *>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{false};
-
   static char const *from_string(std::string_view text) = delete;
 
   static std::string_view
@@ -535,9 +505,6 @@ template<> struct nullness<char *>
  */
 template<> struct string_traits<char *>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{false};
-
   static std::string_view
   to_buf(std::span<char> buf, char *const &value, ctx c = {})
   {
@@ -565,9 +532,6 @@ template<std::size_t N> struct nullness<char[N]> : no_null<char[N]>
  */
 template<std::size_t N> struct string_traits<char[N]>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{false};
-
   static constexpr zview
   to_buf(char *, char *, char const (&value)[N]) noexcept
   {
@@ -590,9 +554,6 @@ template<> struct nullness<std::string> : no_null<std::string>
 
 template<> struct string_traits<std::string>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static std::string from_string(std::string_view text)
   {
     return std::string{text};
@@ -628,9 +589,6 @@ template<> struct nullness<std::string_view> : no_null<std::string_view>
  */
 template<> struct string_traits<std::string_view>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static constexpr std::size_t
   size_buffer(std::string_view const &value) noexcept
   {
@@ -654,9 +612,6 @@ template<> struct nullness<zview> : no_null<zview>
 /// String traits for `zview`.
 template<> struct string_traits<zview>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{false};
-
   static constexpr std::size_t
   size_buffer(std::string_view const &value) noexcept
   {
@@ -680,9 +635,6 @@ template<> struct nullness<std::stringstream> : no_null<std::stringstream>
 
 template<> struct string_traits<std::stringstream>
 {
-  static constexpr bool converts_to_string{false};
-  static constexpr bool converts_from_string{true};
-
   static std::size_t size_buffer(std::stringstream const &) = delete;
 
   static std::stringstream from_string(std::string_view text)
@@ -748,11 +700,6 @@ template<typename T> struct nullness<std::unique_ptr<T>>
 template<typename T, typename... Args>
 struct string_traits<std::unique_ptr<T, Args...>>
 {
-  static constexpr bool converts_to_string{
-    string_traits<T>::converts_to_string};
-  static constexpr bool converts_from_string{
-    string_traits<T>::converts_from_string};
-
   static std::unique_ptr<T> from_string(std::string_view text)
   {
     return std::make_unique<T>(string_traits<T>::from_string(text));
@@ -803,11 +750,6 @@ template<typename T> struct nullness<std::shared_ptr<T>>
 
 template<typename T> struct string_traits<std::shared_ptr<T>>
 {
-  static constexpr bool converts_to_string{
-    string_traits<T>::converts_to_string};
-  static constexpr bool converts_from_string{
-    string_traits<T>::converts_from_string};
-
   static std::shared_ptr<T> from_string(std::string_view text)
   {
     return std::make_shared<T>(string_traits<T>::from_string(text));
@@ -847,9 +789,6 @@ template<binary DATA> struct nullness<DATA> : no_null<DATA>
 
 template<binary DATA> struct string_traits<DATA>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static std::size_t size_buffer(DATA const &value) noexcept
   {
     return internal::size_esc_bin(std::size(value));
@@ -924,9 +863,6 @@ private:
   static constexpr zview s_null{"NULL"};
 
 public:
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{false};
-
   static std::string_view
   to_buf(std::span<char> buf, T const &value, ctx c = {})
   {

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -229,14 +229,10 @@ public:
       // though.
       char *const data{std::data(m_buf)};
 
-      // XXX: Use 8.0-style API; no more terminating zero.
       auto const written{pqxx::into_buf<COUNTER>(
         {data + 1, data + std::size(m_buf) - 1}, m_current, c)};
-      assert(written > 0);
-      assert(data[written] == '\0');
       std::size_t end{1 + written};
-      // (Subtract because we don't include the trailing zero.)
-      m_len = check_cast<COUNTER>(end, "placeholders counter", loc) - 1;
+      m_len = check_cast<COUNTER>(end, "placeholders counter", loc);
     }
     else
     {

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -228,9 +228,13 @@ public:
       // case, just rewrite the entire number.  Leave the $ in place
       // though.
       char *const data{std::data(m_buf)};
-      std::size_t end{
-        1 +
-        into_buf<COUNTER>({data + 1, data + std::size(m_buf)}, m_current, c)};
+
+      // XXX: Use 8.0-style API; no more terminating zero.
+      auto const written{pqxx::into_buf<COUNTER>(
+        {data + 1, data + std::size(m_buf) - 1}, m_current, c)};
+      assert(written > 0);
+      assert(data[written] == '\0');
+      std::size_t end{1 + written};
       // (Subtract because we don't include the trailing zero.)
       m_len = check_cast<COUNTER>(end, "placeholders counter", loc) - 1;
     }

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -466,43 +466,6 @@ template<typename TYPE> struct string_traits<range<TYPE>>
     }
   }
 
-  static inline char *into_buf(
-    char *begin, char *end, range<TYPE> const &value, sl loc = sl::current())
-  {
-    conversion_context const c{{}, loc};
-    if (value.empty())
-    {
-      if (std::cmp_less_equal(end - begin, std::size(s_empty)))
-        throw conversion_overrun{s_overrun.c_str(), loc};
-      char *here = begin + s_empty.copy(begin, std::size(s_empty));
-      *here++ = '\0';
-      return here;
-    }
-    else
-    {
-      if (end - begin < 4)
-        throw conversion_overrun{s_overrun.c_str(), loc};
-      char *here = begin;
-      *here++ =
-        (static_cast<char>(value.lower_bound().is_inclusive() ? '[' : '('));
-      TYPE const *lower{value.lower_bound().value()};
-      // Convert bound (but go back to overwrite that trailing zero).
-      if (lower != nullptr)
-        here += pqxx::into_buf({here, end}, *lower);
-      *here++ = ',';
-      TYPE const *upper{value.upper_bound().value()};
-      // Convert bound (but go back to overwrite that trailing zero).
-      if (upper != nullptr)
-        here += pqxx::into_buf({here, end}, *upper, c);
-      if ((end - here) < 2)
-        throw conversion_overrun{s_overrun.c_str(), loc};
-      *here++ =
-        static_cast<char>(value.upper_bound().is_inclusive() ? ']' : ')');
-      *here++ = '\0';
-      return here;
-    }
-  }
-
   [[nodiscard]] static inline range<TYPE>
   from_string(std::string_view text, sl loc = sl::current())
   {

--- a/include/pqxx/range.hxx
+++ b/include/pqxx/range.hxx
@@ -453,11 +453,13 @@ template<typename TYPE> struct string_traits<range<TYPE>>
         (static_cast<char>(value.lower_bound().is_inclusive() ? '[' : '('));
       TYPE const *lower{value.lower_bound().value()};
       // Convert bound (but go back to overwrite that trailing zero).
+      // XXX: Use 8.0-style API; no more terminating zero.
       if (lower != nullptr)
         here += pqxx::into_buf({here, end}, *lower) - 1;
       *here++ = ',';
       TYPE const *upper{value.upper_bound().value()};
       // Convert bound (but go back to overwrite that trailing zero).
+      // XXX: Use 8.0-style API; no more terminating zero.
       if (upper != nullptr)
         here += pqxx::into_buf({here, end}, *upper, c) - 1;
       if ((end - here) < 2)

--- a/include/pqxx/separated_list.hxx
+++ b/include/pqxx/separated_list.hxx
@@ -63,10 +63,12 @@ separated_list(std::string_view sep, ITER begin, ITER end, ACCESS access)
 
   char *const data{result.data()};
   char *stop{data + budget};
+  // XXX: Use 8.0-style API; no more terminating zero.
   std::size_t here{pqxx::into_buf({data, stop}, access(begin)) - 1};
   for (++begin; begin != end; ++begin)
   {
     here = pqxx::internal::copy_chars<false>(sep, result, here, sl::current());
+    // XXX: Use 8.0-style API; no more terminating zero.
     here += pqxx::into_buf({data + here, stop}, access(begin)) - 1;
   }
   result.resize(here);

--- a/include/pqxx/separated_list.hxx
+++ b/include/pqxx/separated_list.hxx
@@ -63,13 +63,11 @@ separated_list(std::string_view sep, ITER begin, ITER end, ACCESS access)
 
   char *const data{result.data()};
   char *stop{data + budget};
-  // XXX: Use 8.0-style API; no more terminating zero.
-  std::size_t here{pqxx::into_buf({data, stop}, access(begin)) - 1};
+  std::size_t here{pqxx::into_buf({data, stop}, access(begin))};
   for (++begin; begin != end; ++begin)
   {
     here = pqxx::internal::copy_chars<false>(sep, result, here, sl::current());
-    // XXX: Use 8.0-style API; no more terminating zero.
-    here += pqxx::into_buf({data + here, stop}, access(begin)) - 1;
+    here += pqxx::into_buf({data + here, stop}, access(begin));
   }
   result.resize(here);
   return result;

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -214,8 +214,8 @@ template<typename TYPE> struct string_traits final
    *
    * @warning If you convert a string to `std::string_view`, you're basically
    * just getting a pointer into the original buffer.  So, the `string_view`
-   * will become invalid when the original string's lifetime ends, or gets
-   * overwritten.  Do not access the `string_view` you got after that!
+   * will become invalid when the original string's lifetime ends, or when it
+   * gets overwritten.  Do not access the `string_view` after that!
    *
    * If there is no support for converting from an SQL string to this type,
    * simply leave this function out of the struct.

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -456,6 +456,7 @@ to_buf(std::span<char> buf, TYPE const &value, ctx c = {})
 }
 
 
+// XXX: Re-implement using traits<TYPE>>to_buf() instead.
 /// Write an SQL representation of `value` into `buf`.
 /** This calls string_traits<TYPE>::into_buf(), but bridges some API version
  * differences.

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -622,6 +622,7 @@ to_buf(char *begin, char const *end, TYPE... value)
 }
 
 
+// XXX: Test!
 /// Convert multiple values to strings inside a single buffer.
 /** There must be enough room for all values, or this will throw
  * @c conversion_overrun.  You can obtain a conservative estimate of the buffer
@@ -641,9 +642,7 @@ to_buf_multi(std::span<char> buf, TYPE... value)
     assert(start < here);
     assert(here <= std::size(buf));
     // C++26: Use buf.at().
-    assert(buf[here - 1] == '\0');
-    // Exclude the trailing zero out of the zview.
-    auto len{here - start - 1};
+    auto const len{here - start};
     return std::string_view{std::data(buf) + start, len};
   }(value)...};
 }

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -216,17 +216,6 @@ template<typename TYPE> struct string_traits final
   [[nodiscard]] static inline std::string_view
   to_buf(std::span<char> buf, TYPE const &value, ctx = {});
 
-  /// Write value's string representation into buffer.
-  /* @warning A null value has no string representation.  Do not pass a null.
-   *
-   * Writes value's string representation into the buffer, starting exactly at
-   * the beginning of the buffer.  Returns the offset into the buffer just
-   * after the string, so the caller could use it as the starting point for
-   * another call to write a next value.
-   */
-  static inline std::size_t
-  into_buf(std::span<char> buf, TYPE const &value, ctx = {});
-
   /// Parse a string representation of a @c TYPE value.
   /** Throws @c conversion_error if @c value does not meet the expected format
    * for a value of this type.
@@ -285,11 +274,6 @@ template<typename TYPE> struct forbidden_conversion
   static constexpr bool converts_from_string{false};
   [[noreturn]] static std::string_view
   to_buf(std::span<char>, TYPE const &, ctx = {})
-  {
-    oops_forbidden_conversion<TYPE>();
-  }
-  [[noreturn]] static std::size_t
-  into_buf(std::span<char>, TYPE const &, ctx = {})
   {
     oops_forbidden_conversion<TYPE>();
   }
@@ -398,22 +382,7 @@ concept to_buf_8 = requires(
 };
 
 
-/// Signature for string_traits<TYPE>::into_buf() in libpqxx 7.
-template<typename TYPE>
-concept into_buf_7 =
-  requires(char *out, char *begin, char *end, TYPE const &value) {
-    out = string_traits<TYPE>::into_buf(begin, end, value);
-  };
-
-/// Signature for string_traits<TYPE>::into_buf() in libpqxx 8.
-template<typename TYPE>
-concept into_buf_8 =
-  requires(std::size_t out, std::span<char> buf, TYPE const &value, ctx c) {
-    out = string_traits<TYPE>::into_buf(buf, value, c);
-    out = string_traits<TYPE>::into_buf(buf, value);
-  };
-
-/// Signature for string_traist<TYPE>::from_string() in libpqxx 8.
+/// Signature for string_traits<TYPE>::from_string() in libpqxx 8.
 template<typename TYPE>
 concept from_string_8 = requires(TYPE out, std::string_view text, ctx c) {
   out = string_traits<TYPE>::from_string(text, c);
@@ -570,12 +539,6 @@ template<typename ENUM> struct enum_traits
   to_buf(std::span<char> buf, ENUM const &value, ctx c = {})
   {
     return pqxx::to_buf(buf, to_underlying(value), c);
-  }
-
-  static std::size_t
-  into_buf(std::span<char> buf, ENUM const &value, ctx c = {})
-  {
-    return pqxx::into_buf(buf, to_underlying(value), c);
   }
 
   [[nodiscard]] static ENUM from_string(std::string_view text, ctx c = {})

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -329,6 +329,7 @@ private:
         auto const total{offset + budget};
         m_buffer.resize(total);
         auto const data{m_buffer.data()};
+        // XXX: Use 8.0-style API; no more terminating zero.
         std::size_t const end{
           offset + into_buf({data + offset, data + total}, f, c)};
         assert(end < std::size(m_buffer));

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -329,14 +329,12 @@ private:
         auto const total{offset + budget};
         m_buffer.resize(total);
         auto const data{m_buffer.data()};
-        // XXX: Use 8.0-style API; no more terminating zero.
         std::size_t const end{
           offset + into_buf({data + offset, data + total}, f, c)};
-        assert(end < std::size(m_buffer));
-        assert(m_buffer[end - 1] == '\0');
-        m_buffer[end - 1] = '\t';
+        assert((end + 1) < std::size(m_buffer));
+        m_buffer[end] = '\t';
         // Shrink to fit.  Keep the tab though.
-        m_buffer.resize(end);
+        m_buffer.resize(end + 1);
       }
       else if constexpr (
         std::is_same_v<Field, std::string> or

--- a/include/pqxx/time.hxx
+++ b/include/pqxx/time.hxx
@@ -59,14 +59,10 @@ struct nullness<std::chrono::year_month_day>
 template<> struct PQXX_LIBEXPORT string_traits<std::chrono::year_month_day>
 {
   [[nodiscard]] static std::string_view to_buf(
-    std::span<char> buf, std::chrono::year_month_day const &value, ctx c = {})
-  {
-    return generic_to_buf(buf, value, c);
-  }
+    std::span<char> buf, std::chrono::year_month_day const &value, ctx c = {});
 
-  static char *into_buf(
-    char *begin, char *end, std::chrono::year_month_day const &value,
-    sl = sl::current());
+  static std::size_t into_buf(
+    std::span<char> buf, std::chrono::year_month_day const &value, ctx c = {});
 
   [[nodiscard]] static std::chrono::year_month_day
   from_string(std::string_view text, sl = sl::current());

--- a/include/pqxx/time.hxx
+++ b/include/pqxx/time.hxx
@@ -61,9 +61,6 @@ template<> struct PQXX_LIBEXPORT string_traits<std::chrono::year_month_day>
   [[nodiscard]] static std::string_view to_buf(
     std::span<char> buf, std::chrono::year_month_day const &value, ctx c = {});
 
-  static std::size_t into_buf(
-    std::span<char> buf, std::chrono::year_month_day const &value, ctx c = {});
-
   [[nodiscard]] static std::chrono::year_month_day
   from_string(std::string_view text, sl = sl::current());
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -180,17 +180,6 @@ string_traits<T>::to_buf(std::span<char> buf, T const &value, ctx c)
 }
 
 
-template<pqxx::internal::integer T>
-inline std::size_t
-string_traits<T>::into_buf(std::span<char> buf, T const &value, ctx c)
-{
-  // This is exactly what to_chars is good at.  Trust standard library
-  // implementers to optimise better than we can.
-  return static_cast<std::size_t>(
-    wrap_to_chars(buf, value, c.loc) - std::data(buf));
-}
-
-
 template struct string_traits<short>;
 template struct string_traits<unsigned short>;
 template struct string_traits<int>;
@@ -448,19 +437,6 @@ float_string_traits<T>::to_buf(std::span<char> buf, T const &value, ctx c)
         c.loc};
     return {begin, static_cast<std::size_t>(res.size)};
   }
-#endif
-}
-
-
-template<std::floating_point T>
-std::size_t
-float_string_traits<T>::into_buf(std::span<char> buf, T const &value, ctx c)
-{
-#if defined(PQXX_HAVE_CHARCONV_FLOAT)
-  return static_cast<std::size_t>(
-    wrap_to_chars(buf, value, c.loc) - std::data(buf));
-#else
-  return generic_into_buf(buf, value, c.loc);
 #endif
 }
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -440,18 +440,13 @@ float_string_traits<T>::to_buf(std::span<char> buf, T const &value, ctx c)
 #else
   {
     auto const end{begin + std::size(buf)};
-    if (end == begin)
-      throw usage_error{
-        std::format(
-          "No buffer space for converting {} to string.", name_type<T>()),
-        c.loc};
     auto const res{std::format_to_n(begin, end - begin, "{}", value)};
     if (std::cmp_greater_equal(res.size, end - begin))
       throw conversion_overrun{
         std::format(
           "Buffer too small for converting {} to string.", name_type<T>()),
         c.loc};
-    return {begin, res.size};
+    return {begin, static_cast<std::size_t>(res.size)};
   }
 #endif
 }

--- a/src/time.cxx
+++ b/src/time.cxx
@@ -177,27 +177,6 @@ std::string make_parse_error(std::string_view text)
 
 namespace pqxx
 {
-std::size_t string_traits<std::chrono::year_month_day>::into_buf(
-  std::span<char> buf, std::chrono::year_month_day const &value, ctx c)
-{
-  if (std::size(buf) < size_buffer(value))
-    throw conversion_overrun{"Not enough room in buffer for date.", c.loc};
-  auto here{std::data(buf)};
-  // XXX: Pass c.
-  here = year_into_buf(here, value.year());
-  *here++ = '-';
-  here = month_into_buf(here, value.month());
-  *here++ = '-';
-  here = day_into_buf(here, value.day());
-  if (int{value.year()} <= 0) [[unlikely]]
-    here += s_bc.copy(here, std::size(s_bc));
-  *here++ = '\0';
-  // XXX: Retire assertion once confident.
-  assert(here >= std::data(buf));
-  return static_cast<std::size_t>(here - std::data(buf));
-}
-
-
 std::string_view string_traits<std::chrono::year_month_day>::to_buf(
   std::span<char> buf, std::chrono::year_month_day const &value, ctx c)
 {

--- a/src/time.cxx
+++ b/src/time.cxx
@@ -20,6 +20,7 @@ using namespace std::literals;
 constexpr int ten{10};
 
 
+// XXX: Retire comment on termnating zero.
 /// Render the numeric part of a year value into a buffer.
 /** Converts the year from "common era" (with a Year Zero) to "anno domini"
  * (without a Year Zero).
@@ -68,6 +69,7 @@ year_into_buf(char *begin, char *end, std::chrono::year const &value)
       if (absy < ten)
         *begin++ = '0';
     }
+    // XXX: Use 8.x API; no more terminating zero.
     begin = pqxx::string_traits<short>::into_buf(begin, end, absy) - 1;
   }
   return begin;
@@ -89,6 +91,7 @@ inline int year_from_buf(std::string_view text, pqxx::sl loc)
 }
 
 
+// XXX: Retire comment about terminating zero.
 /// Render a valid 1-based month number into a buffer.
 /* Where @c string_traits::into_buf() returns a pointer to the position right
  * after the terminating zero, this function returns a pointer to the character

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -367,7 +367,7 @@ int main(int argc, char const *argv[])
   // get from 300 workers.  That can change radically though: right now there
   // are just a few "negative tests" holding things up by waiting for a few
   // seconds to check that something doesn't happen.
-  std::ptrdiff_t const jobs{1};
+  std::ptrdiff_t const jobs{4};
   dispatcher disp{jobs, std::move(tests)};
 
   std::vector<std::thread> pool;

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -259,7 +259,7 @@ run_test(std::string_view name, pqxx::test::testfunc func)
 }
 
 
-/// Maximum allowed number of test concurrent tests.
+/// Maximum allowed number of concurrent tests.
 /** No particular reason, except anything higher isn't likely to give us much
  * in the way of speedup while still increasing peak memory usage etc.
  */
@@ -367,7 +367,7 @@ int main(int argc, char const *argv[])
   // get from 300 workers.  That can change radically though: right now there
   // are just a few "negative tests" holding things up by waiting for a few
   // seconds to check that something doesn't happen.
-  std::ptrdiff_t const jobs{4};
+  std::ptrdiff_t const jobs{1};
   dispatcher disp{jobs, std::move(tests)};
 
   std::vector<std::thread> pool;

--- a/test/test00.cxx
+++ b/test/test00.cxx
@@ -20,7 +20,9 @@ strconv(std::string const &type, T const &obj, std::string const &expected)
 
   PQXX_CHECK_EQUAL(objstr, expected, "String mismatch for " + type + ".");
 
-  if constexpr (pqxx::string_traits<T>::converts_from_string)
+  if constexpr (requires(T val, std::string_view v) {
+                  val = pqxx::string_traits<T>::from_string(v);
+                })
   {
     T newobj;
     pqxx::from_string(objstr, newobj);

--- a/test/test00.cxx
+++ b/test/test00.cxx
@@ -11,6 +11,12 @@
 
 namespace
 {
+template<typename T>
+concept converts_from_string = requires(T val, std::string_view v) {
+  val = pqxx::string_traits<T>::from_string(v);
+};
+
+
 /// Convert an object to/from string, and check for expected results.
 template<typename T>
 inline void
@@ -20,9 +26,7 @@ strconv(std::string const &type, T const &obj, std::string const &expected)
 
   PQXX_CHECK_EQUAL(objstr, expected, "String mismatch for " + type + ".");
 
-  if constexpr (requires(T val, std::string_view v) {
-                  val = pqxx::string_traits<T>::from_string(v);
-                })
+  if constexpr (converts_from_string<T>)
   {
     T newobj;
     pqxx::from_string(objstr, newobj);

--- a/test/test_float.cxx
+++ b/test/test_float.cxx
@@ -105,8 +105,8 @@ template<typename T> void test_float_length(T value)
 {
   auto const text{pqxx::to_string(value)};
   PQXX_CHECK_GREATER_EQUAL(
-    pqxx::size_buffer(value), std::size(text) + 1,
-    "Not enough buffer space for " + text + ".");
+    pqxx::size_buffer(value), std::size(text),
+    std::format("Not enough buffer space for '{}'.", text));
 }
 
 

--- a/test/test_range.cxx
+++ b/test/test_range.cxx
@@ -338,7 +338,7 @@ void test_range_intersection()
     PQXX_CHECK_EQUAL(
       intersect<int>(left, right), expected,
       std::format(
-        "Intersection of '{}' and '{} produced unexpected result.", left,
+        "Intersection of '{}' and '{}' produced unexpected result.", left,
         right));
     PQXX_CHECK_EQUAL(
       intersect<int>(right, left), expected,

--- a/test/test_strconv.cxx
+++ b/test/test_strconv.cxx
@@ -196,11 +196,7 @@ void check_write(T const &value, std::string_view expected)
     end, pqxx::string_traits<T>::size_buffer(value),
     std::format("Under-budgeted for into_buf() on {}.", name));
   PQXX_CHECK_EQUAL(
-    std::size(std::string_view{std::data(buf)}) + 1, end,
-    std::format(
-      "Termating zero for into_buf() on {} not in the expected place.", name));
-  PQXX_CHECK_EQUAL(
-    (std::string_view{std::data(buf), end - 1}), expected,
+    (std::string_view{std::data(buf), end}), expected,
     std::format("Wrong result from into_buf() on {}.", name));
   PQXX_CHECK_EQUAL(
     char_as_unsigned(buf.at(end)), char_as_unsigned(hash_index(end)),

--- a/test/test_strconv.cxx
+++ b/test/test_strconv.cxx
@@ -67,6 +67,13 @@ void test_strconv_bool()
   PQXX_CHECK_EQUAL(result, true);
   pqxx::from_string("1", result);
   PQXX_CHECK_EQUAL(result, true);
+
+  // Nasty little corner case: to_buf() for bool will return a view on a
+  // string constant, and not use the buffer you give it.  But into_buf() will
+  // copy that into the buffer, and this requires a separate overrun check.
+  std::array<char, 3> small_buf{};
+  PQXX_CHECK_THROWS(
+    std::ignore = pqxx::into_buf(small_buf, true), pqxx::conversion_overrun);
 }
 
 

--- a/test/test_strconv.cxx
+++ b/test/test_strconv.cxx
@@ -145,7 +145,9 @@ constexpr char hash_index(std::size_t index)
 
 // Extra-thorough test for to_buf() & into_buf() on a given type.
 template<typename T>
-void check_write(T const &value, std::string_view expected)
+void check_write(
+  T const &value, std::string_view expected,
+  pqxx::sl loc = pqxx::sl::current())
 {
   std::string const name{pqxx::name_type<T>()};
   std::array<char, 1000> buf{};
@@ -157,51 +159,37 @@ void check_write(T const &value, std::string_view expected)
   pqxx::zview const out{pqxx::to_buf(buf, value, c)};
   PQXX_CHECK_EQUAL(
     std::size(out), std::size(expected),
-    std::format("to_buf() for {} wrote wrong length.", name));
+    std::format("to_buf() for {} wrote wrong length.", name), loc);
 
   auto const sz{std::size(out)};
   PQXX_CHECK_LESS_EQUAL(
     sz, pqxx::string_traits<T>::size_buffer(value),
-    std::format("Under-budgeted for to_buf on {}.", name));
+    std::format("Under-budgeted for to_buf on {}.", name), loc);
   PQXX_CHECK_LESS(
-    sz, std::size(buf), std::format("Too much to_buf() data for {}.", name));
+    sz, std::size(buf), std::format("Too much to_buf() data for {}.", name),
+    loc);
 
   PQXX_CHECK_EQUAL(
-    expected, out, std::format("to_buf() for {} wrote wrong value.", name));
+    expected, out, std::format("to_buf() for {} wrote wrong value.", name),
+    loc);
   if (sz > 0)
     PQXX_CHECK_NOT_EQUAL(
       char_as_unsigned(out.at(sz - 1)), 0u,
-      std::format(
-        "to_buf() for {} put terminating zero inside result.", name));
-  PQXX_CHECK_EQUAL(
-    std::size(std::string_view{out}), sz,
-    std::format(
-      "to_buf() for {} did not put terminating zero in the right place.",
-      name));
-  if (std::data(out) == std::data(buf))
-    PQXX_CHECK_EQUAL(
-      char_as_unsigned(buf.at(sz + 1)), char_as_unsigned(hash_index(sz + 1)),
-      std::format(
-        "to_buf() for {} overwrote byte after terminating zero.", name));
+      std::format("to_buf() for {} put terminating zero inside result.", name),
+      loc);
 
   // Test into_buf().
   for (auto i{0u}; i < std::size(buf); ++i) buf.at(i) = hash_index(i);
   std::size_t const end{pqxx::into_buf(buf, value, c)};
-  PQXX_CHECK_GREATER(
-    end, 0u, std::format("into_buf() for {} returned zero.", name));
   PQXX_CHECK_LESS_EQUAL(
     end, std::size(buf),
-    std::format("into_buf() for {} overran buffer.", name));
+    std::format("into_buf() for {} overran buffer.", name), loc);
   PQXX_CHECK_LESS_EQUAL(
     end, pqxx::string_traits<T>::size_buffer(value),
-    std::format("Under-budgeted for into_buf() on {}.", name));
+    std::format("Under-budgeted for into_buf() on {}.", name), loc);
   PQXX_CHECK_EQUAL(
     (std::string_view{std::data(buf), end}), expected,
-    std::format("Wrong result from into_buf() on {}.", name));
-  PQXX_CHECK_EQUAL(
-    char_as_unsigned(buf.at(end)), char_as_unsigned(hash_index(end)),
-    std::format(
-      "into_buf() for {} overwrote buffer after terminating zero.", name));
+    std::format("Wrong result from into_buf() on {}.", name), loc);
 }
 
 

--- a/test/test_string_conversion.cxx
+++ b/test/test_string_conversion.cxx
@@ -151,12 +151,8 @@ void test_string_view_conversion()
     "more view"s);
   PQXX_CHECK(buf.at(stop - 2) == 'w');
 
-  std::string_view org{"another!"sv};
-  pqxx::zview out{traits::to_buf(buf, org)};
+  std::string_view const org{"another!"sv}, out{traits::to_buf(buf, org)};
   PQXX_CHECK_EQUAL(std::string{out}, "another!"s);
-  PQXX_CHECK(
-    std::data(out) != std::data(org),
-    "string_view to_buf returned original view, which may not be terminated.");
 }
 
 

--- a/test/test_string_conversion.cxx
+++ b/test/test_string_conversion.cxx
@@ -142,14 +142,13 @@ void test_string_view_conversion()
 
   std::array<char, 200> buf{};
 
-  std::size_t const stop{traits::into_buf(buf, "more view"sv)};
+  std::size_t const stop{pqxx::into_buf(buf, "more view"sv)};
   PQXX_CHECK_LESS(stop, std::size(buf));
   assert(stop > 0);
-  PQXX_CHECK(buf.at(stop - 1) == '\0');
   PQXX_CHECK_EQUAL(
-    (std::string{std::data(buf), static_cast<std::size_t>(stop - 1)}),
+    (std::string{std::data(buf), static_cast<std::size_t>(stop)}),
     "more view"s);
-  PQXX_CHECK(buf.at(stop - 2) == 'w');
+  PQXX_CHECK(buf.at(stop - 1) == 'w');
 
   std::string_view const org{"another!"sv}, out{traits::to_buf(buf, org)};
   PQXX_CHECK_EQUAL(std::string{out}, "another!"s);

--- a/test/test_types.hxx
+++ b/test/test_types.hxx
@@ -84,9 +84,6 @@ template<> struct nullness<ipv4> : no_null<ipv4>
 
 template<> struct string_traits<ipv4>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static ipv4 from_string(std::string_view text, sl loc = sl::current())
   {
     ipv4 ts;
@@ -174,9 +171,6 @@ template<> struct nullness<bytea> : no_null<bytea>
 
 template<> struct string_traits<bytea>
 {
-  static constexpr bool converts_to_string{true};
-  static constexpr bool converts_from_string{true};
-
   static bytea from_string(std::string_view text)
   {
     if ((std::size(text) & 1) != 0)

--- a/test/test_zview.cxx
+++ b/test/test_zview.cxx
@@ -36,7 +36,9 @@ void test_zview_converts_to_string()
   PQXX_CHECK_EQUAL(std::string{v}, "myview");
 
   auto const p{pqxx::into_buf(buf, "moreview"_zv)};
-  PQXX_CHECK(p == std::strlen("moreview"), "into_buf of zview did not store in buffer.");
+  PQXX_CHECK(
+    p == std::strlen("moreview"),
+    "into_buf of zview did not store in buffer.");
   PQXX_CHECK(buf.at(p - 1) == 'w');
   PQXX_CHECK_EQUAL((std::string{std::data(buf), p}), "moreview");
 }

--- a/test/test_zview.cxx
+++ b/test/test_zview.cxx
@@ -30,21 +30,15 @@ void test_zview_converts_to_string()
 
   PQXX_CHECK_EQUAL(pqxx::to_string("hello"_zv), std::string{"hello"});
 
-  char buf[100];
+  std::array<char, 100> buf;
 
   auto const v{traits::to_buf(std::begin(buf), std::end(buf), "myview"_zv)};
   PQXX_CHECK_EQUAL(std::string{v}, "myview");
 
-  auto const p{
-    traits::into_buf(std::begin(buf), std::end(buf), "moreview"_zv)};
-  PQXX_CHECK_NOT_EQUAL(
-    p, std::begin(buf), "into_buf on zview returns beginning of buffer.");
-  PQXX_CHECK(
-    p > std::begin(buf) and p < std::end(buf),
-    "into_buf on zview did not store in buffer.");
-  PQXX_CHECK(*(p - 1) == '\0', "into_buf on zview wasted space.");
-  PQXX_CHECK(*(p - 2) == 'w');
-  PQXX_CHECK_EQUAL(std::string(std::data(buf)), "moreview");
+  auto const p{pqxx::into_buf(buf, "moreview"_zv)};
+  PQXX_CHECK(p == std::strlen("moreview"), "into_buf of zview did not store in buffer.");
+  PQXX_CHECK(buf.at(p - 1) == 'w');
+  PQXX_CHECK_EQUAL((std::string{std::data(buf), p}), "moreview");
 }
 
 

--- a/test/test_zview.cxx
+++ b/test/test_zview.cxx
@@ -30,7 +30,7 @@ void test_zview_converts_to_string()
 
   PQXX_CHECK_EQUAL(pqxx::to_string("hello"_zv), std::string{"hello"});
 
-  std::array<char, 100> buf;
+  std::array<char, 100> buf{};
 
   auto const v{traits::to_buf(std::begin(buf), std::end(buf), "myview"_zv)};
   PQXX_CHECK_EQUAL(std::string{v}, "myview");


### PR DESCRIPTION
This takes a lot of other things with it, so the diff will be big.  It's taken months.  (Also I'm not feeling too well, that doesn't help.)

But it's probably worth it:
* One less function to implement when building a conversion.
* No more trailing zero in the strings we generate.  Saves work, and space.
* Views instead of buffer offsets: one more step away from raw pointers and confusion.
* Result of a `to_buf()` is only valid while the original value remains valid, so `string_view` and such are trivial to convert.

The _generic_ `into_buf()` calls the traits' `to_buf()`, and then uses `std::memmove()` to move the string to its destination, if necessary.

The lifetime change  is quite significant.  Where appropriate, a conversion to string may now simply return a view directly into the original value.  It's only with `into_buf()` that we really need the string to live inside the buffer that the caller provides.

I wonder if there's any further performance gain to be had by skipping the `memmove()` in the common case where `to_buf()` writes into the buffer from exactly its beginning.  But I imagine `std::memmove()` starts with an inline check against this situation.  If the conversion itself is inlined, the compiler may be smart enough to recognise statically whether that is the case.