### PR TITLE
Also test against clang/libc++.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
   # Test like test-linux, except using clang and its own C++ library, libc++.
   # (By default it uses gcc's libstdc++, because that's what existing packages
   # are built against.)
-  test-libc++:
+  test-libcplusplus:
     parameters:
       cxx_ver:
         type: string
@@ -587,7 +587,7 @@ workflows:
               # is -O1.
               opt: [0, 2, 3]
 
-      - test-libc++:
+      - test-libcplusplus:
           matrix:
             parameters:
               cxx_ver: ["c++20", "c++23", "c++26"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,8 @@ jobs:
 
       - run:
           name: Install
-          # TODO: Move the extra install into install-deps.sh.
-          command: "./tools/install-deps.sh ubuntu clang++ >/tmp/vars.sh && \
-              apt-get install -qy libc++-dev"
+          command: "./tools/install-deps.sh ubuntu clang++ libc++-dev \
+              >/tmp/vars.sh"
           max_auto_reruns: 3
       - store_artifacts:
           path: "/tmp/install.log"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,6 @@ jobs:
       - run:
           name: Start database
           command: ". /tmp/vars.sh && ./tools/run-test-postgres.sh postgres"
-      - store_artifacts:
-          path: postgres.log
       - run:
           name: Test
           command: . /tmp/vars.sh && make -j4 check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
       - checkout
       - run:
           name: Install
-          command: "tools/install-deps.sh archlinux-coverage g++ >/tmp/vars.sh"
+          command: "tools/install-deps.sh archlinux g++ lcov >/tmp/vars.sh"
           max_auto_reruns: 3
       - store_artifacts:
           path: "/tmp/install.log"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,127 @@ jobs:
       - store_artifacts:
           path: examples
 
+  # Test like test-linux, except using clang and its own C++ library, libc++.
+  # (By default it uses gcc's libstdc++, because that's what existing packages
+  # are built against.)
+  test-libc++:
+    parameters:
+      cxx_ver:
+        type: string
+    docker:
+      - image: ubuntu
+    resource_class: large
+    steps:
+      - checkout
+
+      - run:
+          name: Install
+          command: "./tools/install-deps.sh ubuntu clang++ >/tmp/vars.sh && \
+              apt-get install -qy libc++-dev"
+          max_auto_reruns: 3
+      - store_artifacts:
+          path: "/tmp/install.log"
+      - store_artifacts:
+          path: "/tmp/vars.sh"
+
+      - run:
+          name: Autogen
+          command: ". /tmp/vars.sh && autoreconf"
+      - run:
+          name: Configure
+          command: ". /tmp/vars.sh && ./configure \
+                --enable-maintainer-mode --enable-audit \
+                --enable-shared --disable-static \
+                CXX=clang++ \
+                CXXFLAGS=\"-O1 -std=<< parameters.cxx_ver >> -stdlib=libc++\" \
+                LDFLAGS=-stdlib=libc++"
+      - store_artifacts:
+          path: config.log
+      - store_artifacts:
+          path: include/pqxx
+      - run:
+          name: Make
+          command: make -j4
+      - run:
+          name: Start database
+          command: ". /tmp/vars.sh && ./tools/run-test-postgres.sh postgres"
+      - store_artifacts:
+          path: postgres.log
+      - run:
+          name: Test
+          command: . /tmp/vars.sh && make -j4 check
+      - store_artifacts:
+          path: test-suite.log
+      - store_artifacts:
+          path: postgres.log
+      - store_artifacts:
+          path: examples
+
+  test-macos:
+    parameters:
+      compiler:
+        type: string
+      cxx_ver:
+        type: string
+    macos:
+      # Bummer.  We *have* to specify an exact xcode version.  And match it up
+      # with a resource class that supports it.  Available combinations are
+      # listed here:
+      #
+      # https://circleci.com/docs/guides/execution-managed/using-macos/
+      #
+      # Without updating these, the macos builds will just stop working when
+      # the XCode/image combo falls out of support.
+      #
+      xcode: "26.2.0"
+
+    # As of late 2025, this is the default resource class we get for macOS.
+    # But since they include the chip generation, they will eventually fall out
+    # of date.  Transient problems can ensue.
+    # resource_class: "m4pro.medium"
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: "./tools/install-deps.sh macos << parameters.compiler >> \
+              >/tmp/vars.sh"
+          max_auto_reruns: 3
+      - store_artifacts:
+          path: "/tmp/install.log"
+      - store_artifacts:
+          path: "/tmp/vars.sh"
+      - run:
+          name: Configure
+          command: ". /tmp/vars.sh && autoreconf && ./configure \
+                --enable-maintainer-mode --enable-audit \
+                --enable-shared --disable-static \
+                CPPFLAGS=\"-I/opt/homebrew/opt/libpq/include/\" \
+                CXX=<< parameters.compiler >> \
+                CXXFLAGS=\"-O1 -std=<< parameters.cxx_ver >>\" \
+                LDFLAGS=\"-L/opt/homebrew/opt/libpq/lib\""
+      - store_artifacts:
+          path: config.log
+      - store_artifacts:
+          path: include/pqxx
+      - run:
+          name: Make
+          command: make -j4
+      - run:
+          name: Start database
+          command: ". /tmp/vars.sh && ./tools/run-test-postgres.sh"
+      - store_artifacts:
+          path: postgres.log
+      - run:
+          name: Test
+          command: ". /tmp/vars.sh && make -j4 check"
+      - store_artifacts:
+          path: test-suite.log
+      - store_artifacts:
+          path: postgres.log
+      - store_artifacts:
+          path: examples
+
+
   test-macos:
     parameters:
       compiler:
@@ -529,6 +650,11 @@ workflows:
               # visible at lower levels.  So... only level we end up skipping
               # is -O1.
               opt: [0, 2, 3]
+
+      - test-libc++:
+          matrix:
+            parameters:
+              cxx_ver: ["c++20", "c++23", "c++26"]
 
       - test-linux:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
 
       - run:
           name: Install
+          # TODO: Move the extra install into install-deps.sh.
           command: "./tools/install-deps.sh ubuntu clang++ >/tmp/vars.sh && \
               apt-get install -qy libc++-dev"
           max_auto_reruns: 3
@@ -126,71 +127,6 @@ jobs:
           path: postgres.log
       - store_artifacts:
           path: examples
-
-  test-macos:
-    parameters:
-      compiler:
-        type: string
-      cxx_ver:
-        type: string
-    macos:
-      # Bummer.  We *have* to specify an exact xcode version.  And match it up
-      # with a resource class that supports it.  Available combinations are
-      # listed here:
-      #
-      # https://circleci.com/docs/guides/execution-managed/using-macos/
-      #
-      # Without updating these, the macos builds will just stop working when
-      # the XCode/image combo falls out of support.
-      #
-      xcode: "26.2.0"
-
-    # As of late 2025, this is the default resource class we get for macOS.
-    # But since they include the chip generation, they will eventually fall out
-    # of date.  Transient problems can ensue.
-    # resource_class: "m4pro.medium"
-    steps:
-      - checkout
-      - run:
-          name: Install
-          command: "./tools/install-deps.sh macos << parameters.compiler >> \
-              >/tmp/vars.sh"
-          max_auto_reruns: 3
-      - store_artifacts:
-          path: "/tmp/install.log"
-      - store_artifacts:
-          path: "/tmp/vars.sh"
-      - run:
-          name: Configure
-          command: ". /tmp/vars.sh && autoreconf && ./configure \
-                --enable-maintainer-mode --enable-audit \
-                --enable-shared --disable-static \
-                CPPFLAGS=\"-I/opt/homebrew/opt/libpq/include/\" \
-                CXX=<< parameters.compiler >> \
-                CXXFLAGS=\"-O1 -std=<< parameters.cxx_ver >>\" \
-                LDFLAGS=\"-L/opt/homebrew/opt/libpq/lib\""
-      - store_artifacts:
-          path: config.log
-      - store_artifacts:
-          path: include/pqxx
-      - run:
-          name: Make
-          command: make -j4
-      - run:
-          name: Start database
-          command: ". /tmp/vars.sh && ./tools/run-test-postgres.sh"
-      - store_artifacts:
-          path: postgres.log
-      - run:
-          name: Test
-          command: ". /tmp/vars.sh && make -j4 check"
-      - store_artifacts:
-          path: test-suite.log
-      - store_artifacts:
-          path: postgres.log
-      - store_artifacts:
-          path: examples
-
 
   test-macos:
     parameters:

--- a/config-tests/PQXX_HAVE_UU_RESTRICT.cxx
+++ b/config-tests/PQXX_HAVE_UU_RESTRICT.cxx
@@ -6,7 +6,7 @@
  * it to a view or a span, only to a raw pointer.  We no longer use a lot of
  * raw pointers in libpqxx.
  */
-char first(char const * __restrict x)
+char first(char const *__restrict x)
 {
   return x[0];
 }

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -147,7 +147,8 @@ generic_into_buf(std::span<char> buf, T const &value, ctx c = {})
  */
 template<std::floating_point T> struct float_string_traits
 {
-  PQXX_LIBEXPORT PQXX_HOT static T from_string(std::string_view text, ctx = {});
+  PQXX_LIBEXPORT PQXX_HOT static T
+  from_string(std::string_view text, ctx = {});
 
   PQXX_LIBEXPORT PQXX_HOT static std::string_view
   to_buf(std::span<char> buf, T const &value, ctx c = {});
@@ -161,7 +162,8 @@ template<std::floating_point T> struct float_string_traits
       return 1 + digits10(value / 10);
   }
 
-  PQXX_HOT PQXX_INLINE_COV static constexpr std::size_t size_buffer(T const &) noexcept
+  PQXX_HOT PQXX_INLINE_COV static constexpr std::size_t
+  size_buffer(T const &) noexcept
   {
     using lims = std::numeric_limits<T>;
     // See #328 for a detailed discussion on the maximum number of digits.
@@ -213,11 +215,13 @@ template<std::floating_point T> struct float_string_traits
  */
 template<pqxx::internal::integer T> struct integer_string_traits
 {
-  PQXX_LIBEXPORT PQXX_HOT static T from_string(std::string_view text, ctx = {});
+  PQXX_LIBEXPORT PQXX_HOT static T
+  from_string(std::string_view text, ctx = {});
   PQXX_LIBEXPORT PQXX_HOT static std::string_view
   to_buf(std::span<char> buf, T const &value, ctx c = {});
 
-  PQXX_INLINE_ONLY PQXX_HOT static constexpr std::size_t size_buffer(T const &) noexcept
+  PQXX_INLINE_ONLY PQXX_HOT static constexpr std::size_t
+  size_buffer(T const &) noexcept
   {
     /** Includes a sign if needed; the number of base-10 digits which the type
      * can reliably represent; and the one extra base-10 digit which the type
@@ -277,7 +281,8 @@ struct string_traits<long double> final
 
 template<> struct string_traits<bool> final
 {
-  PQXX_LIBEXPORT PQXX_HOT static bool from_string(std::string_view text, ctx c = {});
+  PQXX_LIBEXPORT PQXX_HOT static bool
+  from_string(std::string_view text, ctx c = {});
 
   PQXX_PURE PQXX_HOT static constexpr zview
   to_buf(std::span<char>, bool const &value, ctx = {}) noexcept
@@ -285,7 +290,11 @@ template<> struct string_traits<bool> final
     return value ? "true"_zv : "false"_zv;
   }
 
-  PQXX_PURE PQXX_HOT static constexpr std::size_t size_buffer(bool const &) noexcept { return 5; }
+  PQXX_PURE PQXX_HOT static constexpr std::size_t
+  size_buffer(bool const &) noexcept
+  {
+    return 5;
+  }
 };
 
 
@@ -302,7 +311,8 @@ template<typename T> struct nullness<std::optional<T>> final
   {
     return ((not v.has_value()) or pqxx::is_null(*v));
   }
-  [[nodiscard]] PQXX_PURE PQXX_HOT static constexpr std::optional<T> null() noexcept
+  [[nodiscard]] PQXX_PURE PQXX_HOT static constexpr std::optional<T>
+  null() noexcept
   {
     return {};
   }

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -5,7 +5,7 @@
 # Must be run with root privileges.  This is meant for use in disposable
 # containers and VMs.
 #
-# Usage: install-deps.sh <system> <compiler>
+# Usage: install-deps.sh <system> <compiler> [extra OS packages...]
 #
 # Where <system> is one of the environments for which this script works:
 # * archlinux
@@ -90,18 +90,7 @@ install_archlinux() {
     pacman_install \
         "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
         postgresql which \
-        "$(compiler_pkg "$1")"
-
-    echo "export PGHOST=/run/postgresql"
-}
-
-
-# Install test coveraage tools.
-install_archlinux_coverage() {
-    pacman_install \
-        "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
-        lcov postgresql which \
-        "$(compiler_pkg "$1")"
+        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/run/postgresql"
 }
@@ -123,7 +112,7 @@ install_archlinux_infer() {
     pacman_install \
         "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
         tzdata wget xz \
-        "$(compiler_pkg "$1")"
+        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
 
     cd /opt
     # This is not idempotent.  I wasn't joking about using a disposable
@@ -140,7 +129,7 @@ install_archlinux_lint() {
         "${PKGS_ARCHLINUX_BASE[@]}" \
         cmake cppcheck make markdownlint python-pyflakes ruff shellcheck \
         which yamllint \
-        "$(compiler_pkg "$1")"
+        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
 }
 
 
@@ -148,7 +137,7 @@ install_debian() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" "${PKGS_DEBIAN_AUTOTOOLS[@]}" \
         postgresql \
-        "$(compiler_pkg "$1" clang g++)"
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -161,7 +150,7 @@ install_fedora() {
         "${PKGS_ALL_AUTOTOOLS[@]}" \
         libasan libubsan postgresql postgresql-devel postgresql-server \
         python3 uv which \
-        "$(compiler_pkg "$1" clang g++)"
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
 }
@@ -173,7 +162,7 @@ install_macos() {
 
     brew_install \
         "${PKGS_ALL_AUTOTOOLS[@]}" \
-        postgresql@$pg_ver uv libpq
+        postgresql@$pg_ver uv libpq "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp PGBIN=/opt/homebrew/bin/ PGVER=$pg_ver"
 }
@@ -185,7 +174,7 @@ install_ubuntu_codeql() {
         sudo -E apt-get -q -o DPkg::Lock::Timeout=120 update
         sudo -E apt-get -q install -y -o DPkg::Lock::Timeout=120 \
             cmake git libpq-dev make \
-            "$(compiler_pkg "$1" clang g++)"
+            "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
     ) >>/tmp/install.log
 }
 
@@ -194,7 +183,7 @@ install_ubuntu() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" "${PKGS_DEBIAN_AUTOTOOLS[@]}" \
         postgresql \
-        "$(compiler_pkg "$1" clang g++)"
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -206,7 +195,7 @@ install_ubuntu_valgrind() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" \
 	cmake ninja-build postgresql valgrind \
-        "$(compiler_pkg "$1" clang g++)"
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -260,6 +249,7 @@ pacman -S \
     cmake \
     ninja \
     $cxxpkg \
+    "${EXTRA_PACKAGES[@]}" \
     --noconfirm
 " | tee -a install.log >&2
 
@@ -284,13 +274,11 @@ fi
 
 PROFILE="$1"
 COMPILER="$2"
+EXTRA_PACKAGES="${@:3}"
 
 case "$PROFILE" in
     archlinux)
         install_archlinux "$COMPILER"
-        ;;
-    archlinux-coverage)
-        install_archlinux_coverage "$COMPILER"
         ;;
     archlinux-infer)
         install_archlinux_infer "$COMPILER"

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -90,7 +90,7 @@ install_archlinux() {
     pacman_install \
         "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
         postgresql which \
-        "$(compiler_pkg "$1")" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/run/postgresql"
 }
@@ -112,7 +112,7 @@ install_archlinux_infer() {
     pacman_install \
         "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
         tzdata wget xz \
-        "$(compiler_pkg "$1")" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
 
     cd /opt
     # This is not idempotent.  I wasn't joking about using a disposable
@@ -129,7 +129,7 @@ install_archlinux_lint() {
         "${PKGS_ARCHLINUX_BASE[@]}" \
         cmake cppcheck make markdownlint python-pyflakes ruff shellcheck \
         which yamllint \
-        "$(compiler_pkg "$1")" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
 }
 
 
@@ -137,7 +137,7 @@ install_debian() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" "${PKGS_DEBIAN_AUTOTOOLS[@]}" \
         postgresql \
-        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -150,7 +150,7 @@ install_fedora() {
         "${PKGS_ALL_AUTOTOOLS[@]}" \
         libasan libubsan postgresql postgresql-devel postgresql-server \
         python3 uv which \
-        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
 }
@@ -162,7 +162,7 @@ install_macos() {
 
     brew_install \
         "${PKGS_ALL_AUTOTOOLS[@]}" \
-        postgresql@$pg_ver uv libpq $EXTRA_PACKAGES
+        postgresql@$pg_ver uv libpq "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp PGBIN=/opt/homebrew/bin/ PGVER=$pg_ver"
 }
@@ -174,7 +174,7 @@ install_ubuntu_codeql() {
         sudo -E apt-get -q -o DPkg::Lock::Timeout=120 update
         sudo -E apt-get -q install -y -o DPkg::Lock::Timeout=120 \
             cmake git libpq-dev make \
-            "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
+            "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
     ) >>/tmp/install.log
 }
 
@@ -183,7 +183,7 @@ install_ubuntu() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" "${PKGS_DEBIAN_AUTOTOOLS[@]}" \
         postgresql \
-        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -195,7 +195,7 @@ install_ubuntu_valgrind() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" \
 	cmake ninja-build postgresql valgrind \
-        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
+        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -203,6 +203,7 @@ install_ubuntu_valgrind() {
 }
 
 
+# TODO: Support EXTRA_PACKAGES here.
 install_windows() {
     local arch="mingw-w64-x86_64"
     local cxxpkg
@@ -249,7 +250,6 @@ pacman -S \
     cmake \
     ninja \
     $cxxpkg \
-    $EXTRA_PACKAGES \
     --noconfirm
 " | tee -a install.log >&2
 
@@ -274,7 +274,7 @@ fi
 
 PROFILE="$1"
 COMPILER="$2"
-EXTRA_PACKAGES="${@:3}"
+EXTRA_PACKAGES=("${@:3}")
 
 case "$PROFILE" in
     archlinux)

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -163,11 +163,18 @@ install_fedora() {
 
 install_macos() {
     # Looks like our compilers come pre-installed on this image.
+
+    # macOS ships with an older bash version because of licencing issues,
+    # and that version treats an empty array as uninitialised!
+    #
+    # We need a bit of extra syntax to work around this.  This "${A+B}" syntax
+    # means "if A is set, use B, otherwise use an empty value."
+    local extra="${EXTRA_PACKAGES[@]+"${EXTRA_PACKAGES[@]}"}"
     local pg_ver=18
 
     brew_install \
         "${PKGS_ALL_AUTOTOOLS[@]}" \
-        postgresql@$pg_ver uv libpq "${EXTRA_PACKAGES[@]}"
+        postgresql@$pg_ver uv libpq "${extra[@]+"${extra[@]}"}"
 
     echo "export PGHOST=/tmp PGBIN=/opt/homebrew/bin/ PGVER=$pg_ver"
 }

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -27,6 +27,11 @@
 set -Cue -o pipefail
 
 
+PROFILE="$1"
+COMPILER="$2"
+EXTRA_PACKAGES=("${@:3}")
+
+
 # For Debian-flavoured distros:
 export DEBIAN_FRONTEND=noninteractive TZ=UTC
 
@@ -272,9 +277,6 @@ EOF
     exit 1
 fi
 
-PROFILE="$1"
-COMPILER="$2"
-EXTRA_PACKAGES=("${@:3}")
 
 case "$PROFILE" in
     archlinux)

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -169,7 +169,7 @@ install_macos() {
     #
     # We need a bit of extra syntax to work around this.  This "${A+B}" syntax
     # means "if A is set, use B, otherwise use an empty value."
-    local extra="${EXTRA_PACKAGES[@]+"${EXTRA_PACKAGES[@]}"}"
+    local extra=("${EXTRA_PACKAGES[@]+"${EXTRA_PACKAGES[@]}"}")
     local pg_ver=18
 
     brew_install \

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -262,7 +262,7 @@ pacman -S \
 if [ -z "${1:-}" ] || [ -z "${2:-}" ]
 then
     cat >&2 <<EOF
-Usage: $0 <profile> <compiler>
+Usage: $0 <profile> <compiler> [extra packages...]
 
 Where <profile> is usually an OS name, sometimes a combination of OS and
 purpose: archlinux, archilinux-lint, debian, fedora, macos, windows...

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -90,7 +90,7 @@ install_archlinux() {
     pacman_install \
         "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
         postgresql which \
-        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1")" $EXTRA_PACKAGES
 
     echo "export PGHOST=/run/postgresql"
 }
@@ -112,7 +112,7 @@ install_archlinux_infer() {
     pacman_install \
         "${PKGS_ARCHLINUX_BASE[@]}" "${PKGS_ARCHLINUX_AUTOTOOLS[@]}" \
         tzdata wget xz \
-        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1")" $EXTRA_PACKAGES
 
     cd /opt
     # This is not idempotent.  I wasn't joking about using a disposable
@@ -129,7 +129,7 @@ install_archlinux_lint() {
         "${PKGS_ARCHLINUX_BASE[@]}" \
         cmake cppcheck make markdownlint python-pyflakes ruff shellcheck \
         which yamllint \
-        "$(compiler_pkg "$1")" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1")" $EXTRA_PACKAGES
 }
 
 
@@ -137,7 +137,7 @@ install_debian() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" "${PKGS_DEBIAN_AUTOTOOLS[@]}" \
         postgresql \
-        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -150,7 +150,7 @@ install_fedora() {
         "${PKGS_ALL_AUTOTOOLS[@]}" \
         libasan libubsan postgresql postgresql-devel postgresql-server \
         python3 uv which \
-        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
 
     echo "export PGHOST=/tmp"
 }
@@ -162,7 +162,7 @@ install_macos() {
 
     brew_install \
         "${PKGS_ALL_AUTOTOOLS[@]}" \
-        postgresql@$pg_ver uv libpq "${EXTRA_PACKAGES[@]}"
+        postgresql@$pg_ver uv libpq $EXTRA_PACKAGES
 
     echo "export PGHOST=/tmp PGBIN=/opt/homebrew/bin/ PGVER=$pg_ver"
 }
@@ -174,7 +174,7 @@ install_ubuntu_codeql() {
         sudo -E apt-get -q -o DPkg::Lock::Timeout=120 update
         sudo -E apt-get -q install -y -o DPkg::Lock::Timeout=120 \
             cmake git libpq-dev make \
-            "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
+            "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
     ) >>/tmp/install.log
 }
 
@@ -183,7 +183,7 @@ install_ubuntu() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" "${PKGS_DEBIAN_AUTOTOOLS[@]}" \
         postgresql \
-        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -195,7 +195,7 @@ install_ubuntu_valgrind() {
     apt_install \
         "${PKGS_DEBIAN_BASE[@]}" \
 	cmake ninja-build postgresql valgrind \
-        "$(compiler_pkg "$1" clang g++)" "${EXTRA_PACKAGES[@]}"
+        "$(compiler_pkg "$1" clang g++)" $EXTRA_PACKAGES
 
     echo "export PGHOST=/tmp"
     echo "export PATH='$PATH:$HOME/.local/bin'"
@@ -249,7 +249,7 @@ pacman -S \
     cmake \
     ninja \
     $cxxpkg \
-    "${EXTRA_PACKAGES[@]}" \
+    $EXTRA_PACKAGES \
     --noconfirm
 " | tee -a install.log >&2
 


### PR DESCRIPTION
Chose Ubuntu for the OS image, fairly arbitrarily (the Arch image happened to run into a packaging problem, Debian required an additional package).

The default Ubuntu builds use gcc's libstdc++, even with clang, because that's what the existing packages are built against.