### PR TITLE
Transparent std::optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ win32/common
 **/lint.trs
 build/
 .vscode/
+.clangd

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ win32/common
 **/*~
 **/lint.log
 **/lint.trs
+build/
+.vscode/

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -188,6 +188,7 @@ public:
     }
     else
     {
+      if constexpr (optional_type<TYPE>) return append(*value, loc); 
       // TODO: Block-allocate storage for parameters.
       m_params.emplace_back(to_string(value, conversion_context{m_enc, loc}));
     }

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -148,8 +148,11 @@ class PQXX_LIBEXPORT params final
     /// Extract a value from variant
     template<variant_type T> [[nodiscard]] entry extract(T &&value) const
     {
+      // some compilers complain about 'this' not being used
       return std::visit(
-        [this](auto &&v) { return extract(std::forward<decltype(v)>(v)); },
+        [this](auto &&v) {
+          return this->extract(std::forward<decltype(v)>(v));
+        },
         std::forward<T>(value));
     }
 

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -142,7 +142,9 @@ class PQXX_LIBEXPORT params final
 
   private:
     /// Extract a value from ptr-like type (e.g. unique_ptr or optional)
-    template<dereferenceable_type T> [[nodiscard]] entry extract(T &&value) const
+    template<dereferenceable_type T>
+    [[nodiscard]] entry extract(T &&value) const
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access) checked with is_null
     { return extract(*std::forward<T>(value)); }
 
     /// Extract a value from variant

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -97,7 +97,7 @@ class PQXX_LIBEXPORT params final
      * remains active.
      */
     [[nodiscard]] entry convert(bytes_view value) const
