### PR TITLE
Fix type check for pqxx::conversion_context

### DIFF
--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -83,7 +83,7 @@ public:
   params(First &&first, Args &&...args)
   {
     sl loc;
-    if constexpr (std::is_same_v<std::remove_cvref<First>, conversion_context>)
+    if constexpr (std::is_same_v<std::remove_cvref_t<First>, conversion_context>)
       loc = first.loc;
     else
       loc = sl::current();


### PR DESCRIPTION
The type check for `pqxx::conversion_context` in the `pqxx::params` constructor is incorrect and currently always returns false. The source location passed in the conversion_context input argument is therefore always ignored and a new one is constructed instead.

The `std::remove_cvref<>` in the type comparison check is missing a `::type` or should have been `std::remove_cvref_t<>` instead. Currently the check compares the `std::remove_cvref` struct type itself instead of the intended result type.
