### PR TITLE
Transactor update for 8.x.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@
  - Fix under-budgeting for arrays. (#1235)
  - Fix check for passing `conversion_context` to `params` constructor. (#1237)
  - Binary data with null pointer is now an empty blob, not a null. (#1242)
+ - Redesign retry conditions for transactor `perform()`. (#1248)
 8.0.1
  - A lot more constructors are now `explicit`.
  - Update GNU attributes to use standard `[[attribute]]` syntax. (#1199)

--- a/include/pqxx/except.hxx
+++ b/include/pqxx/except.hxx
@@ -1,4 +1,4 @@
-/* Definition of libpqxx exception classes.
+/* Definition of libpqxx exception types.
  *
  * pqxx::sql_error, pqxx::broken_connection, pqxx::in_doubt_error, ...
  *
@@ -27,7 +27,7 @@
 namespace pqxx
 {
 /**
- * @addtogroup exception Exception classes
+ * @addtogroup exception Exception types
  *
  * All exception types thrown by libpqxx are derived from @ref pqxx::failure,
  * so that should be your starting point in exploring them.  When you write a
@@ -37,7 +37,7 @@ namespace pqxx
  * the exception is a libpqxx exception, you can get a lot of extra information
  * that's not normally available in exceptions.
  *
- * There is no multiple inheritance in this class hierarchy.  That means that
+ * There is no multiple inheritance in this type hierarchy.  That means that
  * the different kinds of libpqxx exception are not reflected in inheritance
  * from `std::logic_error,` `std::runtime_error`, and so on.  They are _all_
  * derived from @ref pqxx::failure (whether directly or indirectly), which in
@@ -58,7 +58,7 @@ namespace pqxx
  * So as of libpqxx 8, if you want more detail in how you handle different
  * types of exceptions, you use member functions, mostly at run time.  All of
  * the properties are available right from the top down, in the @ref failure
- * base class.  Some of the strings will not apply to all types of exception,
+ * base type.  Some of the strings will not apply to all types of exception,
  * but in those cases, they will simply be empty strings.
  *
  * In libpqxx, the exception hierarchy exists not for taxonomy's sake but to
@@ -66,12 +66,12 @@ namespace pqxx
  * effort from you.  In most cases, when an exception occurs, both the safest
  * and the easiest thing to do is drop the objects involved in the error,
  * report what happened, and move on from a reliable state.  That is what these
- * classes are here to support.
+ * types are here to support.
  *
  * @{
  */
 
-/// Base class for all exceptions specific to libpqxx.
+/// Base type for all exceptions specific to libpqxx.
 struct PQXX_LIBEXPORT failure : std::exception
 {
   failure(failure const &) = default;
@@ -292,7 +292,7 @@ private:
 };
 
 
-/// Exception class for lost or failed backend connection.
+/// Exception type for lost or failed backend connection.
 /**
  * @warning When this happens on Unix-like systems, you may also get a SIGPIPE
  * signal.  That signal aborts the program by default, so if you wish to be
@@ -366,11 +366,11 @@ struct PQXX_LIBEXPORT variable_set_to_null : failure
 };
 
 
-/// Exception class for failed queries.
+/// Exception type for failed queries.
 /** Carries, in addition to a regular error message, a copy of the failed query
  * and (if available) the SQLSTATE value accompanying the error.
  *
- * These exception classes follow, roughly, the two-level hierarchy defined by
+ * These exception types follow, roughly, the two-level hierarchy defined by
  * the PostgreSQL SQLSTATE error codes (see Appendix A of the PostgreSQL
  * documentation corresponding to your server version).  This is not a complete
  * mapping though.  There are other differences as well, e.g. the error code
@@ -403,7 +403,7 @@ struct PQXX_LIBEXPORT sql_error : public failure
 };
 
 
-/// Exception class for mis-communication with the server.
+/// Exception type for mis-communication with the server.
 /** This happens when the conversation between libpq and the server gets messed
  * up.  There aren't many situations where this happens, but one known instance
  * is when you call a parameterised or prepared statement with the wrong number
@@ -966,7 +966,7 @@ struct PQXX_LIBEXPORT too_many_connections : broken_connection
 
 
 /// PL/pgSQL error.
-/** Exceptions derived from this class are errors from PL/pgSQL procedures.
+/** Exceptions derived from this type are errors from PL/pgSQL procedures.
  */
 struct PQXX_LIBEXPORT plpgsql_error : sql_error
 {

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -143,7 +143,7 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
         throw;
     }
   }
-  PQXX_UNREACHABLE;
+  throw internal_error{"Reached unreachable transactor state."};
 }
 } // namespace pqxx
 //@}

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -36,10 +36,11 @@ namespace pqxx
  * simply want to "replay" the whole request, in a fresh transaction.
  *
  * You won't necessarily want to execute the exact same SQL commands with the
- * exact same data.  Some of your SQL statements may depend on state that can
- * vary between retries.  Data in the database may already have changed, for
- * instance.  So instead of dumbly replaying the SQL, you re-run the same
- * application code that produced those SQL commands, from the start.
+ * exact same data.  Some of your SQL statements may depend on state that may
+ * have changed by the time you replay the request.  For example, your code may
+ * query information from the database that can change between retries.  So
+ * instead of dumbly replaying the SQL, you re-run the same application code
+ * that produced those SQL commands, from the start.
  *
  * The transactor framework makes it a little easier for you to do this safely,
  * and avoid typical pitfalls.  You encapsulate the work that you want to do
@@ -50,49 +51,50 @@ namespace pqxx
  * commits at the end.  You pass that callback to @ref pqxx::perform, which
  * runs it for you.
  *
- * If there's a failure inside your callback, there will be an exception.  Your
- * transaction object goes out of scope and gets destroyed, so that it aborts
- * implicitly.  Seeing this, @ref perform tries running your callback again. It
- * stops doing that when the callback succeeds, or when it has failed too many
- * times, or when there's an error that leaves the database in an unknown
- * state, such as a lost connection just while we're waiting for the database
- * to confirm a commit.  It all depends on the type of exception.
+ * If there's a database-related failure inside your callback, libpqxx will
+ * throw an exception.  Your transaction object goes out of scope and gets
+ * destroyed, at which point it aborts implicitly.  Seeing this, @ref perform
+ * tries running your callback again.  It may have to repeat this a few times.
  *
- * The callback takes no arguments.  If you're using lambdas, the easy way to
- * pass arguments is for the lambda to "capture" them from your variables.
+ * It stops trying that when...
+ * * the callback succeeds; or
+ * * it has failed too many times; or
+ * * a non-libpqxx exception occurs; or
+ * * there's an error that leaves the database in an unknown state.
  *
- * Once your callback succeeds, it can return a result, and @ref perform will
- * return that result back to you.
+ * That last scenario can happen for example when you lose your network
+ * connection to the database _just_ while you're waiting for it to confirm the
+ * result of a commit.  In that situation, there's no way for the client to
+ * know whether the transaction succeeded from the server's perspective (and so
+ * was committed), or whether it failed and got aborted.  (If this possibility
+ * is a major concern to you, also have a look at the @ref robusttransaction
+ * class.  It does not help make your transaction more likely to succeed, but
+ * it tries harder to avoid these unknown states.
+ *
+ * The callback you pass to @ref perform takes no arguments.  If you're using
+ * lambdas, the easy way to pass arguments is for the lambda to "capture" them
+ * from your variables.
+ *
+ * Once your callback succeeds, it can return a result of your choosing, and
+ * @ref perform will return that result back to you.
+ *
+ * @warning Transactors can be helpful, but they do require some extra care.
+ * If your callback makes use of data from the database, you'll probably have
+ * to query that data within your callback.  If there's a failure, and the
+ * framework replays it, you'll be in a fresh transaction and the data in the
+ * database may have changed under your feet.
+ *
+ * @warning Also be careful about changing variables or data structures from
+ * within your callback.  The run may still fail, and perhaps get run again.
+ * The ideal way to do it (in most cases) is to return your result from your
+ * callback, and change your program's data state only after @ref perform
+ * completes successfully.
  */
 //@{
 
 /// Simple way to execute a transaction with automatic retry.
-/**
- * Executes your transaction code as a callback.  Repeats it until it completes
- * normally, or it throws an error other than the few libpqxx-generated
- * exceptions that the framework understands, or after a given number of failed
- * attempts, or if the transaction ends in an "in-doubt" state.
- *
- * (An in-doubt state is one where libpqxx cannot determine whether the server
- * finally committed a transaction or not.  This can happen if the network
- * connection to the server is lost just while we're waiting for its reply to
- * a "commit" statement.  The server may have completed the commit, or not, but
- * it can't tell you because there's no longer a connection.
- *
- * Using this still takes a bit of care.  If your callback makes use of data
- * from the database, you'll probably have to query that data within your
- * callback.  If the attempt to perform your callback fails, and the framework
- * tries again, you'll be in a new transaction and the data in the database may
- * have changed under your feet.
- *
- * Also be careful about changing variables or data structures from within
- * your callback.  The run may still fail, and perhaps get run again.  The
- * ideal way to do it (in most cases) is to return your result from your
- * callback, and change your program's data state only after @ref perform
- * completes successfully.
- *
- * @param callback Transaction code that can be called with no arguments.
- * @param attempts Maximum number of times to attempt performing callback.
+/** @param callback Transaction code that can be called with no arguments.
+ * @param attempts Maximum number of times to attempt performing @ref callback.
  *     Must be greater than zero.
  * @return Whatever your callback returns.
  */
@@ -123,55 +125,29 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
       // again.
       throw;
     }
-    catch (broken_connection const &)
+    catch (insufficient_resources const &)
     {
-      // Connection failed.  May be worth retrying, if the transactor opens its
-      // own connection.
-      if (attempts <= 1)
-        throw;
-      continue;
+      // Server is benig overloaded.  Back off.
+      throw;
     }
-    catch (transaction_rollback const &)
+    catch (too_many_connections const &)
     {
-      // Some error that may well be transient, such as serialization failure
-      // or deadlock.  Worth retrying.
+      // Server is benig overloaded.  Back off.
+      throw;
+    }
+    }
+    catch (failure const &)
+    {
+      // Some other database-related failure.
       if (attempts <= 1)
         throw;
-      continue;
     }
   }
