### PR TITLE
Accommodate MSVC in C++17 mode with `<ciso646>`.

### DIFF
--- a/include/pqxx/internal/header-pre.hxx
+++ b/include/pqxx/internal/header-pre.hxx
@@ -66,8 +66,16 @@
 // C++20: No longer needed.
 // Enable ISO-646 alternative operaotr representations: "and" instead of "&&"
 // etc. on older compilers.  C++17 deprecates this header; C++20 removes it.
-#if PQXX_CPLUSPLUS < 201703L && __has_include(<ciso646>)
+//
+// We still need to include it on MSVC because the new keywords won't work
+// in C++17 mode without it; but some compilers may complain that we're
+// including a header that's deprecated in C++17.
+#if PQXX_CPLUSPLUS <= 201703L && __has_include(<ciso646>)
+#  include "include/pqxx/internal/ignore-deprecated-post.hxx"
+
 #  include <ciso646>
+
+#  include "include/pqxx/internal/ignore-deprecated-pre.hxx"
 #endif
 
 #if defined(PQXX_HAVE_GCC_PURE)


### PR DESCRIPTION
Fixes: https://github.com/jtv/libpqxx/issues/1036

Annoying.  Microsoft Visual Studio 2022 _requires_ us to include `<ciso646>` even in C++17 mode, or the new keywords don't work.  But the header is deprecated in C++17, so some compilers may complain about us including it.