### PR TITLE
[8.0] Minor improvements for pqxx::array

### DIFF
--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -88,12 +88,23 @@ public:
     }
   }
 
+  /// The element type of values in this array
+  using value_type = ELEMENT;
+
   /// How many dimensions does this array have?
   /** This value is known at compile time.
    */
-  PQXX_PURE constexpr std::size_t dimensions() const noexcept
+  PQXX_PURE static constexpr std::size_t dimensions() noexcept
   {
     return DIMENSIONS;
+  }
+
+  /// What is the separator used for parsing this array's values?
+  /** This value is known at compile time.
+   */
+  PQXX_PURE static constexpr char separator() noexcept
+  {
+    return SEPARATOR;
   }
 
   /// Return the sizes of this array in each of its dimensions.

--- a/include/pqxx/field.hxx
+++ b/include/pqxx/field.hxx
@@ -244,7 +244,8 @@ public:
     return as<O<T>>();
   }
 
-  /// Read SQL array contents as a @ref pqxx::array.
+  /// Read SQL array contents as a @ref pqxx::array.  You can also use
+  /// `as<pqxx::array<...>>()`
   template<typename ELEMENT, auto... ARGS>
   array<ELEMENT, ARGS...> as_sql_array(sl loc = sl::current()) const
   {

--- a/test/test_array.cxx
+++ b/test/test_array.cxx
@@ -718,7 +718,10 @@ void test_as_sql_array()
     // Connection closes, but we should still be able to parse the array.
   }
   auto const array{r[0].as_sql_array<int>()};
-  PQXX_CHECK_EQUAL(array[1], 4, "Got wrong value out of array.");
+  PQXX_CHECK_EQUAL(array[1], 4, "Got wrong value out of array (via as_sql_array).");
+
+  auto const array2{r[0].as<pqxx::array<int>>()};
+  PQXX_CHECK_EQUAL(array2[3], 2, "Got wrong value out of array (via as).");
 }
 
 


### PR DESCRIPTION
This fixes calls to `field.as<pqxx::array<int>>()` (and similar) not working: they would compile, but would end up constructing a pqxx::array with an invalid encoding, which would then immediately throw an usage error exception 'Tried to parse array without knowing its encoding.'

This was not only affecting `field.as<...>()` but also things that use that under the hood, such as:

    row.as<int, pqxx::array<int>>()

and higher level calls that build on this such as:

    tx.query01<int, pqxx::array<int>>("...")

This commit makes these all work by making the call to `as` detect the pqxx::array argument and diverting to as_sql_array().