-  throw pqxx::internal_error{"No outcome reached on perform().", loc};
 }
 
 
 /// Simple way to execute a transaction with automatic retry.
-/**
- * Executes your transaction code as a callback.  Repeats it until it completes
- * normally, or it throws an error other than the few libpqxx-generated
- * exceptions that the framework understands, or after a given number of failed
- * attempts, or if the transaction ends in an "in-doubt" state.
- *
- * (An in-doubt state is one where libpqxx cannot determine whether the server
- * finally committed a transaction or not.  This can happen if the network
- * connection to the server is lost just while we're waiting for its reply to
- * a "commit" statement.  The server may have completed the commit, or not, but
- * it can't tell you because there's no longer a connection.
- *
- * Using this still takes a bit of care.  If your callback makes use of data
- * from the database, you'll probably have to query that data within your
- * callback.  If the attempt to perform your callback fails, and the framework
- * tries again, you'll be in a new transaction and the data in the database may
- * have changed under your feet.
- *
- * Also be careful about changing variables or data structures from within
- * your callback.  The run may still fail, and perhaps get run again.  The
- * ideal way to do it (in most cases) is to return your result from your
- * callback, and change your program's data state only after @ref perform
- * completes successfully.
- *
- * @param callback Transaction code that can be called with no arguments.
- * @param attempts Maximum number of times to attempt performing callback.
- *     Must be greater than zero.
+/** @param callback Transaction code that can be called with no arguments.
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -99,8 +99,8 @@ namespace pqxx
  * @return Whatever your callback returns.
  */
 template<typename TRANSACTION_CALLBACK>
