### PR TITLE
Aftercare for #1242, #1243.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@
  - Fix `bool` conversion to string. (#1229)
  - Fix under-budgeting for arrays. (#1235)
  - Fix check for passing `conversion_context` to `params` constructor. (#1237)
+ - Binary data with null pointer is now an empty blob, not a null. (#1242)
 8.0.1
  - A lot more constructors are now `explicit`.
  - Update GNU attributes to use standard `[[attribute]]` syntax. (#1199)

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -114,12 +114,12 @@ pqxx::internal::c_params pqxx::params::make_c_params(sl loc) const
         }
         else
         {
-          static constexpr char const * const empty_value = "";
-          auto const data{std::empty(value) 
-            ? empty_value
-            : reinterpret_cast<char const *>(std::data(value))
-          };
-        
+          static constexpr char const *const empty_value = "";
+          auto const data{
+            std::empty(value) ?
+              empty_value :
+              reinterpret_cast<char const *>(std::data(value))};
+
           p.values.push_back(data);
           p.lengths.push_back(
             check_cast<int>(std::ssize(value), s_overflow, loc));


### PR DESCRIPTION
Adds a `NEWS` entry, and runs the formatter.