-    { return m_copy ? entry{bytes{std::from_range, value}} : entry{value}; }
+    { return m_copy ? entry{bytes{value.begin(), value.end()}} : entry{value}; }
 
 
     /// Make a non-null binary parameter.

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -63,6 +63,109 @@ namespace pqxx
  */
 class PQXX_LIBEXPORT params final
 {
+  // The way we store a parameter depends on whether it's binary or text
+  // (most types are text), and whether we're responsible for storing the
+  // contents.
+  using entry =
+    std::variant<std::nullptr_t, zview, std::string, bytes_view, bytes>;
+
+  class converter
+  {
+  public:
+    explicit converter(sl loc, encoding_group enc) : m_loc{loc}, m_enc{enc} {}
+
+    /// Make a null parameter.
+    [[nodiscard]] entry convert() const { return {nullptr}; }
+
+    /// Make a non-null zview parameter.
+    /** The underlying data must stay valid for as long as the `params`
+     * remains active.
+     */
+    [[nodiscard]] entry convert(zview value) const { return {value}; }
+
+    /// Make a non-null string parameter.
+    /** Copies the underlying data into internal storage.  For best efficiency,
+     * use the @ref zview variant if you can, or `std::move()`
+     */
+    [[nodiscard]] entry convert(std::string const &value) const { return {value}; }
+
+    /// Make a non-null string parameter.
+    [[nodiscard]] entry convert(std::string &&value) const { return {std::move(value)}; }
+    
+    /// Make a non-null binary parameter.
+    /** The underlying data must stay valid for as long as the `params`
+     * remains active.
+     */
+    [[nodiscard]] entry convert(bytes_view value) const
+    { return m_copy ? entry{bytes{std::from_range, value}} : entry{value}; }
+
+
+    /// Make a non-null binary parameter.
+    /** The `data` object must stay in place and unchanged, for as long as the
+     * `params` remains active.
+     */
+    template<binary DATA> [[nodiscard]] entry convert(DATA const &data) const
+    { return convert(binary_cast(data)); }
+
+    /// Make a non-null binary parameter.
+    [[nodiscard]] entry convert(bytes &&value) const { return {std::move(value)}; }
+
+    /// Make value from a single-value container
+    /** @note finale value here is always copied or moved
+     */
+    template<typename T>
+      requires dereferenceable_type<T> || variant_type<T>
+    [[nodiscard]] entry convert(T &&value)
+    {
+      if (is_null(value))
+        return convert();
+
+      // we have to copy bytes_view if it was passed in temporary wrapper
+      m_copy = std::is_rvalue_reference_v<T &&>;
+      return extract(std::forward<T>(value));
+    }
+
+    /// Make a generic parameter
+    template<typename TYPE>
+    [[nodiscard]] entry convert([[maybe_unused]] TYPE const &value) const
+    {
+      // TODO: Pool storage for multiple string conversions in one buffer?
+      if constexpr (pqxx::always_null<TYPE>())
+        return convert();
+
+      if (is_null(value))
+        return convert();
+
+      // TODO: Block-allocate storage for parameters.
+      return convert(to_string(value, conversion_context{m_enc, m_loc}));
+    }
+
+  private:
+    /// Extract a value from ptr-like type (e.g. unique_ptr or optional)
+    template<dereferenceable_type T> [[nodiscard]] entry extract(T &&value) const
+    { return extract(*std::forward<T>(value)); }
+
+    /// Extract a value from variant
+    template<variant_type T> [[nodiscard]] entry extract(T &&value) const
+    {
+      return std::visit(
+        [this](auto &&v) { return extract(std::forward<decltype(v)>(v)); },
+        std::forward<T>(value));
+    }
+
+    /// Convert extracted value to entry
+    template<class T> [[nodiscard]] entry extract(T &&value) const
+    { return convert(std::forward<T>(value)); }
+
+    sl m_loc;
+    encoding_group m_enc{encoding_group::unknown};
+
+    /// copy final result if it is a bytes_view
+    /** this allows to extend lifetime of an argument
+     */
+    bool m_copy{false};
+  };
+
 public:
   params() = default;
 
@@ -78,6 +181,8 @@ public:
    * where a complex object can't be passed otherwise.  To keep things clear,
    * we recommend passing it in the general case so that you never run into
    * exceptions about encoding being unknown.
+   * 
+   * NB: Be carefull with binary args lifetime - params often store only view of them
    */
   template<typename First, typename... Args>
   params(First &&first, Args &&...args)
@@ -133,66 +238,27 @@ public:
   /// Append a null value.
   void append(sl = sl::current()) &;
 
-  /// Append a non-null zview parameter.
-  /** The underlying data must stay valid for as long as the `params`
-   * remains active.
+  /// see converter::convert for references
+  /** @note t lifetime depends on type
+   * * string like and convertible to string - lifetime extended
+   * * byte_views like - lifetime should be longer than of params
+   * * anything wrapped in ptr, optional or variant:
+   *   * if passed by value - lifetime extended
+   *   * if passed by reference - lifetime should be longer than of params
+   *
+   * Nice ways to shoot yourself in the foot:
+   * * pqxx::params make_params(std::optional<bytes> value) { return {value}; }
    */
-  void append(zview, sl = sl::current()) &;
-
-  /// Append a non-null string parameter.
-  /** Copies the underlying data into internal storage.  For best efficiency,
-   * use the @ref zview variant if you can, or `std::move()`
-   */
-  void append(std::string const &, sl = sl::current()) &;
-
-  /// Append a non-null string parameter.
-  void append(std::string &&, sl = sl::current()) &;
-
-  /// Append a non-null binary parameter.
-  /** The underlying data must stay valid for as long as the `params`
-   * remains active.
-   */
-  void append(bytes_view, sl = sl::current()) &;
-
-  /// Append a non-null binary parameter.
-  /** The `data` object must stay in place and unchanged, for as long as the
-   * `params` remains active.
-   */
-  template<binary DATA> void append(DATA const &data, sl loc = sl::current()) &
-  {
-    append(binary_cast(data), loc);
-  }
-
-  /// Append a non-null binary parameter.
-  void append(bytes &&, sl = sl::current()) &;
+  template<typename T>
+    requires (!std::is_same_v<std::remove_cvref_t<T>, params>)
+  void append(T &&t, sl loc = sl::current()) &
+  { m_params.emplace_back(converter{loc, m_enc}.convert(std::forward<T>(t))); }
 
   /// Append all parameters in `value`.
   void append(params const &value, sl = sl::current()) &;
 
   /// Append all parameters in `value`.
   void append(params &&value, sl = sl::current()) &;
-
-  /// Append a non-null parameter, converting it to its string
-  /// representation.
-  template<typename TYPE>
-  void append([[maybe_unused]] TYPE const &value, sl loc = sl::current()) &
-  {
-    // TODO: Pool storage for multiple string conversions in one buffer?
-    if constexpr (pqxx::always_null<TYPE>())
-    {
-      m_params.emplace_back();
-    }
-    else if (is_null(value))
-    {
-      m_params.emplace_back();
-    }
-    else
-    {
-      if constexpr (optional_type<TYPE>) return append(*value, loc); 
-      // TODO: Block-allocate storage for parameters.
-      m_params.emplace_back(to_string(value, conversion_context{m_enc, loc}));
-    }
-  }
 
   /// Append all elements of `range` as parameters.
   template<std::ranges::range RANGE>
@@ -228,11 +294,7 @@ private:
    */
   void append_pack(sl) const noexcept {}
 
-  // The way we store a parameter depends on whether it's binary or text
-  // (most types are text), and whether we're responsible for storing the
-  // contents.
-  using entry =
-    std::variant<std::nullptr_t, zview, std::string, bytes_view, bytes>;
+
   std::vector<entry> m_params;
 
   encoding_group m_enc{encoding_group::unknown};

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <memory>
 #include <ranges>
 #include <source_location>
 #include <string>
@@ -212,15 +213,6 @@ concept not_borrowed =
 template<typename E>
 concept enum_type = std::is_enum_v<E>;
 
-namespace detail {
-template<typename E> inline constexpr bool is_optional_v = false;
-template<typename E> inline constexpr bool is_optional_v<::std::optional<E>> = true;
-}
-
-/// Concept: A C++ `std::optional` type.
-template<typename E>
-concept optional_type = detail::is_optional_v<E>;
-
 /// Marker for @ref stream_from constructors: "stream from table."
 /** @deprecated Use @ref stream_from::table() instead.
  */
@@ -232,6 +224,51 @@ struct from_table_t final
  */
 struct from_query_t final
 {};
+} // namespace pqxx
+
+namespace pqxx::detail
+{
+template<typename E> inline constexpr bool is_optional_v = false;
+template<typename E>
+inline constexpr bool is_optional_v<::std::optional<E>> = true;
+
+template<typename E> inline constexpr bool is_unique_ptr_v = false;
+template<typename Tp, typename Dp = std::default_delete<Tp>>
+inline constexpr bool is_unique_ptr_v<::std::unique_ptr<Tp, Dp>> = true;
+
+template<typename E> inline constexpr bool is_shared_ptr_v = false;
+template<typename E>
+inline constexpr bool is_shared_ptr_v<::std::shared_ptr<E>> = true;
+
+template<typename E> inline constexpr bool is_variant_v = false;
+template<typename... E>
+inline constexpr bool is_variant_v<::std::variant<E...>> = true;
+
+template<typename E>
+using remove_cr = std::remove_const_t<std::remove_reference_t<E>>;
+} // namespace pqxx::detail
+
+namespace pqxx
+{
+/// extract value from user container
+/**  specify this value as:
+ * inline constexpr bool user_container_v<user_type> = true;
+ * user_type has to have operator*()
+ */
+template<typename E>
+inline constexpr bool user_container_v = false;
+
+/// Concept: A C++ type that can be dereferenced
+template<typename E>
+concept dereferenceable_type =
+  requires(E e) { *e; } &&
+  (detail::is_optional_v<detail::remove_cr<E>> || detail::is_unique_ptr_v<detail::remove_cr<E>> ||
+   detail::is_shared_ptr_v<detail::remove_cr<E>> || user_container_v<detail::remove_cr<E>>);
+
+/// Concept: A C++ `std::variant` type.
+template<typename E>
+concept variant_type = detail::is_variant_v<detail::remove_cr<E>>;
+
 } // namespace pqxx
 
 

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -23,6 +23,7 @@
 #include <string_view>
 #include <type_traits>
 #include <typeinfo>
