### PR TITLE
Replace deprecated exec0 with exec().no_rows() in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Here's an example with all the basics to get you going:
             // Execute a statement, and check that it returns 0 rows of data.
             // This will throw pqxx::unexpected_rows if the query returns rows.
             std::cout << "Doubling all employees' salaries...\n";
-            tx.exec0("UPDATE employee SET salary = salary*2");
+            tx.exec("UPDATE employee SET salary = salary*2").no_rows();
 
             // Shorthand: conveniently query a single value from the database.
             int my_salary = tx.query_value<int>(


### PR DESCRIPTION
README.md currently uses exec0:

```
// Execute a statement, and check that it returns 0 rows of data.
// This will throw pqxx::unexpected_rows if the query returns rows.
std::cout << "Doubling all employees' salaries...\n";
tx.exec0("UPDATE employee SET salary = salary*2");
```

exec0 has been deprecated in 7.10.0 (#875). It should be replaced with exec().no_rows().