### PR TITLE
connection: fix inverted O_NONBLOCK logic in set_blocking (POSIX)

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -565,9 +565,9 @@ void pqxx::connection::set_blocking(bool block) &
       internal::concat("Could not get socket state: ", err)};
   }
   if (block)
-    flags |= O_NONBLOCK;
-  else
     flags &= ~O_NONBLOCK;
+  else
+    flags |= O_NONBLOCK;
   if (::fcntl(fd, F_SETFL, flags) == -1)
   {
     char const *const err{pqxx::internal::error_string(errno, errbuf)};


### PR DESCRIPTION
On POSIX, O_NONBLOCK means non-blocking.
When block is true, clear O_NONBLOCK.
When block is false, set O_NONBLOCK.
Windows code path is unchanged.
