### PR TITLE
Fix string conversion budget for arrays with unquoted-safe elements

### DIFF
--- a/include/pqxx/internal/conversions.hxx
+++ b/include/pqxx/internal/conversions.hxx
@@ -912,15 +912,10 @@ template<typename T> struct nonbinary_range_traits
       return 3 + std::accumulate(
                    std::begin(value), std::end(value), std::size_t{},
                    [](std::size_t acc, elt_type const &elt) {
-                     // Budget for each element includes a terminating zero.
-                     // We won't actually be wanting those, but don't subtract
-                     // that one byte: we want room for a separator instead.
-                     // However, std::size(s_null) doesn't account for the
-                     // terminating zero, so add one to make s_null pay for its
-                     // own separator.
+                     // Add one extra byte for the separator
                      return acc + (pqxx::is_null(elt) ?
-                                     (std::size(s_null) + 1) :
-                                     elt_traits::size_buffer(elt));
+                                     std::size(s_null) :
+                                     elt_traits::size_buffer(elt)) + 1;
                    });
     else
       return 3 + std::accumulate(

--- a/test/test_array.cxx
+++ b/test/test_array.cxx
@@ -333,6 +333,23 @@ void test_generate_multiple_items(pqxx::test::context &)
   PQXX_CHECK_EQUAL(
     pqxx::to_string(std::vector<std::string>{"foo", "bar"}, make_context()),
     "{\"foo\",\"bar\"}");
+
+  // Reproduce #1235: Under-budgeted conversion of unquoted-safe elements in arrays
+  PQXX_CHECK_GREATER_EQUAL(
+    pqxx::size_buffer(std::vector<unsigned int>{1073741823, 1789569706, 2505397589}), 34U,
+    "Buffer size allocated for an array of 3 unsigned int was too small.");
+
+  PQXX_CHECK_GREATER_EQUAL(
+    pqxx::size_buffer(std::vector<unsigned int>{1073741823, 1789569706, 2505397589, 3221225472}), 45U,
+    "Buffer size allocated for an array of 4 unsigned int was too small.");
+
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string(std::vector<unsigned int>{1073741823, 1789569706, 2505397589}, make_context()),
+    "{1073741823,1789569706,2505397589}");
+
+  PQXX_CHECK_EQUAL(
+    pqxx::to_string(std::vector<unsigned int>{1073741823, 1789569706, 2505397589, 3221225472}, make_context()),
+    "{1073741823,1789569706,2505397589,3221225472}");
 }
 
 


### PR DESCRIPTION
Fix string conversion budget for arrays with unquoted-safe elements + add regression tests

Fixes: #1235.