### PR TITLE
Include `<typeinfo>`.

### DIFF
--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -20,6 +20,7 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <typeinfo>
 #include <type_traits>
 
 


### PR DESCRIPTION
See: #1000.

I don't see anything that would necessitate this, but @christianbrugger notes that his clang on Windows won't build without it.