### PR TITLE
Retire string conversion for `encoding_group`.

### DIFF
--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -288,7 +288,7 @@ PQXX_INLINE_COV inline void parse_composite_field(
       throw conversion_error{
         std::format(
           "Composite value contained more fields than the expected {}: '{}'.",
-          to_string(last_field, c), std::data(input)),
+          to_string(last_field, c), input),
         loc};
     if (input[pos] != ')' and input[pos] != ']')
       throw conversion_error{

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -344,7 +344,7 @@ specialize_parse_composite_field(conversion_context const &c)
   throw internal_error{
     std::format(
       "Unexpected encoding group code: {}.",
-      std::underlying_type_t<encoding_group>(c.enc)),
+      static_cast<std::underlying_type_t<encoding_group>>(c.enc)),
     c.loc};
 }
 

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -296,7 +296,7 @@ PQXX_INLINE_COV inline void parse_composite_field(
           "Composite value has unexpected characters where closing "
           "parenthesis "
           "was expected: '{}'.",
-          std::string{input}),
+          input),
         loc};
 
     pos += one_ascii_char;
@@ -306,7 +306,7 @@ PQXX_INLINE_COV inline void parse_composite_field(
         std::format(
           "Composite value has unexpected text after closing parenthesis: "
           "'{}'.",
-          std::string{input}),
+          input),
         loc};
   }
   ++index;
@@ -342,7 +342,9 @@ specialize_parse_composite_field(conversion_context const &c)
     return parse_composite_field<encoding_group::sjis>;
   }
   throw internal_error{
-    std::format("Unexpected encoding group code: {}.", to_string(c.enc)),
+    std::format(
+      "Unexpected encoding group code: {}.",
+      std::underlying_type_t<encoding_group>(c.enc)),
     c.loc};
 }
 

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -332,7 +332,7 @@ PQXX_PURE
     throw pqxx::internal_error{
       std::format(
         "Unexpected encoding group: {}.",
-        std::underlying_type_t<encoding_group>(enc)),
+        static_cast<std::underlying_type_t<encoding_group>>(enc)),
       loc};
   }
 }

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -18,12 +18,6 @@
 #include "pqxx/strconv.hxx"
 
 
-namespace pqxx
-{
-PQXX_DECLARE_ENUM_CONVERSION(encoding_group);
-} // namespace pqxx
-
-
 namespace pqxx::internal
 {
 /// Return PostgreSQL's name for encoding enum value.
@@ -336,7 +330,10 @@ PQXX_PURE
 
   default:
     throw pqxx::internal_error{
-      std::format("Unexpected encoding group: {}.", to_string(enc)), loc};
+      std::format(
+        "Unexpected encoding group: {}.",
+        std::underlying_type_t<encoding_group>(enc)),
+      loc};
   }
 }
 } // namespace pqxx::internal

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -151,7 +151,10 @@ array_parser::specialize_for_encoding(encoding_group enc, sl loc)
     PQXX_ENCODING_CASE(sjis);
   }
   [[unlikely]] throw pqxx::internal_error{
-    std::format("Unsupported encoding code: {}.", to_string(enc)), loc};
+    std::format(
+      "Unsupported encoding code: {}.",
+      std::underlying_type_t<encoding_group>(enc)),
+    loc};
 
 #undef PQXX_ENCODING_CASE
 }

--- a/src/array.cxx
+++ b/src/array.cxx
@@ -153,7 +153,7 @@ array_parser::specialize_for_encoding(encoding_group enc, sl loc)
   [[unlikely]] throw pqxx::internal_error{
     std::format(
       "Unsupported encoding code: {}.",
-      std::underlying_type_t<encoding_group>(enc)),
+      static_cast<std::underlying_type_t<encoding_group>>(enc)),
     loc};
 
 #undef PQXX_ENCODING_CASE

--- a/test/test_connection.cxx
+++ b/test/test_connection.cxx
@@ -217,13 +217,17 @@ void test_connection_client_encoding(pqxx::test::context &tctx)
     {"GB18030", pqxx::encoding_group::gb18030},
     {"SJIS", pqxx::encoding_group::sjis},
     {"SHIFT_JIS_2004", pqxx::encoding_group::sjis},
-    // Not actually ASCII-safe, but just close enough for our purposes.
+    // Close enough to ASCII-safe for our purposes, but not actually
+    // generally safe.
     {"UHC", pqxx::encoding_group::ascii_safe},
   };
+  using underlying = std::underlying_type_t<pqxx::encoding_group>;
   for (auto const &[name, enc] : unsafe_encodings)
   {
     cx.set_client_encoding(name);
-    PQXX_CHECK_EQUAL(cx.get_encoding_group(), enc);
+    PQXX_CHECK_EQUAL(
+      static_cast<underlying>(cx.get_encoding_group()),
+      static_cast<underlying>(enc));
   }
 
   std::vector<char const *> const safe_encodings{
@@ -269,7 +273,8 @@ void test_connection_client_encoding(pqxx::test::context &tctx)
   {
     cx.set_client_encoding(e);
     PQXX_CHECK_EQUAL(
-      cx.get_encoding_group(), pqxx::encoding_group::ascii_safe,
+      static_cast<underlying>(cx.get_encoding_group()),
+      static_cast<underlying>(pqxx::encoding_group::ascii_safe),
       std::format("Unexpected encoding group for '{}'.", e));
   }
 


### PR DESCRIPTION
Turns out `PQXX_DECLARE_ENUM_CONVERSION` was never a good idea.  So, stop using it for `encoding_group`.