-inline std::invoke_result_t<TRANSACTION_CALLBACK>
-perform(TRANSACTION_CALLBACK &&callback, int attempts = 3, sl = sl::current())
+inline std::invoke_result_t<TRANSACTION_CALLBACK> perform(
+  TRANSACTION_CALLBACK &&callback, int attempts = 3, sl loc = sl::current())
 {
   if (attempts <= 0)
     throw std::invalid_argument{
@@ -142,7 +142,7 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts = 3, sl = sl::current())
         throw;
     }
   }
-  throw internal_error{"Reached unreachable transactor state."};
+  throw internal_error{"Reached unreachable transactor state.", loc};
 }
 
 

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -135,7 +135,6 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
       // Server is being overloaded.  Back off.
       throw;
     }
-    }
     catch (failure const &)
     {
       // Some other database-related failure.  Retry, unless we've run out of
@@ -144,6 +143,7 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
         throw;
     }
   }
+  PQXX_UNREACHABLE;
 }
 
 

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -100,8 +100,7 @@ namespace pqxx
  */
 template<typename TRANSACTION_CALLBACK>
 inline std::invoke_result_t<TRANSACTION_CALLBACK>
-perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
-
+perform(TRANSACTION_CALLBACK &&callback, int attempts = 3, sl = sl::current())
 {
   if (attempts <= 0)
     throw std::invalid_argument{
@@ -144,6 +143,15 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
     }
   }
   throw internal_error{"Reached unreachable transactor state."};
