### PR TITLE
Test "make install"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ jobs:
           path: test.log
 
 
-  try-make-dist:
+  try-make-dist-install:
     parameters:
       compiler:
         type: string
@@ -480,11 +480,16 @@ jobs:
           name: Extract tarball
           command: "tar --one-top-level=unpacked -xf libpqxx-*.*.tar*"
       - run:
-          name: Build from extracted tarball
+          name: Build from extracted tarball, install
           command: ". /tmp/vars.sh && \
                 cd unpacked/libpqxx-* && \
                 ./configure CXX=<< parameters.compiler >> CXXFLAGS=-O0 && \
-                make -j4"
+                make -j4 && make install"
+      - run:
+          name: Build using installed headers & binary
+          command: ". /tmp/vars.sh && cd unpacked/libpqxx-* && \
+                rm -rf include src && ./tools/run-test-postgres.sh && \
+                make -j4 check"
 
 
 workflows:
@@ -542,7 +547,7 @@ workflows:
               compiler: ["clang++", "g++"]
               cxx_ver: ["c++20", "c++23", "c++26"]
 
-      - try-make-dist:
+      - try-make-dist-install:
           matrix:
             parameters:
               compiler: ["clang++"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,8 +493,8 @@ jobs:
           command: ". /tmp/vars.sh && \
                 mkdir client && \
                 cd client && \
-                cp ../examples/quick_example.cxx . && \
-                << parameters.compiler >> quick_example.cxx -lpqxx -lpq && \
+                cp ../examples/quick_example.cxx clnt.cxx && \
+                << parameters.compiler >> -std=c++20 clnt.cxx -lpqxx -lpq && \
                 ./a.out"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,9 +486,11 @@ jobs:
                 ./configure CXX=<< parameters.compiler >> CXXFLAGS=-O0 && \
                 make -j4 && make install"
       - run:
-          name: Build using installed headers & binary
-          command: ". /tmp/vars.sh && cd unpacked/libpqxx-* && \
-                rm -rf include src && ./tools/run-test-postgres.sh && \
+          name: Build using just the installed headers & binary
+          command: ". /tmp/vars.sh && \
+                cd unpacked/libpqxx-* && \
+                rm -rf include src && \
+                ./tools/run-test-postgres.sh postgres && \
                 make -j4 check"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,9 @@ jobs:
           path: "/tmp/vars.sh"
 
       - run:
+          name: Start database
+          command: ". /tmp/vars.sh && ./tools/run-test-postgres.sh postgres"
+      - run:
           name: Autogen
           command: ". /tmp/vars.sh && autoreconf"
       - run:
@@ -488,10 +491,11 @@ jobs:
       - run:
           name: Build using just the installed headers & binary
           command: ". /tmp/vars.sh && \
-                cd unpacked/libpqxx-* && \
-                rm -rf include src && \
-                ./tools/run-test-postgres.sh postgres && \
-                make -j4 check"
+                mkdir client && \
+                cd client && \
+                cp ../examples/quick_example.cxx . && \
+                << parameters.compiler >> quick_example.cxx -lpqxx -lpq && \
+                ./a.out"
 
 
 workflows:

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,9 +33,20 @@ SUBDIRS = . include
 EXTRA_DIST = autogen.sh Makefile.am.template README.md VERSION \
 	requirements.json .clang-format .clang-tidy .cmake-format \
 	.inferconfig .lcovrc .lgtm.yml .lift .mdlrc .mdl_style.rb .yamllint \
-	doc/Doxyfile \
-	src/pqxx-source.hxx \
+	doc/Doxyfile include/pqxx/version.hxx.template \
+	src/pqxx-source.hxx include/pqxx/doc/mainpage.md.template \
 	test/helpers.hxx test/sample_types.hxx \
+        include/pqxx/doc/accessing-results.md \
+        include/pqxx/doc/binary-data.md \
+        include/pqxx/doc/datatypes.md \
+        include/pqxx/doc/escaping.md \
+        include/pqxx/doc/getting-started.md \
+        include/pqxx/doc/mainpage.md \
+        include/pqxx/doc/parameters.md \
+        include/pqxx/doc/performance.md \
+        include/pqxx/doc/prepared-statement.md \
+        include/pqxx/doc/streams.md \
+        include/pqxx/doc/thread-safety.md \
 	tools/benchmark.cxx \
 	tools/check_ascii.py \
 	tools/compiler_flags.py \

--- a/Makefile.am.template
+++ b/Makefile.am.template
@@ -20,9 +20,12 @@ SUBDIRS = . include
 EXTRA_DIST = autogen.sh Makefile.am.template README.md VERSION \
 	requirements.json .clang-format .clang-tidy .cmake-format \
 	.inferconfig .lcovrc .lgtm.yml .lift .mdlrc .mdl_style.rb .yamllint \
-	doc/Doxyfile \
-	src/pqxx-source.hxx \
+	doc/Doxyfile include/pqxx/version.hxx.template \
+	src/pqxx-source.hxx include/pqxx/doc/mainpage.md.template \
 	test/helpers.hxx test/sample_types.hxx \
+###MAKTEMPLATE:FOREACH include/pqxx/doc/*.md
+        include/pqxx/doc/###BASENAME###.md \
+###MAKTEMPLATE:ENDFOREACH
 ###MAKTEMPLATE:FOREACH tools/*.cxx
 	tools/###BASENAME###.cxx \
 ###MAKTEMPLATE:ENDFOREACH

--- a/Makefile.in
+++ b/Makefile.in
@@ -669,9 +669,20 @@ SUBDIRS = . include
 EXTRA_DIST = autogen.sh Makefile.am.template README.md VERSION \
 	requirements.json .clang-format .clang-tidy .cmake-format \
 	.inferconfig .lcovrc .lgtm.yml .lift .mdlrc .mdl_style.rb .yamllint \
-	doc/Doxyfile \
-	src/pqxx-source.hxx \
+	doc/Doxyfile include/pqxx/version.hxx.template \
+	src/pqxx-source.hxx include/pqxx/doc/mainpage.md.template \
 	test/helpers.hxx test/sample_types.hxx \
+        include/pqxx/doc/accessing-results.md \
+        include/pqxx/doc/binary-data.md \
+        include/pqxx/doc/datatypes.md \
+        include/pqxx/doc/escaping.md \
+        include/pqxx/doc/getting-started.md \
+        include/pqxx/doc/mainpage.md \
+        include/pqxx/doc/parameters.md \
+        include/pqxx/doc/performance.md \
+        include/pqxx/doc/prepared-statement.md \
+        include/pqxx/doc/streams.md \
+        include/pqxx/doc/thread-safety.md \
 	tools/benchmark.cxx \
 	tools/check_ascii.py \
 	tools/compiler_flags.py \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -76,8 +76,3 @@ nobase_include_HEADERS= pqxx/pqxx \
 
 
 nobase_nodist_include_HEADERS = pqxx/internal/config.h
-
-EXTRA_DIST = \
-	pqxx/doc/*.md \
-	pqxx/doc/mainpage.md.template \
-	pqxx/version.hxx.template

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -383,11 +383,6 @@ nobase_include_HEADERS = pqxx/pqxx \
 	pqxx/internal/gates/transaction-transaction_focus.hxx
 
 nobase_nodist_include_HEADERS = pqxx/internal/config.h
-EXTRA_DIST = \
-	pqxx/doc/*.md \
-	pqxx/doc/mainpage.md.template \
-	pqxx/version.hxx.template
-
 all: all-am
 
 .SUFFIXES:


### PR DESCRIPTION
Fixes: #1192 

Extends the "make dist" CI test scenario to also "make install", and then build and run a test against the installed headers and binaries.