### PR TITLE
Support running on ASCII-only database.

### DIFF
--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -517,6 +517,7 @@ public:
     exec(std::format("SET {}={}", quote_name(var), quote(value, loc)), loc);
   }
 
+  // XXX: Return value documentation is wrong!  There's no std::optional here.
   /// Read currently applicable value of a variable.
   /** This function executes an SQL statement, so it won't work while a
    * @ref pipeline or query stream is active on the connection.


### PR DESCRIPTION
This is for #1015, where people are running the libpqxx tests against a database using the `SQL_ASCII` character set.  There are two tests that do need to store (however fleetingly) a non-ASCII character in the database.

(There are extensive tests for non-ASCII characters, but the others don't _store_ those in the database.  Turns out you can `SELECT` a character that the database encoding can't handle just fine.)