+}
+
+
+template<typename TRANSACTION_CALLBACK>
+[[deprecated("No soruce_location needed.")]] inline std::invoke_result_t<
+  TRANSACTION_CALLBACK>
+perform(TRANSACTION_CALLBACK &&callback, sl loc)
+{
+  return perform(std::forward(callback), 3, loc);
 }
 } // namespace pqxx
 //@}

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -127,18 +127,19 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
     }
     catch (insufficient_resources const &)
     {
-      // Server is benig overloaded.  Back off.
+      // Server is being overloaded.  Back off.
       throw;
     }
     catch (too_many_connections const &)
     {
-      // Server is benig overloaded.  Back off.
+      // Server is being overloaded.  Back off.
       throw;
     }
     }
     catch (failure const &)
     {
-      // Some other database-related failure.
+      // Some other database-related failure.  Retry, unless we've run out of
+      // attempts.
       if (attempts <= 1)
         throw;
     }

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -123,12 +123,6 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
       // again.
       throw;
     }
-    catch (protocol_violation const &)
-    {
-      // This is a subclass of broken_connection, but it's not one where
-      // retrying is likely to do us any good.
-      throw;
-    }
     catch (broken_connection const &)
     {
       // Connection failed.  May be worth retrying, if the transactor opens its

--- a/include/pqxx/transactor.hxx
+++ b/include/pqxx/transactor.hxx
@@ -69,7 +69,7 @@ namespace pqxx
  * was committed), or whether it failed and got aborted.  (If this possibility
  * is a major concern to you, also have a look at the @ref robusttransaction
  * class.  It does not help make your transaction more likely to succeed, but
- * it tries harder to avoid these unknown states.
+ * it tries harder to avoid these unknown states.)
  *
  * The callback you pass to @ref perform takes no arguments.  If you're using
  * lambdas, the easy way to pass arguments is for the lambda to "capture" them
@@ -100,7 +100,7 @@ namespace pqxx
  */
 template<typename TRANSACTION_CALLBACK>
 inline std::invoke_result_t<TRANSACTION_CALLBACK>
-perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
+perform(TRANSACTION_CALLBACK &&callback, int attempts = 3)
 
 {
   if (attempts <= 0)
@@ -144,18 +144,6 @@ perform(TRANSACTION_CALLBACK &&callback, int attempts, sl loc = sl::current())
     }
   }
   PQXX_UNREACHABLE;
-}
-
-
-/// Simple way to execute a transaction with automatic retry.
-/** @param callback Transaction code that can be called with no arguments.
- * @return Whatever your callback returns.
- */
-template<typename TRANSACTION_CALLBACK>
-inline std::invoke_result_t<TRANSACTION_CALLBACK>
-perform(TRANSACTION_CALLBACK &&callback, sl loc = sl::current())
-{
-  return perform(callback, 3, loc);
 }
 } // namespace pqxx
 //@}

--- a/test/test_transactor.cxx
+++ b/test/test_transactor.cxx
@@ -57,13 +57,12 @@ void test_transactor_newstyle_does_not_retry_insufficient(
   auto const &callback{[&counter] {
     ++counter;
     if (counter == 1)
-      throw pqxx::insufficent_resources{"Help, I'm overloaded!  Back off."};
+      throw pqxx::insufficient_resources{"Help, I'm overloaded!  Back off."};
     return counter;
   }};
 
-  int const result{pqxx::perform(callback)};
-  PQXX_CHECK_EQUAL(result, 2);
-  PQXX_CHECK_EQUAL(counter, result);
+  PQXX_CHECK_THROWS(pqxx::perform(callback), pqxx::insufficient_resources);
+  PQXX_CHECK_EQUAL(counter, 1);
 }
 
 
@@ -77,9 +76,8 @@ void test_transactor_newstyle_does_not_retry_too_many(pqxx::test::context &)
     return counter;
   }};
 
-  int const result{pqxx::perform(callback)};
-  PQXX_CHECK_EQUAL(result, 2);
-  PQXX_CHECK_EQUAL(counter, result);
+  PQXX_CHECK_THROWS(pqxx::perform(callback), pqxx::too_many_connections);
+  PQXX_CHECK_EQUAL(counter, 1);
 }
 
 
@@ -119,10 +117,11 @@ void test_transactor_newstyle_does_not_retry_statement_completion_unknown(
   int counter{0};
   auto const &callback{[&counter] {
     ++counter;
-    throw pqxx::statement_completion_unknown("Simulated error");
+    throw pqxx::statement_completion_unknown{"Simulated error", "COMMIT"};
   }};
 
-  PQXX_CHECK_THROWS(pqxx::perform(callback), pqxx::in_doubt_error);
+  PQXX_CHECK_THROWS(
+    pqxx::perform(callback), pqxx::statement_completion_unknown);
   PQXX_CHECK_EQUAL(counter, 1, "Transactor retried after in_doubt_error.");
 }
 