+#include <variant>
 
 #if defined(PQXX_HAVE_STACKTRACE)
 #  include <stacktrace>
@@ -233,7 +234,10 @@ template<typename E>
 inline constexpr bool is_optional_v<::std::optional<E>> = true;
 
 template<typename E> inline constexpr bool is_unique_ptr_v = false;
-template<typename Tp, typename Dp = std::default_delete<Tp>>
+// some compilers don't allow default arguments in specialization
+template<typename Tp>
+inline constexpr bool is_unique_ptr_v<::std::unique_ptr<Tp>> = true;
+template<typename Tp, typename Dp>
 inline constexpr bool is_unique_ptr_v<::std::unique_ptr<Tp, Dp>> = true;
 
 template<typename E> inline constexpr bool is_shared_ptr_v = false;
@@ -255,15 +259,15 @@ namespace pqxx
  * inline constexpr bool user_container_v<user_type> = true;
  * user_type has to have operator*()
  */
-template<typename E>
-inline constexpr bool user_container_v = false;
+template<typename E> inline constexpr bool user_container_v = false;
 
 /// Concept: A C++ type that can be dereferenced
 template<typename E>
 concept dereferenceable_type =
-  requires(E e) { *e; } &&
-  (detail::is_optional_v<detail::remove_cr<E>> || detail::is_unique_ptr_v<detail::remove_cr<E>> ||
-   detail::is_shared_ptr_v<detail::remove_cr<E>> || user_container_v<detail::remove_cr<E>>);
+  requires(E e) { *e; } && (detail::is_optional_v<detail::remove_cr<E>> ||
+                            detail::is_unique_ptr_v<detail::remove_cr<E>> ||
+                            detail::is_shared_ptr_v<detail::remove_cr<E>> ||
+                            user_container_v<detail::remove_cr<E>>);
 
 /// Concept: A C++ `std::variant` type.
 template<typename E>

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -212,6 +212,14 @@ concept not_borrowed =
 template<typename E>
 concept enum_type = std::is_enum_v<E>;
 
