### PR TITLE
Add error code to insufficient_privilege exception

### DIFF
--- a/src/result.cxx
+++ b/src/result.cxx
@@ -265,7 +265,7 @@ void PQXX_COLD pqxx::result::throw_sql_error(
       break;
     case '2':
       if (equal(code, "42501"))
-        throw insufficient_privilege{Err, Query};
+        throw insufficient_privilege{Err, Query, code};
       if (equal(code, "42601"))
         throw syntax_error{Err, Query, code, errorposition()};
       if (equal(code, "42703"))


### PR DESCRIPTION
The error code provided by PostgreSQL is now stored in the `pqxx::insufficient_privilege` exception just like it is in all other exceptions.