### PR TITLE
Silence clang-tidy warnings about `config.h`.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -266,4 +266,4 @@ Checks: >
     readability-use-anyofallof,
     zircon-temporary-objects
 
-#ExcludeHeaderFilter: config.h
+ExcludeHeaderFilter: config.h

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -266,4 +266,4 @@ Checks: >
     readability-use-anyofallof,
     zircon-temporary-objects
 
-ExcludeHeaderFilter: config.h
+ExcludeHeaderFilterRegex: config.h

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -265,3 +265,5 @@ Checks: >
     readability-uniqueptr-delete-release,
     readability-use-anyofallof,
     zircon-temporary-objects
+
+#ExcludeHeaderFilter: config.h

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ There are two different ways of building libpqxx from the command line:
 HP-UX, Irix, Solaris, etc.  Even on Microsoft Windows, a Unix-like environment
 such as WSL, Cygwin, or MinGW should work.
 
-You'll find detailed build and install instructions in [`BUILDING-configure.md`](./BUILDING-configure.md)
-and [`BUILDING-cmake.md`](./BUILDING-cmake.md), respectively.
+You'll find detailed build and install instructions in
+[`BUILDING-configure.md`](./BUILDING-configure.md) and
+[`BUILDING-cmake.md`](./BUILDING-cmake.md), respectively.
 
 And if you're working with Microsoft Visual Studio, have a look at Gordon
 Elliott's


### PR DESCRIPTION
I guess there was a software update somewhere.  Suddenly clang-tidy started scouring this file for lint — and it found something that's not under my control.