+namespace detail {
+template<typename E> inline constexpr bool is_optional_v = false;
+template<typename E> inline constexpr bool is_optional_v<::std::optional<E>> = true;
+}
+
+/// Concept: A C++ `std::optional` type.
+template<typename E>
+concept optional_type = detail::is_optional_v<E>;
 
 /// Marker for @ref stream_from constructors: "stream from table."
 /** @deprecated Use @ref stream_from::table() instead.

--- a/include/pqxx/types.hxx
+++ b/include/pqxx/types.hxx
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <source_location>
 #include <string>

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -275,7 +275,9 @@ template<potential_binary TYPE> inline bytes_view binary_cast(TYPE const &data)
 template<char_sized CHAR, typename SIZE>
 bytes_view binary_cast(CHAR const *data, SIZE size)
 {
-  return binary_cast(std::span<CHAR>{data, check_cast<std::size_t>(size)});
+  return binary_cast(
+    std::span<CHAR const>{
+      data, check_cast<std::size_t>(size, "binary range size"sv)});
 }
 
 

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -38,7 +38,6 @@ void pqxx::internal::c_params::reserve(std::size_t n) &
   formats.reserve(n);
 }
 
-
 void pqxx::params::reserve(std::size_t n) &
 {
   m_params.reserve(n);
@@ -50,43 +49,11 @@ void pqxx::params::append(sl) &
   m_params.emplace_back(nullptr);
 }
 
-
-void pqxx::params::append(zview value, sl) &
-{
-  m_params.emplace_back(value);
-}
-
-
-void pqxx::params::append(std::string const &value, sl) &
-{
-  m_params.emplace_back(value);
-}
-
-
-void pqxx::params::append(std::string &&value, sl) &
-{
-  m_params.emplace_back(std::move(value));
-}
-
-
 void pqxx::params::append(params const &value, sl) &
 {
   this->reserve(std::size(value.m_params) + std::size(this->m_params));
   for (auto const &param : value.m_params) m_params.emplace_back(param);
 }
-
-
-void pqxx::params::append(bytes_view value, sl) &
-{
-  m_params.emplace_back(value);
-}
-
-
-void pqxx::params::append(bytes &&value, sl) &
-{
-  m_params.emplace_back(std::move(value));
-}
-
 
 void pqxx::params::append(params &&value, sl) &
 {

--- a/test/test_params.cxx
+++ b/test/test_params.cxx
@@ -2,7 +2,6 @@
 
 #include "helpers.hxx"
 
-
 namespace
 {
 using pqxx::operator""_zv;
@@ -13,31 +12,90 @@ void test_statement_params(pqxx::test::context &)
   pqxx::connection cx;
   pqxx::work tx{cx};
 
-  std::array<std::byte, 2> const bin{std::byte{'a'}, std::byte{'b'}};
+  using binary_data = std::array<std::byte, 2>;
+  binary_data const bin{std::byte{'a'}, std::byte{'b'}};
+  pqxx::bytes bin2{std::byte{'b'}, std::byte{'c'}};
+  pqxx::bytes_view bin3{bin2};
+
+  // test cases:
+  // 1. general append usage
+  // 2. append by value, view, reference - lifetime is different
+  // 3. append wrapped value(std:some_ptr, std::optional, std::variant) by
+  // value and reference
+  //
+  // Potential dangling references:
+  // append(std::optional<const bytes>{std::move(value)});
+  // append(std::make_unique<bytes>{value});
 
   pqxx::params p;
-  p.append();
-  p.append("zview"_zv);
+  p.append();           // 0
+  p.append("zview"_zv); // 1
 
   {
     pqxx::params q;
     q.append(bin);
-    p.append(q);
+    p.append(q); // 2
   }
 
-  p.append(pqxx::bytes{});
-  p.append(std::optional<pqxx::bytes>{});
-  p.append(std::optional{bin});
+  p.append(pqxx::bytes{});                // 3
+  p.append(std::optional<pqxx::bytes>{}); // 4
+  std::optional v1{bin3};
+  p.append(v1); // 5, object passed by reference, lifetime is managed by user
+
+  const std::optional<std::optional<pqxx::bytes_view>> v2{
+    std::in_place, std::in_place, bin3};
+  p.append(v2); // 6, same, lifetime is managed by user
+
+  auto v3 = std::make_unique<pqxx::bytes_view>(bin3);
+  p.append(v3); // 7, same, lifetime is managed by user
+  // 8, rvalue reference, lifetime is managed by params
+  p.append(std::move(v3));
+  // 9, by value, lifetime is managed by params
+  p.append(std::make_unique<pqxx::bytes_view>(bin3));
+
+  auto v4 = std::make_shared<pqxx::bytes_view>(bin3);
+  p.append(v4); // 10, same as 6
+
+  std::variant<pqxx::bytes_view, int> v5{bin3};
+  p.append(v5);                                      // 11, by reference
+  p.append(std::variant<pqxx::bytes_view, int>{42}); // 12, converted to string
   {
     const auto c_params = p.make_c_params({});
     constexpr auto binary = static_cast<int>(pqxx::format::binary);
     constexpr auto text = static_cast<int>(pqxx::format::text);
+
     PQXX_CHECK_EQUAL(c_params.formats[2], binary);
     PQXX_CHECK(c_params.values[4] == nullptr);
     PQXX_CHECK_EQUAL(c_params.formats[5], binary);
+    // pointer is the same, bytes are stored by view
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[5], 0uz).data() == bin2.data());
+    PQXX_CHECK_EQUAL(c_params.formats[6], binary);
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[6], 0uz).data() == bin2.data());
+    PQXX_CHECK_EQUAL(c_params.formats[7], binary);
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[7], 0uz).data() == bin2.data());
+    PQXX_CHECK_EQUAL(c_params.formats[8], binary);
+    // copy has been created
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[8], 0uz).data() != bin2.data());
+    PQXX_CHECK_EQUAL(c_params.formats[9], binary);
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[9], 0uz).data() != bin2.data());
+
+    PQXX_CHECK_EQUAL(c_params.formats[10], binary);
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[10], 0uz).data() == bin2.data());
+    PQXX_CHECK_EQUAL(c_params.formats[11], binary);
+    PQXX_CHECK(
+      pqxx::binary_cast(c_params.values[11], 0uz).data() == bin2.data());
+
+    PQXX_CHECK_EQUAL(c_params.formats[12], text);
   }
 
-  auto const res{tx.exec("SELECT $1, $2, $3, $4, $5, $6", p)};
+  auto const res{
+    tx.exec("SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13", p)};
   const auto &row = res.at(0);
   PQXX_CHECK(row.at(0).is_null());
   PQXX_CHECK_EQUAL(row.at(1).view(), "zview");
@@ -46,7 +104,14 @@ void test_statement_params(pqxx::test::context &)
   PQXX_CHECK_EQUAL(row.at(3).view(), "");
   PQXX_CHECK(row.at(4).is_null());
   PQXX_CHECK(not row.at(5).is_null());
-  PQXX_CHECK_EQUAL(row.at(5).view(), "ab");
+  PQXX_CHECK_EQUAL(row.at(5).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(6).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(7).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(8).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(9).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(10).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(11).view(), "bc");
+  PQXX_CHECK_EQUAL(row.at(12).view(), "42");
 }
 
 

--- a/test/test_params.cxx
+++ b/test/test_params.cxx
@@ -15,19 +15,38 @@ void test_statement_params(pqxx::test::context &)
 
   std::array<std::byte, 2> const bin{std::byte{'a'}, std::byte{'b'}};
 
-  pqxx::params p, q;
+  pqxx::params p;
   p.append();
   p.append("zview"_zv);
-  q.append(bin);
-  q.append(pqxx::bytes{});
-  p.append(q);
 
-  auto const res{tx.exec("SELECT $1, $2, $3, $4", p)};
-  PQXX_CHECK(res.at(0).at(0).is_null());
-  PQXX_CHECK_EQUAL(res.at(0).at(1).view(), "zview");
-  PQXX_CHECK_EQUAL(res.at(0).at(2).view(), "ab");
-  PQXX_CHECK(not res.at(0).at(3).is_null());
-  PQXX_CHECK_EQUAL(res.at(0).at(3).view(), "");
+  {
+    pqxx::params q;
+    q.append(bin);
+    p.append(q);
+  }
+
+  p.append(pqxx::bytes{});
+  p.append(std::optional<pqxx::bytes>{});
+  p.append(std::optional{bin});
+  {
+    const auto c_params = p.make_c_params({});
+    constexpr auto binary = static_cast<int>(pqxx::format::binary);
+    constexpr auto text = static_cast<int>(pqxx::format::text);
+    PQXX_CHECK_EQUAL(c_params.formats[2], binary);
+    PQXX_CHECK(c_params.values[4] == nullptr);
+    PQXX_CHECK_EQUAL(c_params.formats[5], binary);
+  }
+
+  auto const res{tx.exec("SELECT $1, $2, $3, $4, $5, $6", p)};
+  const auto &row = res.at(0);
+  PQXX_CHECK(row.at(0).is_null());
+  PQXX_CHECK_EQUAL(row.at(1).view(), "zview");
+  PQXX_CHECK_EQUAL(row.at(2).view(), "ab");
+  PQXX_CHECK(not row.at(3).is_null());
+  PQXX_CHECK_EQUAL(row.at(3).view(), "");
+  PQXX_CHECK(row.at(4).is_null());
+  PQXX_CHECK(not row.at(5).is_null());
+  PQXX_CHECK_EQUAL(row.at(5).view(), "ab");
 }
 
 

--- a/test/test_params.cxx
+++ b/test/test_params.cxx
@@ -63,33 +63,34 @@ void test_statement_params(pqxx::test::context &)
     const auto c_params = p.make_c_params({});
     constexpr auto binary = static_cast<int>(pqxx::format::binary);
     constexpr auto text = static_cast<int>(pqxx::format::text);
+    constexpr size_t size{0};
 
     PQXX_CHECK_EQUAL(c_params.formats[2], binary);
     PQXX_CHECK(c_params.values[4] == nullptr);
     PQXX_CHECK_EQUAL(c_params.formats[5], binary);
     // pointer is the same, bytes are stored by view
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[5], 0uz).data() == bin2.data());
+      pqxx::binary_cast(c_params.values[5], size).data() == bin2.data());
     PQXX_CHECK_EQUAL(c_params.formats[6], binary);
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[6], 0uz).data() == bin2.data());
+      pqxx::binary_cast(c_params.values[6], size).data() == bin2.data());
     PQXX_CHECK_EQUAL(c_params.formats[7], binary);
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[7], 0uz).data() == bin2.data());
+      pqxx::binary_cast(c_params.values[7], size).data() == bin2.data());
     PQXX_CHECK_EQUAL(c_params.formats[8], binary);
     // copy has been created
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[8], 0uz).data() != bin2.data());
+      pqxx::binary_cast(c_params.values[8], size).data() != bin2.data());
     PQXX_CHECK_EQUAL(c_params.formats[9], binary);
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[9], 0uz).data() != bin2.data());
+      pqxx::binary_cast(c_params.values[9], size).data() != bin2.data());
 
     PQXX_CHECK_EQUAL(c_params.formats[10], binary);
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[10], 0uz).data() == bin2.data());
+      pqxx::binary_cast(c_params.values[10], size).data() == bin2.data());
     PQXX_CHECK_EQUAL(c_params.formats[11], binary);
     PQXX_CHECK(
-      pqxx::binary_cast(c_params.values[11], 0uz).data() == bin2.data());
+      pqxx::binary_cast(c_params.values[11], size).data() == bin2.data());
 
     PQXX_CHECK_EQUAL(c_params.formats[12], text);
   }


### PR DESCRIPTION
1. recognize std::optional in params::append and append its value(improves std::optional<binary> handling)
2. copy values for containers passed by temporary value