@@ -162,11 +161,11 @@ void test_transactor(pqxx::test::context &tctx)
   test_transactor_newstyle_can_return_void(tctx);
   test_transactor_newstyle_completes_upon_success(tctx);
   test_transactor_newstyle_retries_broken_connection(tctx);
-  test_transactor_newstyle_does_not_retry_insufficient(ctx);
-  test_transactor_newstyle_does_not_retry_too_many(ctx);
+  test_transactor_newstyle_does_not_retry_insufficient(tctx);
+  test_transactor_newstyle_does_not_retry_too_many(tctx);
   test_transactor_newstyle_retries_rollback(tctx);
   test_transactor_newstyle_does_not_retry_in_doubt_error(tctx);
-  test_transactor_newstyle_does_not_retry_statement_completion_unknown(ctx);
+  test_transactor_newstyle_does_not_retry_statement_completion_unknown(tctx);
   test_transactor_newstyle_does_not_retry_other_error(tctx);
   test_transactor_newstyle_repeats_up_to_given_number_of_attempts(tctx);
 }

--- a/test/test_transactor.cxx
+++ b/test/test_transactor.cxx
@@ -50,6 +50,39 @@ void test_transactor_newstyle_retries_broken_connection(pqxx::test::context &)
 }
 
 
+void test_transactor_newstyle_does_not_retry_insufficient(
+  pqxx::test::context &)
+{
+  int counter{0};
+  auto const &callback{[&counter] {
+    ++counter;
+    if (counter == 1)
+      throw pqxx::insufficent_resources{"Help, I'm overloaded!  Back off."};
+    return counter;
+  }};
+
+  int const result{pqxx::perform(callback)};
+  PQXX_CHECK_EQUAL(result, 2);
+  PQXX_CHECK_EQUAL(counter, result);
+}
+
+
+void test_transactor_newstyle_does_not_retry_too_many(pqxx::test::context &)
+{
+  int counter{0};
+  auto const &callback{[&counter] {
+    ++counter;
+    if (counter == 1)
+      throw pqxx::too_many_connections{"Help, I'm overloaded!  Back off."};
+    return counter;
+  }};
+
+  int const result{pqxx::perform(callback)};
+  PQXX_CHECK_EQUAL(result, 2);
+  PQXX_CHECK_EQUAL(counter, result);
+}
+
+
 void test_transactor_newstyle_retries_rollback(pqxx::test::context &)
 {
   int counter{0};
@@ -73,6 +106,20 @@ void test_transactor_newstyle_does_not_retry_in_doubt_error(
   auto const &callback{[&counter] {
     ++counter;
     throw pqxx::in_doubt_error("Simulated error");
+  }};
+
+  PQXX_CHECK_THROWS(pqxx::perform(callback), pqxx::in_doubt_error);
+  PQXX_CHECK_EQUAL(counter, 1, "Transactor retried after in_doubt_error.");
+}
+
+
+void test_transactor_newstyle_does_not_retry_statement_completion_unknown(
+  pqxx::test::context &)
+{
+  int counter{0};
+  auto const &callback{[&counter] {
+    ++counter;
+    throw pqxx::statement_completion_unknown("Simulated error");
   }};
 
   PQXX_CHECK_THROWS(pqxx::perform(callback), pqxx::in_doubt_error);
@@ -115,8 +162,11 @@ void test_transactor(pqxx::test::context &tctx)
   test_transactor_newstyle_can_return_void(tctx);
   test_transactor_newstyle_completes_upon_success(tctx);
   test_transactor_newstyle_retries_broken_connection(tctx);
+  test_transactor_newstyle_does_not_retry_insufficient(ctx);
+  test_transactor_newstyle_does_not_retry_too_many(ctx);
   test_transactor_newstyle_retries_rollback(tctx);
   test_transactor_newstyle_does_not_retry_in_doubt_error(tctx);
+  test_transactor_newstyle_does_not_retry_statement_completion_unknown(ctx);
   test_transactor_newstyle_does_not_retry_other_error(tctx);
   test_transactor_newstyle_repeats_up_to_given_number_of_attempts(tctx);
 }


### PR DESCRIPTION
See discussion in #1241.

Reconsiders the retry conditions for `perform()`.  There are now 4 categories of exception, as far as this function is concerned:
1. Non-libpqxx exceptions — rethrow.
2. Errors that leave the database in an unknown state — rethrow.
3. Server load complaints — rethrow so that we don't exacerbate the problem with retries.
4. Other exceptions — retry (until we run out of attempts).

(Also, rewording documentation.  It says "class" rather a lot, but the exception types are _structs_now.)