### PR TITLE
Too much random data passes SJIS checks.  Moar.

### DIFF
--- a/test/test_encodings.cxx
+++ b/test/test_encodings.cxx
@@ -167,7 +167,12 @@ auto find_x(std::array<char, N> const &data, pqxx::encoding_group enc)
 void test_find_chars_reports_malencoded_text(pqxx::test::context &tctx)
 {
   // Set up an array containing random char values, but not '|'.
-  std::array<char, 500> data{};
+  //
+  // We really need an amazingly large array here, since our encoding support
+  // is only designed to detect structural problems, not invalid characters per
+  // se.  So even an array of 500 bytes will pass the SJIS checks far too
+  // often.
+  std::array<char, 1000> data{};
   for (std::size_t i{0}; i < std::size(data); ++i)
   {
     data.at(i) = tctx.random_char();


### PR DESCRIPTION
The encoding support code isn't designed to detect invalid characters, only _malformed_ ones that might lead to SQL injections and such.

That makes the code very efficient, but unfortunately leaves a sizable chance that 500 random bytes will pass the SJIS integrity check.  So... generate 1,000 bytes instead.