### PR TITLE
Fix budget for `bool` conversion.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  - Fix an apparent `memcpy()` overlap.
  - Rename `config-compiler.h` to just `internal/config.h`. (#1211)
  - Fix detection of supported compiler flags.
+ - Fix `bool` conversion to stsring. (#1229)
 8.0.1
  - A lot more constructors are now `explicit`.
  - Update GNU attributes to use standard `[[attribute]]` syntax. (#1199)

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@
  - Fix an apparent `memcpy()` overlap.
  - Rename `config-compiler.h` to just `internal/config.h`. (#1211)
  - Fix detection of supported compiler flags.
- - Fix `bool` conversion to stsring. (#1229)
+ - Fix `bool` conversion to string. (#1229)
 8.0.1
  - A lot more constructors are now `explicit`.
  - Update GNU attributes to use standard `[[attribute]]` syntax. (#1199)

--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -284,16 +284,16 @@ template<> struct string_traits<bool> final
   PQXX_LIBEXPORT PQXX_HOT static bool
   from_string(std::string_view text, ctx c = {});
 
-  PQXX_PURE PQXX_HOT static constexpr zview
+  PQXX_PURE PQXX_HOT static constexpr std::string_view
   to_buf(std::span<char>, bool const &value, ctx = {}) noexcept
   {
-    return value ? "true"_zv : "false"_zv;
+    return value ? "true": "false";
   }
 
   PQXX_PURE PQXX_HOT static constexpr std::size_t
   size_buffer(bool const &) noexcept
   {
-    return 5;
+    return 6;
   }
 };
 

--- a/test/test_stream_to.cxx
+++ b/test/test_stream_to.cxx
@@ -729,6 +729,8 @@ void test_stream_to_bool(pqxx::test::context &tctx)
 
   // In #1203, this triggered an assertion failure.
   stream.write_values("2026", true);
+  // And in #1229, this one did (because "false" is 1 byte longer).
+  stream.write_values("2026", false);
   stream.complete();
 }
 


### PR DESCRIPTION
Fixes: #1229.

The string conversion for `bool` ran out of budget for the value `false`.