### PR TITLE
Fix silent conversion of empty BYTEA to NULL in params.cxx

### DIFF
--- a/src/params.cxx
+++ b/src/params.cxx
@@ -114,7 +114,7 @@ pqxx::internal::c_params pqxx::params::make_c_params(sl loc) const
         }
         else
         {
-          static constexpr char empty_value[] = "";
+          static constexpr char const * const empty_value = "";
           auto const data{std::empty(value) 
             ? empty_value
             : reinterpret_cast<char const *>(std::data(value))

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -114,7 +114,7 @@ pqxx::internal::c_params pqxx::params::make_c_params(sl loc) const
         }
         else
         {
-          static constexpr char empty_value[]{};
+          static constexpr char empty_value[] = "";
           auto const data{std::empty(value) 
             ? empty_value
             : reinterpret_cast<char const *>(std::data(value))

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -114,7 +114,13 @@ pqxx::internal::c_params pqxx::params::make_c_params(sl loc) const
         }
         else
         {
-          p.values.push_back(reinterpret_cast<char const *>(std::data(value)));
+          static constexpr char empty_value[]{};
+          auto const data{std::empty(value) 
+            ? empty_value
+            : reinterpret_cast<char const *>(std::data(value))
+          };
+        
+          p.values.push_back(data);
           p.lengths.push_back(
             check_cast<int>(std::ssize(value), s_overflow, loc));
         }

--- a/test/test_params.cxx
+++ b/test/test_params.cxx
@@ -19,11 +19,15 @@ void test_statement_params(pqxx::test::context &)
   p.append();
   p.append("zview"_zv);
   q.append(bin);
+  q.append(pqxx::bytes{});
   p.append(q);
-  auto const res{tx.exec("SELECT $1, $2, $3", p)};
+
+  auto const res{tx.exec("SELECT $1, $2, $3, $4", p)};
   PQXX_CHECK(res.at(0).at(0).is_null());
   PQXX_CHECK_EQUAL(res.at(0).at(1).view(), "zview");
   PQXX_CHECK_EQUAL(res.at(0).at(2).view(), "ab");
+  PQXX_CHECK(not res.at(0).at(3).is_null());
+  PQXX_CHECK_EQUAL(res.at(0).at(3).view(), "");
 }
 
 


### PR DESCRIPTION
Refactor empty value handling to use a static sentinel pointer.

Avoids passing an empty binary field (represented by `std::vector` or `std::span` over the vector) as a `nullptr` (which is treated as `NULL` by Postgres and breaks on `NOT NULL` columns).