### PR TITLE
Run codespell across the codebase.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = autom4te.cache,config,configure,configure~,libtool
+ignore-words-list = parm,parms,doub

--- a/BUILDING-configure.md
+++ b/BUILDING-configure.md
@@ -96,7 +96,7 @@ Here are some popular `configure` options:
 * `--with-postgres-include=$DIR` looks for the libpq headers in `$DIR`.
 * `--prefix=$PATH` prepares to install libpqxx in `$PATH`.
 * `--enable-shared` enables compilation of libpqxx as a shared library.
-* `--disable-shared` disbles compilation of libpqxx as a shared library.
+* `--disable-shared` disables compilation of libpqxx as a shared library.
 * `--enable-static` enables compilation of libpqxx as a static library.
 * `--disable-static` disables compilation of libpqxx as a static library.
 * `--help` shows you a lot more of the options.

--- a/NEWS
+++ b/NEWS
@@ -233,7 +233,7 @@
 7.7.1
  - When you build libpqxx, configure the compiler's C++ version yourself!
  - Finally fix a long-standing silly warning in autogen.
- - Fix `digit_to_number` not being found on some comilers.  (#518, #519)
+ - Fix `digit_to_number` not being found on some compilers.  (#518, #519)
  - In audit mode, define `_FORTIFY_SOURCE` to enable some extra checks.
  - Make more functions `constexpr`.  Nothing particularly useful though.
  - Make more functions `noexcept`.
@@ -354,7 +354,7 @@
  - Removed `transaction_base::classname()`.  Did anyone ever use it?
  - Internal reorg of the `transaction` and `transactionfocus` hierarchies.
  - Removed the only case of virtual inheritance, related to `namedclass`.
- - Internal `concat()` for faster, simpler string concatentation.
+ - Internal `concat()` for faster, simpler string concatenation.
  - Fix compile omission in string conversions for `nullptr_t`.
  - `pqxx::size_buffer()` can now size multiple values at once.
  - `multi_to_string()` to convert multiple values into one `std::string`.
@@ -542,7 +542,7 @@
  - Work around Visual Studio 2017 not supporting ISO 646.
 6.3.0
  - New "table stream" classes by Joseph Durel: stream_from/stream_to.
- - Support weird characters in more identifiers: cursors, notifcations, etc.
+ - Support weird characters in more identifiers: cursors, notifications, etc.
  - Connection policies are deprecated.  It'll all be one class in 7.0!
  - Connection deactivation/reactivation is deprecated.
  - Some items that were documented as deprecated are now also declared as such.

--- a/config-tests/README.md
+++ b/config-tests/README.md
@@ -8,7 +8,7 @@ We need to teach both of these to test things like "does this compiler
 environment support `std::to_chars` for floating-point types?"
 
 In both build systems we test these things by trying to compile a particular
-snippet of code, found in this directry, and seeing whether that succeeds.
+snippet of code, found in this directory, and seeing whether that succeeds.
 These are the snippets with names like `PQXX_*.cxx`.
 
 To avoid duplicating those snippets for multiple build systems, we put them

--- a/configure
+++ b/configure
@@ -21220,7 +21220,7 @@ fi
 
 
 
-# Remove redundant occurrances of -lpq
+# Remove redundant occurrences of -lpq
 LIBS=$(echo "$LIBS" | sed -e 's/-lpq * -lpq\>/-lpq/g')
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ${MAKE-make} sets \$(MAKE)" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -375,7 +375,7 @@ occurring in the file.
 	${with_postgres_libpath})
 
 
-# Remove redundant occurrances of -lpq
+# Remove redundant occurrences of -lpq
 LIBS=[$(echo "$LIBS" | sed -e 's/-lpq * -lpq\>/-lpq/g')]
 
 AC_PROG_MAKE_SET

--- a/cxx_features.txt
+++ b/cxx_features.txt
@@ -3,7 +3,7 @@
 # source files and headers.  This can avoid ABI inconsistencies when an
 # application uses a libpqxx that was compiled with a slightly different
 # compiler configuration, such as the same compiler but under a different
-# version ofthe C++ language.
+# version of the C++ language.
 #
 # Each (non-empty, non-comment) line consists of a libpqxx feature macro
 # and the corresponding C++ feature test macro that we need to check in

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 project = "libpqxx"
 copyright = "2000-2026, Jeroen T. Vermeulen"
 author = "Jeroen T. Vermeulen"

--- a/examples/faster_data.cxx
+++ b/examples/faster_data.cxx
@@ -69,6 +69,8 @@ int main()
         process_row(row.at(0).as<std::string_view>(), row.at(1).as<int>());
 
     // This produces the exact same results.
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(sum1b == sum1a);
 
     // If you prefer a declarative style with callbacks, you can also use the
@@ -86,6 +88,8 @@ int main()
     });
 
     // This again produces the same results.
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(sum1c == sum1a);
 
     // But all these are just the first way of querying data.  It reads all the
@@ -122,6 +126,8 @@ int main()
         sum2b += process_row(name, number);
       });
 
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(sum2b == sum2a);
   }
   catch (std::exception const &e)

--- a/examples/simple_queries.cxx
+++ b/examples/simple_queries.cxx
@@ -244,7 +244,7 @@ void query_customers(pqxx::connection &cx)
 
   // Or, if you prefer a callback-based style, for_query() takes a query and a
   // callback.  It executes the query, iterates over the result rows, calling
-  // your callback with the row's respective field values as argments.  It
+  // your callback with the row's respective field values as arguments.  It
   // detects the parameter types your callback expects, and converts the fields
   // to those respective types.
   std::cout << "That same data again:\n";

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -449,6 +449,8 @@ private:
           throw conversion_error{
             "Malformed array: found element where sub-array was expected.",
             loc};
+        // clang-tidy rule bug:
+        // NOLINTNEXTLINE(cert-dcl03-c)
         assert(dim != outer);
         ++extents.at(dim);
         std::size_t end{};
@@ -508,6 +510,8 @@ private:
 
     if (dim != outer)
       throw conversion_error{"Malformed array; may be truncated.", loc};
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(know_extents_from == 0);
     PQXX_ASSUME(know_extents_from == 0);
 
@@ -624,8 +628,11 @@ public:
   to_buf(std::span<char> buf, array_type const &value, ctx c = {})
   {
     auto const len{pqxx::internal::array_into_buf(buf, value, c)};
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
     assert(len > 0);
     assert(buf[len - 1] == '\0');
+    // NOLINTEND(cert-dcl03-c)
     return {std::data(buf), len - 1};
   }
 

--- a/include/pqxx/array.hxx
+++ b/include/pqxx/array.hxx
@@ -403,6 +403,8 @@ private:
               "Array text representation closed and reopened its outside "
               "brace pair.",
               loc};
+          // clang-tidy rule bug:
+          // NOLINTNEXTLINE(cert-dcl03-c)
           assert(here == 0);
           PQXX_ASSUME(here == 0);
         }

--- a/include/pqxx/blob.hxx
+++ b/include/pqxx/blob.hxx
@@ -87,7 +87,7 @@ public:
 
   /// Read up to `size` bytes of the object into `buf`.
   /** Uses a buffer that you provide, resizing it as needed.  If it suits you,
-   * this lets you allocate the buffer once and then re-use it multiple times.
+   * this lets you allocate the buffer once and then reuse it multiple times.
    *
    * Resizes `buf` as needed.
    *

--- a/include/pqxx/connection.hxx
+++ b/include/pqxx/connection.hxx
@@ -704,7 +704,7 @@ public:
    * processes them by checking for a matching notification handler, and if it
    * finds one, invoking it.  If there is no matching handler, nothing happens.
    *
-   * If your notifcation handler throws an exception, `get_notifs()` will just
+   * If your notification handler throws an exception, `get_notifs()` will just
    * propagate it back to you.  (This is different from the old
    * `notification_receiver` mechanism, which would merely log them.)
    *
@@ -731,7 +731,7 @@ public:
    * @ref get_notifs repeatedly until it returns zero.  This allows you to
    * handle other events besides notifications with a single wait point.
    *
-   * If your notifcation handler throws an exception, this function will just
+   * If your notification handler throws an exception, this function will just
    * propagate it on up to you.  (This is different from the old
    * `notification_receiver` mechanism, which would merely log them.)
    *
@@ -756,7 +756,7 @@ public:
    * @ref get_notifs repeatedly until it returns zero.  This allows you to
    * handle other events besides notifications with a single wait point.
    *
-   * If your notifcation handler throws an exception, this function will just
+   * If your notification handler throws an exception, this function will just
    * propagate it on up to you.  (This is different from the old
    * `notification_receiver` mechanism, which would merely log them.)
    *
@@ -981,7 +981,7 @@ public:
   }
 
   /// Escape string for use as SQL string literal, into `buffer`.
-  /** Use this variant when you want to re-use the same buffer across multiple
+  /** Use this variant when you want to reuse the same buffer across multiple
    * calls.  If that's not the case, or convenience and simplicity are more
    * important, use the single-argument variant.
    *
@@ -1022,7 +1022,7 @@ public:
   }
 
   /// Escape binary string for use as SQL string literal, into `buffer`.
-  /** Use this variant when you want to re-use the same buffer across multiple
+  /** Use this variant when you want to reuse the same buffer across multiple
    * calls.  If that's not the case, or convenience and simplicity are more
    * important, use the single-argument variant.
    *

--- a/include/pqxx/doc/datatypes.md
+++ b/include/pqxx/doc/datatypes.md
@@ -3,7 +3,7 @@ Supporting additional data types                              {#datatypes}
 
 Communication with the database mostly happens in a text format.  When you
 include an integer value in a query, either you use `to_string` to convert it
-to that text format, or you pass it as a paraemeter and libpqxx does it for you
+to that text format, or you pass it as a parameter and libpqxx does it for you
 under the bonnet.  When you get a query result field "as a float," libpqxx
 converts from the text format to a floating-point type.  These conversions are
 everywhere in libpqxx.
@@ -388,7 +388,7 @@ better to waste a few bytes of space than to spend a lot of time computing
 the exact buffer space you need.  And failing the conversion because you
 under-budgeted the buffer is worst of all.
 
-Make `size_buffer` a `constexpr` function if you can.  It may sometiems allow
+Make `size_buffer` a `constexpr` function if you can.  It may sometimes allow
 the caller to allocate the buffer on the stack, with a size known at compile
 time.
 
@@ -420,7 +420,7 @@ safe to leave this out; it's _just_ an optimisation for when you're completely
 sure that it's safe.
 
 Make sure this definition is visible wherever you call libpqxx code that may
-call your conversoin.
+call your conversion.
 
 Do not do this if a string representation of your type may contain a comma;
 semicolon; parenthesis; brace; quote; backslash; newline; or any other

--- a/include/pqxx/doc/parameters.md
+++ b/include/pqxx/doc/parameters.md
@@ -1,7 +1,7 @@
 Statement parameters                                        {#parameters}
 ====================
 
-In an SQL statement (including a prepared statemen), you may write special
+In an SQL statement (including a prepared statement), you may write special
 _placeholders_ in the query text.  They look like `$1`, `$2`, and so on.
 
 When executing the query later, you pass parameter values.  The call will

--- a/include/pqxx/doc/streams.md
+++ b/include/pqxx/doc/streams.md
@@ -142,7 +142,7 @@ columns (two integers and two strings), streaming even just a thousand rows was
 considerably faster than a regular query.
 
 If your network connection to the database is slow, however, that may make
-streaming a bit _less_ effcient.  There is a bit more communication back and
+streaming a bit _less_ efficient.  There is a bit more communication back and
 forth between the client and the database to set up a stream.  This overhead
 takes a more or less constant amount of time, so for larger data sets it will
 tend to become insignificant compared to the other performance costs.

--- a/include/pqxx/internal/array-composite.hxx
+++ b/include/pqxx/internal/array-composite.hxx
@@ -26,6 +26,8 @@ template<encoding_group ENC>
 PQXX_INLINE_COV inline constexpr std::size_t
 scan_double_quoted_string(std::string_view input, std::size_t pos, sl loc)
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(input[pos] == '"');
   auto const sz{std::size(input)};
 
@@ -107,8 +109,11 @@ parse_double_quoted_string(std::string_view input, std::size_t pos, sl loc)
 {
   std::string output;
   auto const end{std::size(input)};
+  // clang-tidy rule bug:
+  // NOLINTBEGIN(cert-dcl03-c)
   assert((end - pos) > 1);
   assert(input[end - 1] == '"');
+  // NOLINTEND(cert-dcl03-c)
 
   // Maximum output size is same as the input size, minus the opening and
   // closing quotes.  Or in the extreme opposite case, the real number could be
@@ -117,15 +122,23 @@ parse_double_quoted_string(std::string_view input, std::size_t pos, sl loc)
 
   auto const closing_quote{end - 1};
 
+  // clang-tidy rule bug:
+  // NOLINTBEGIN(cert-dcl03-c)
+
   // We're at the starting quote.  Skip it.
   assert(pos < closing_quote);
   assert(input[pos] == '"');
   pos += one_ascii_char;
+
   assert(pos <= closing_quote);
+
+  // NOLINTEND(cert-dcl03-c)
 
   // In theory, the closing quote should mean that there's no need for the
   // find_ascii_char() call to check for end-of-string inside its loop.  Not
   // sure whether the compiler will be smart enough to see that though.
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(input[closing_quote] == '"');
 
   while (pos < closing_quote)
@@ -133,8 +146,11 @@ parse_double_quoted_string(std::string_view input, std::size_t pos, sl loc)
     auto const next{find_ascii_char<ENC, '"', '\\'>(input, pos, loc)};
     output.append(input.substr(pos, next - pos));
     pos = next;
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
     assert(pos <= closing_quote);
     assert((input[pos] == '"') or (input[pos] == '\\'));
+    // NOLINTEND(cert-dcl03-c)
 
     if (pos >= closing_quote)
       return output;
@@ -145,6 +161,8 @@ parse_double_quoted_string(std::string_view input, std::size_t pos, sl loc)
 
     // We are now at the escaped character.
     // If the input has been scanned correctly, the string can't end here.
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(pos < closing_quote);
 
     if ((input[pos] == '"') or (input[pos] == '\\'))
@@ -160,6 +178,8 @@ parse_double_quoted_string(std::string_view input, std::size_t pos, sl loc)
       // next iteration handle it like any run-of-the-mill character.
     }
   }
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(pos == closing_quote);
 
   return output;
@@ -225,8 +245,11 @@ PQXX_INLINE_COV inline void parse_composite_field(
   std::size_t &index, std::string_view input, std::size_t &pos, T &field,
   std::size_t last_field, sl loc)
 {
+  // clang-tidy rule bug:
+  // NOLINTBEGIN(cert-dcl03-c)
   assert(index <= last_field);
   assert(pos < std::size(input));
+  // NOLINTEND(cert-dcl03-c)
   conversion_context const c{ENC, loc};
 
   // Expect a field.
@@ -387,6 +410,8 @@ PQXX_INLINE_ONLY inline void write_composite_field(
     // To avoid allocating that at run time, we use the end of the buffer that
     // we have.
     auto const budget{size_buffer(field)};
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(budget < std::size(buf));
     // C++26: Use buf.at().
     buf[pos++] = '"';
@@ -458,6 +483,8 @@ template<nonbinary_range TYPE>
       auto const elt_budget{pqxx::size_buffer(elt)};
       // Use the tail end of the destination buffer as an intermediate
       // buffer.
+      // clang-tidy rule bug:
+      // NOLINTNEXTLINE(cert-dcl03-c)
       assert(std::cmp_less(elt_budget, std::size(buf) - here));
       auto const from{pqxx::to_buf(buf.last(elt_budget), elt, c)};
       auto const end{std::size(from)};

--- a/include/pqxx/internal/encodings.hxx
+++ b/include/pqxx/internal/encodings.hxx
@@ -33,6 +33,8 @@ enc_group(int /* libpq encoding ID */, sl);
 PQXX_PURE PQXX_INLINE_ONLY PQXX_HOT constexpr inline unsigned char
 get_byte(std::string_view buffer, std::size_t offset) noexcept
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(offset < std::size(buffer));
   return static_cast<unsigned char>(buffer[offset]);
 }

--- a/include/pqxx/internal/sql_cursor.hxx
+++ b/include/pqxx/internal/sql_cursor.hxx
@@ -17,7 +17,7 @@ namespace pqxx::internal
 /** Thin wrapper around an SQL cursor, with SQL's ideas of positioning.
  *
  * SQL cursors have pre-increment/pre-decrement semantics, with on either end
- * of the result set a special position that does not repesent a row.  This
+ * of the result set a special position that does not represent a row.  This
  * class models SQL cursors for the purpose of implementing more C++-like
  * semantics on top.
  *

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -321,7 +321,7 @@ private:
 
   /// Current row's fields' text, combined into one reusable string.
   /** We carry this buffer over from one invocation to the next, not because we
-   * need the data, but just so we can re-use the space.  It saves us having to
+   * need the data, but just so we can reuse the space.  It saves us having to
    * re-allocate it every time.
    */
   std::string m_row;

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -133,6 +133,8 @@ public:
     // requested type.
     std::tuple<TYPE...> data{parse_field<TYPE>(line, offset, write, m_ctx)...};
 
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(offset == line_size + 1u);
     return data;
   }
@@ -170,21 +172,31 @@ private:
     auto const line_size{std::size(line)};
 #endif
 
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(offset <= line_size);
 
     char const *lp{std::data(line)};
 
     // The COPY line now ends in a tab.  (We replace the trailing newline with
     // that to simplify the loop here.)
+
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
     assert(lp[line_size] == '\t');
     assert(lp[line_size + 1] == '\0');
+    // NOLINTEND(cert-dcl03-c)
 
     if ((lp[offset] == '\\') and (lp[offset + 1] == 'N'))
     {
       // Null field.  Consume the "\N" and the field separator.
       offset += 3;
+      // clang-tidy rule bug:
+      // NOLINTBEGIN(cert-dcl03-c)
       assert(offset <= (line_size + 1));
       assert(lp[offset - 1] == '\t');
+      // NOLINTEND(cert-dcl03-c)
+
       // Return a null value.  There's nothing to write into m_row.
       return {offset, write, {}};
     }
@@ -201,6 +213,8 @@ private:
     // Effectively, the newline acts as a final field separator.
     while (lp[offset] != '\t')
     {
+      // clang-tidy rule bug:
+      // NOLINTNEXTLINE(cert-dcl03-c)
       assert(lp[offset] != '\0');
 
       // Beginning of the next character of interest (or the end of the line).
@@ -209,6 +223,8 @@ private:
       // previous character of interest.
       auto const stop_char{m_char_finder(line, offset, c.loc)};
       PQXX_ASSUME(stop_char >= offset);
+      // clang-tidy rule bug:
+      // NOLINTNEXTLINE(cert-dcl03-c)
       assert(stop_char < (line_size + 1));
 
       // Copy the text we have so far.  It's got no special characters in it.
@@ -223,6 +239,8 @@ private:
         // Escape sequence.
         // Consume the backslash.
         ++offset;
+        // clang-tidy rule bug:
+        // NOLINTNEXTLINE(cert-dcl03-c)
         assert(offset < line_size);
 
         // The database will only escape ASCII characters, so we assume that
@@ -232,6 +250,9 @@ private:
         // I think this is a valid way to check for the high bit: the shift
         // may be signed or unsigned (implementation-defined for char), but
         // either way we get a zero if the bit is clear or nonzero if it's set.
+
+        // clang-tidy rule bug:
+        // NOLINTNEXTLINE(cert-dcl03-c)
         assert((escaped >> 7) == 0);
         ++offset;
         *write++ = unescape_char(escaped);
@@ -239,11 +260,16 @@ private:
       else
       {
         // Field separator.  Fall out of the loop.
+        // clang-tidy rule bug:
+        // NOLINTNEXTLINE(cert-dcl03-c)
         assert(special == '\t');
       }
     }
 
     // Hit the end of the field.
+
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(lp[offset] == '\t');
     *write = '\0';
     ++write;
@@ -274,6 +300,8 @@ private:
   {
     using field_type = std::remove_cvref_t<TARGET>;
 
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(offset <= std::size(line));
 
     auto [new_offset, new_write, text]{read_field(line, offset, write, c)};

--- a/include/pqxx/internal/stream_query.hxx
+++ b/include/pqxx/internal/stream_query.hxx
@@ -109,6 +109,8 @@ public:
   /// Parse and convert the latest line of data we received.
   std::tuple<TYPE...> parse_line(std::string_view line) &
   {
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(not done());
 
     auto const line_size{std::size(line)};

--- a/include/pqxx/internal/stream_query_impl.hxx
+++ b/include/pqxx/internal/stream_query_impl.hxx
@@ -71,6 +71,8 @@ public:
    */
   stream_query_iterator &operator++() &
   {
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(not done());
     consume_line(m_created_loc);
     return *this;
@@ -122,6 +124,8 @@ private:
       // with the field separator, so the parsing loop only needs to scan for a
       // tab, not a tab or a newline.
       char *const ptr{m_line.get()};
+      // clang-tidy rule bug:
+      // NOLINTNEXTLINE(cert-dcl03-c)
       assert(ptr[size] == '\n');
       ptr[size] = '\t';
     }
@@ -150,6 +154,8 @@ template<typename... TYPE>
 inline std::pair<typename stream_query<TYPE...>::line_handle, std::size_t>
 stream_query<TYPE...>::read_line(sl loc) &
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(not done());
 
   internal::gate::connection_stream_from gate{trans().conn()};

--- a/include/pqxx/params.hxx
+++ b/include/pqxx/params.hxx
@@ -306,6 +306,8 @@ public:
       auto const written{pqxx::into_buf<COUNTER>(
         {data + 1, data + std::size(m_buf) - 1}, m_current, c)};
       std::size_t const end{1 + written};
+      // clang-tidy rule bug:
+      // NOLINTNEXTLINE(cert-dcl03-c)
       assert(end < std::size(m_buf));
       data[end] = '\0';
       m_len = check_cast<COUNTER>(end, "placeholders counter", loc);

--- a/include/pqxx/strconv.hxx
+++ b/include/pqxx/strconv.hxx
@@ -642,6 +642,8 @@ template<typename... TYPE>
 inline std::vector<std::string_view>
 to_buf(char *begin, char const *end, TYPE... value)
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(begin <= end);
 
   // We can't construct the span as {begin, end} because end points to const.
@@ -656,10 +658,17 @@ to_buf(char *begin, char const *end, TYPE... value)
   return {[&here, buf](auto v) {
     auto start{here};
     here += pqxx::into_buf(buf.subspan(start), v);
+
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
+
     assert(start < here);
     assert(here <= std::size(buf));
     // C++26: Use buf.at().
     assert(buf[here - 1] == '\0');
+
+    // NOLINTEND(cert-dcl03-c)
+
     // Exclude the trailing zero out of the string_view.
     auto len{here - start - 1};
     return std::string_view{std::data(buf) + start, len};
@@ -684,8 +693,12 @@ to_buf_multi(ctx c, std::span<char> buf, TYPE... value)
   return {[&here, buf, &c](auto v) {
     auto start{here};
     here += pqxx::into_buf(buf.subspan(start), v, c);
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
     assert(start < here);
     assert(here <= std::size(buf));
+    // NOLINTEND(cert-dcl03-c)
+
     // C++26: Use buf.at().
     auto const len{here - start};
     return std::string_view{std::data(buf) + start, len};
@@ -713,6 +726,8 @@ to_buf_multi(std::span<char> buf, TYPE... value)
   // TODO: Would it be worth merging consecutive identical strings?
   std::size_t here{0u};
   conversion_context c{};
+  // clang-tidy rule bug:
+  // NOLINTBEGIN(cert-dcl03-c)
   return {[&here, buf, &c](auto v) {
     auto start{here};
     here += pqxx::into_buf(buf.subspan(start), v, c);
@@ -722,6 +737,7 @@ to_buf_multi(std::span<char> buf, TYPE... value)
     auto const len{here - start};
     return std::string_view{std::data(buf) + start, len};
   }(value)...};
+  // NOLINTEND(cert-dcl03-c)
 }
 
 

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -115,7 +115,7 @@ public:
    * table path and/or columns list, and you want to save a bit of work on
    * composing the internal SQL statement for starting the stream.  It lets you
    * compose the string representations for the table path and the columns
-   * list, so you can compute these once and then re-use them later.
+   * list, so you can compute these once and then reuse them later.
    *
    * @param tx The transaction within which the stream will operate.
    * @param path Name or path for the table upon which the stream will

--- a/include/pqxx/stream_from.hxx
+++ b/include/pqxx/stream_from.hxx
@@ -348,6 +348,8 @@ template<typename Tuple, std::size_t index>
 inline void stream_from::extract_value(Tuple &t, sl loc) const
 {
   using field_type = std::remove_cvref_t<decltype(std::get<index>(t))>;
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(index < std::size(m_fields));
   if constexpr (always_null<field_type>())
   {

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -139,7 +139,7 @@ public:
    * path and/or columns list, and you want to save a bit of work on composing
    * the internal SQL statement for starting the stream.  It lets you compose
    * the string representations for the table path and the columns list, so you
-   * can compute these once and then re-use them later.
+   * can compute these once and then reuse them later.
    *
    * @param tx The transaction within which the stream will operate.
    * @param path Name or path for the table upon which the stream will

--- a/include/pqxx/stream_to.hxx
+++ b/include/pqxx/stream_to.hxx
@@ -347,6 +347,8 @@ private:
         auto const data{m_buffer.data()};
         std::size_t const end{
           offset + into_buf({data + offset, data + total}, f, c)};
+        // clang-tidy rule bug:
+        // NOLINTNEXTLINE(cert-dcl03-c)
         assert((end + 1) < std::size(m_buffer));
         m_buffer[end] = '\t';
         // Shrink to fit.  Keep the tab though.

--- a/include/pqxx/transaction_base.hxx
+++ b/include/pqxx/transaction_base.hxx
@@ -218,7 +218,7 @@ public:
   }
 
   /// Escape binary string for use as SQL string literal, into `buffer`.
-  /** Use this variant when you want to re-use the same buffer across multiple
+  /** Use this variant when you want to reuse the same buffer across multiple
    * calls.  If that's not the case, or convenience and simplicity are more
    * important, use the single-argument variant.
    *
@@ -538,7 +538,7 @@ public:
    * specify.  Unlike with the "exec" functions, processing can start before
    * all the data from the server is in.
    *
-   * @warning You can't pass parmaeters to a streaming query.  This is a
+   * @warning You can't pass parameters to a streaming query.  This is a
    * limitation at a lower level in the software stack.  You can work around
    * this by defining a view or function that you can then call without
    * parameters in the streaming query; or you can compose query strings that

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -245,7 +245,7 @@ using bytes = std::vector<std::byte>;
 /// Cast binary data to a type that libpqxx will recognise as binary.
 /** There are many different formats for storing binary data in memory.  You
  * may have yours as a `std::string`, or a `std::vector<uchar_t>`, or one of
- * many other types.  In libpqxx we commend a container of `std::byte`.
+ * many other types.  In libpqxx we recommend a container of `std::byte`.
  *
  * For libpqxx to recognise your data as binary, we recommend using a
  * `pqxx::bytes`, or a `pqxx::bytes_view`; but any contiguous block of

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -339,6 +339,9 @@ template<c_source_location LOC>
 PQXX_PURE inline std::string source_loc(LOC const &loc)
 {
   char const *const file{loc.file_name()};
+
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(file != nullptr);
 
   char const *const func{loc.function_name()};

--- a/include/pqxx/util.hxx
+++ b/include/pqxx/util.hxx
@@ -492,8 +492,11 @@ void check_unique_unregister(
 PQXX_PURE inline constexpr std::size_t
 size_esc_bin(std::size_t binary_bytes) noexcept
 {
+  // clang-tidy rule bug:
+  // NOLINTBEGIN(cert-dcl03-c)
   assert(std::cmp_less(
     binary_bytes, (std::numeric_limits<std::size_t>::max)() / 2u));
+  // NOLINTEND(cert-dcl03-c)
   return 2 + (2 * binary_bytes) + 1;
 }
 

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -119,7 +119,7 @@ public:
   /// Construct a `zview` from a C-style string.
   /** @warning This scans the string to discover its length.  So if you need to
    * do it many times, it's probably better to create the `zview` once and
-   * re-use it.
+   * reuse it.
    */
   PQXX_ZARGS constexpr zview(char const str[]) noexcept(
     noexcept(std::string_view{str})) :

--- a/include/pqxx/zview.hxx
+++ b/include/pqxx/zview.hxx
@@ -172,8 +172,11 @@ private:
   /// Check invariant: `data()` must be non-null and zero-terminated.
   [[maybe_unused]] constexpr void invariant() const noexcept
   {
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
     assert(std::data(*this) != nullptr);
     assert(std::data(*this)[std::size(*this)] == '\0');
+    // NOLINTEND(cert-dcl03-c)
   }
 };
 

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -1053,7 +1053,7 @@ pqxx::connection::read_copy_line(sl loc)
 {
   char *buf{nullptr};
 
-  // Allocate once, re-use across invocations.
+  // Allocate once, reuse across invocations.
   static auto const q{std::make_shared<std::string>("[END COPY]")};
 
   auto const line_len{PQgetCopyData(real_conn(m_conn), &buf, false)};

--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -1232,6 +1232,8 @@ std::string pqxx::connection::esc_like(
   for (std::size_t here{next}; here < sz; here = next)
   {
     // So we found a special character.  It's exactly 1 byte long.
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert((data[here] == '%') or (data[here] == '_'));
 
     // Look for the next stopping point after that, whether another special

--- a/src/encodings.cxx
+++ b/src/encodings.cxx
@@ -247,6 +247,8 @@ PQXX_PURE encoding_group enc_group(int libpq_enc_id, sl loc)
 /// Represent a short stretch of binary data (at most 3) for human readers.
 PQXX_PURE std::string list_bytes(std::string_view data)
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(not std::empty(data));
   // C++23: Use std::ranges::views::join_with(), std::format()?
   std::stringstream s;

--- a/src/pipeline.cxx
+++ b/src/pipeline.cxx
@@ -275,7 +275,7 @@ void pqxx::pipeline::obtain_dummy(sl loc)
 {
   conversion_context const c{{}, loc};
 
-  // Allocate once, re-use across invocations.
+  // Allocate once, reuse across invocations.
   static auto const text{
     std::make_shared<std::string>("[DUMMY PIPELINE QUERY]")};
 

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -217,7 +217,7 @@ constexpr bool valid_infinity_string(std::string_view text) noexcept
 /** We use this to work around missing std::to_chars for floating-point types.
  *
  * Initialising the stream (including locale and tweaked precision) seems to
- * be expensive.  So, create thread-local instances which we re-use.  It's a
+ * be expensive.  So, create thread-local instances which we reuse.  It's a
  * lockless way of keeping global variables thread-safe, basically.
  *
  * The stream initialisation happens once per thread, in the constructor.

--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -47,6 +47,8 @@ constexpr T top{std::numeric_limits<T>::max()};
 template<pqxx::internal::integer T>
 constexpr inline char *nonneg_to_buf(char *end, T value)
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(std::cmp_greater_equal(value, 0));
   constexpr int ten{10};
   // Seeming bug in clang-tidy rule: it thinks we can make pos a "char const *"
@@ -67,6 +69,8 @@ constexpr inline char *nonneg_to_buf(char *end, T value)
 template<pqxx::internal::integer T>
 constexpr inline char *neg_to_buf(char *end, T value)
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(std::cmp_greater_equal(value, 0));
   // Seeming bug in clang-tidy rule: it thinks we can make pos a "char const *"
   // instead of a plain "char *".  I don't see how.

--- a/src/stream_from.cxx
+++ b/src/stream_from.cxx
@@ -218,6 +218,9 @@ void pqxx::stream_from::parse_line(sl loc)
   //
   // This assertion tells clang-tidy just what it needs in order to deduce
   // that *write never dereferences a null pointer.
+
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(write != nullptr);
 
   // Beginning of current field in m_row, or nullptr for null fields.
@@ -227,6 +230,8 @@ void pqxx::stream_from::parse_line(sl loc)
   while (offset < line_size)
   {
     auto const stop_char{m_char_finder(line_view, offset, loc)};
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(stop_char <= line_size);
     // Copy the text we have so far.  It's got no special characters in it.
     std::memcpy(write, &line_begin[offset], stop_char - offset);
@@ -252,6 +257,9 @@ void pqxx::stream_from::parse_line(sl loc)
     else
     {
       // Escape sequence.
+
+      // clang-tidy rule bug:
+      // NOLINTNEXTLINE(cert-dcl03-c)
       assert(special == '\\');
       if ((offset) >= line_size)
         throw failure{"Row ends in backslash", loc};

--- a/src/stream_to.cxx
+++ b/src/stream_to.cxx
@@ -85,6 +85,8 @@ void pqxx::stream_to::write_buffer(sl loc)
   {
     // In append_to_buffer() we write a tab after each field.  We only want a
     // tab _between_ fields.  Remove that last one.
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(m_buffer[std::size(m_buffer) - 1] == '\t');
     m_buffer.resize(std::size(m_buffer) - 1);
   }

--- a/src/time.cxx
+++ b/src/time.cxx
@@ -198,7 +198,7 @@ std::chrono::year_month_day
 string_traits<std::chrono::year_month_day>::from_string(
   std::string_view text, sl loc)
 {
-  // We can't just re-use the std::chrono::year conversions, because the "BC"
+  // We can't just reuse the std::chrono::year conversions, because the "BC"
   // suffix comes at the very end.
   if (std::size(text) < 9)
     throw conversion_error{make_parse_error(text), loc};

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -158,6 +158,8 @@ namespace pqxx::internal
 {
 void esc_bin(bytes_view binary_data, std::span<char> buffer) noexcept
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(std::size(buffer) >= size_esc_bin(std::size(binary_data)));
   std::size_t here{0u};
   // C++26: Use at().

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -216,6 +216,8 @@ void unesc_bin(
       throw pqxx::failure{"Invalid hex-escaped data.", loc};
     buffer[out++] = static_cast<std::byte>((hi << 4) | lo);
   }
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(out <= std::size(buffer));
 }
 

--- a/test/helpers.hxx
+++ b/test/helpers.hxx
@@ -401,7 +401,7 @@ inline void check_succeeds(
 template<typename EXC, std::invocable F>
 inline void check_throws(
   F &&f, char const text[],
-  std::string desc = "This code did not thow the expected exception.",
+  std::string desc = "This code did not throw the expected exception.",
   pqxx::sl loc = sl::current())
 {
   try
@@ -451,7 +451,7 @@ inline void check_throws(
 template<std::invocable F>
 inline void check_throws_exception(
   F &&f, char const text[],
-  std::string desc = "This code did not thow a std::exception.",
+  std::string desc = "This code did not throw a std::exception.",
   pqxx::sl loc = sl::current())
 {
   try

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -137,6 +137,8 @@ namespace pqxx::test
 {
 void suite::register_test(std::string_view name, testfunc func) noexcept
 {
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(s_num_tests < max_tests);
   s_names.at(s_num_tests) = name;
   s_funcs.at(s_num_tests) = func;

--- a/test/runner.cxx
+++ b/test/runner.cxx
@@ -143,17 +143,22 @@ void suite::register_test(std::string_view name, testfunc func) noexcept
   ++s_num_tests;
 }
 
+
 std::map<std::string_view, testfunc> suite::gather()
 {
   std::map<std::string_view, testfunc> all_tests;
   for (std::size_t idx{0}; idx < s_num_tests; ++idx)
   {
     auto const name{s_names.at(idx)};
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(not all_tests.contains(name));
     auto const func{s_funcs.at(idx)};
 
     // This could happen if the internal arrays get constructed after we've
     // already written tests into them.
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(func != nullptr);
     all_tests.emplace(name, func);
   }
@@ -287,6 +292,8 @@ public:
           m_here{m_tests.begin()},
           m_capacity{jobs}
   {
+    // clang-tidy rule bug:
+    // NOLINTNEXTLINE(cert-dcl03-c)
     assert(m_jobs <= max_jobs);
   }
 

--- a/test/test07.cxx
+++ b/test/test07.cxx
@@ -76,7 +76,7 @@ void test_007(pqxx::test::context &)
       PQXX_CHECK_EQUAL(fctype, rctype);
     }
 
-    // For each occurring year, write converted date back to whereever it may
+    // For each occurring year, write converted date back to wherever it may
     // occur in the table.  Since we're in a transaction, any changes made by
     // others at the same time will not affect us.
     for (auto const &c : conversions)

--- a/test/test26.cxx
+++ b/test/test26.cxx
@@ -44,7 +44,7 @@ std::map<int, int> update_years(pqxx::connection &cx)
       conversions[y.value_or(1)] = to_4_digits(y.value_or(2));
   }
 
-  // For each occurring year, write converted date back to whereever it may
+  // For each occurring year, write converted date back to wherever it may
   // occur in the table.  Since we're in a transaction, any changes made by
   // others at the same time will not affect us.
   for (auto const &c : conversions)

--- a/test/test72.cxx
+++ b/test/test72.cxx
@@ -24,7 +24,7 @@ void test_072(pqxx::test::context &)
   // See that we can process the queries without stumbling over the error
   P.complete();
 
-  // We should be able to get the first result, which preceeds the error
+  // We should be able to get the first result, which precedes the error
   auto const res_1{P.retrieve(id_1).at(0).at(0).as<int>()};
   PQXX_CHECK_EQUAL(res_1, 1);
 

--- a/test/test_array.cxx
+++ b/test/test_array.cxx
@@ -626,9 +626,9 @@ void test_array_parses_quoted_strings(pqxx::test::context &)
     b.at(0),
     "\203\\"
     "");
-  // If encoding support didn't work properly, puting a backslash in front
+  // If encoding support didn't work properly, putting a backslash in front
   // would probably only get applied to the first byte in the character, and
-  // turn that embedded byte bcak into a backslash.
+  // turn that embedded byte back into a backslash.
   PQXX_CHECK_EQUAL(
     b.at(1),
     "\203\\"

--- a/test/test_connection_string.cxx
+++ b/test/test_connection_string.cxx
@@ -40,8 +40,13 @@ std::string app_name(pqxx::connection const &cx)
     for (bool esc{false};
          (here < std::size(all)) and ((all.at(here) != '\'') or esc); ++here)
       esc = (all.at(here) == '\\' and not esc);
+
+    // clang-tidy rule bug:
+    // NOLINTBEGIN(cert-dcl03-c)
     assert(here < std::size(all));
     assert(all.at(here) == '\'');
+    // NOLINTEND(cert-dcl03-c)
+
     // Skip closing quote.
     end = here + 1;
   }

--- a/test/test_encodings.cxx
+++ b/test/test_encodings.cxx
@@ -46,7 +46,6 @@ auto const eels<pqxx::encoding_group::two_tier>{
 /// ASCII-safe: German.
 template<>
 auto const eels<pqxx::encoding_group::ascii_safe>{
-   // codespell:ignore-next-line
   "Mein Luftkissenfahrzeug ist voll mit Aalen."sv};
 /// GB18030: Simplified Chinese.
 template<>

--- a/test/test_encodings.cxx
+++ b/test/test_encodings.cxx
@@ -46,6 +46,7 @@ auto const eels<pqxx::encoding_group::two_tier>{
 /// ASCII-safe: German.
 template<>
 auto const eels<pqxx::encoding_group::ascii_safe>{
+   // codespell:ignore-next-line
   "Mein Luftkissenfahrzeug ist voll mit Aalen."sv};
 /// GB18030: Simplified Chinese.
 template<>

--- a/test/test_range.cxx
+++ b/test/test_range.cxx
@@ -281,7 +281,7 @@ void test_parse_bad_range(pqxx::test::context &)
   using conv_err = pqxx::conversion_error;
   using traits = pqxx::string_traits<range>;
   constexpr std::string_view bad_ranges[]{
-    "",   "x",       "e",          "empt",       "emptyy",   "()",
+    "",   "x",       "e",          "empt",       "empty",   "()",
     "[]", "(empty)", "(empty, 0)", "(0, empty)", ",",        "(,",
     ",)", "(1,2,3)", "(4,5x)",     "(null, 0)",  "[0, 1.0]", "[1.0, 0]",
   };

--- a/test/test_range.cxx
+++ b/test/test_range.cxx
@@ -281,7 +281,7 @@ void test_parse_bad_range(pqxx::test::context &)
   using conv_err = pqxx::conversion_error;
   using traits = pqxx::string_traits<range>;
   constexpr std::string_view bad_ranges[]{
-    "",   "x",       "e",          "empt",       "empty",   "()",
+    "",   "x",       "e",          "empt",       "emptyy",   "()",
     "[]", "(empty)", "(empty, 0)", "(0, empty)", ",",        "(,",
     ",)", "(1,2,3)", "(4,5x)",     "(null, 0)",  "[0, 1.0]", "[1.0, 0]",
   };

--- a/test/test_stream_from.cxx
+++ b/test/test_stream_from.cxx
@@ -304,9 +304,14 @@ void test_stream_from_read_row(pqxx::test::context &)
   auto stream{pqxx::stream_from::table(tx, {"sample"})};
   auto fields{stream.read_row()};
   PQXX_CHECK(fields != nullptr);
+
   // (Work around a weird false positive in clang-tidy where the check that
   // fields is _not_ null somehow convinces the checker that it _is_ null.)
+
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(fields != nullptr);
+
   PQXX_CHECK_EQUAL(fields->size(), 3ul);
   PQXX_CHECK_EQUAL(std::string((*fields)[0]), "321");
   PQXX_CHECK_EQUAL(std::string((*fields)[1]), "something");

--- a/test/test_string_conversion.cxx
+++ b/test/test_string_conversion.cxx
@@ -160,6 +160,8 @@ void test_string_view_conversion(pqxx::test::context &)
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::size_t const stop{pqxx::into_buf(buf, "more view"sv)};
   PQXX_CHECK_LESS(stop, std::size(buf));
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(stop > 0);
   PQXX_CHECK_EQUAL(
     (std::string{std::data(buf), static_cast<std::size_t>(stop)}),

--- a/test/test_util.cxx
+++ b/test/test_util.cxx
@@ -272,6 +272,9 @@ std::string make_filename(pqxx::test::context &tctx)
   case 5: suffix = "hpp"; break;
   case 6: suffix = "h"; break;
   }
+
+  // clang-tidy rule bug:
+  // NOLINTNEXTLINE(cert-dcl03-c)
   assert(suffix != nullptr);
 
   return std::format("{}.{}", tctx.make_name("source"), suffix);

--- a/tools/check_ascii.py
+++ b/tools/check_ascii.py
@@ -2,9 +2,9 @@
 
 """Check that all source files are pure ASCII."""
 
+import sys
 from argparse import ArgumentParser
 from pathlib import Path
-import sys
 
 
 def find_source_files(srcdir: Path) -> list[Path]:

--- a/tools/compiler_flags.py
+++ b/tools/compiler_flags.py
@@ -6,6 +6,8 @@ Prints any of the flags that are accepted when used in combination with the
 base command line and the previously accepted flags.
 """
 
+import shlex
+import sys
 from argparse import (
     ArgumentParser,
     Namespace,
@@ -13,13 +15,10 @@ from argparse import (
 from contextlib import nullcontext
 from os import devnull
 from pathlib import Path
-import shlex
 from subprocess import (
     DEVNULL,
     run,
 )
-import sys
-
 
 EPILOG = """The flags file may contain comments, on lines starting with '#'
 as the first non-whitespace character.  Any whitespace between flags other than

--- a/tools/extract_version.py
+++ b/tools/extract_version.py
@@ -5,10 +5,10 @@
 Version strings look like: "<major>.<minor>.<patch>".
 """
 
+import sys
 from argparse import ArgumentParser, Namespace
 from os import getenv
 from pathlib import Path
-import sys
 
 
 class Fail(Exception):

--- a/tools/filter_config.py
+++ b/tools/filter_config.py
@@ -12,13 +12,12 @@ So, we rewrite the header (or its template) to contain only the macro
 definitions with "PQXX" in the name.
 """
 
+import sys
 from argparse import (
     ArgumentParser,
     Namespace,
 )
 from pathlib import Path
-import sys
-
 
 # We prefix this to the header's text.  It suppresses a clang-tidy warning
 # about there not being an ifdef/define pair to prevent multiple inclusion.

--- a/tools/generate_check_config.py
+++ b/tools/generate_check_config.py
@@ -9,14 +9,13 @@ where that succeeds, define the C++ macro of the same name as the base name
 of the check snippet.
 """
 
+import os.path
 from argparse import (
     ArgumentParser,
     Namespace,
 )
-import os.path
 from pathlib import Path
 from textwrap import dedent
-
 
 # Name of the autoconf configuration script that we produce.  (Lives in the
 # main source directory.)

--- a/tools/generate_cxx_checks.py
+++ b/tools/generate_cxx_checks.py
@@ -9,15 +9,14 @@ Reads the test libpqxx feature macro names, as well as the C++ feature check
 macros that control them, from cxx_features.txt in the source tree.
 """
 
+import os.path
 from argparse import (
     ArgumentParser,
     Namespace,
 )
-import os.path
 from pathlib import Path
 from textwrap import dedent
 from typing import cast
-
 
 # Name of the config file listing, one per line, the macros to test and set.
 #

--- a/tools/generate_cxx_checks.py
+++ b/tools/generate_cxx_checks.py
@@ -30,7 +30,7 @@ from typing import cast
 # (which the configuration will either define or not define depending on
 # whether there is support for the corresponding feature), followed by the
 # name of the C++ feature test macro that we will need to check in order to
-# determinue whether that feature is present.
+# determine whether that feature is present.
 CONFIG = "cxx_features.txt"
 
 

--- a/tools/generate_cxx_checks.py
+++ b/tools/generate_cxx_checks.py
@@ -27,10 +27,10 @@ from typing import cast
 # * a tuple of macro names.
 #
 # In that last case, the line must consist of a libpqxx feature macro name
-# (which the configuration will either define or not define depening on whether
-# there is support for the corresponding feature), followed by the name of the
-# C++ feature test macro that we will need to check in order to determinue
-# whether that feature is present.
+# (which the configuration will either define or not define depending on
+# whether there is support for the corresponding feature), followed by the
+# name of the C++ feature test macro that we will need to check in order to
+# determinue whether that feature is present.
 CONFIG = "cxx_features.txt"
 
 

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -174,7 +174,7 @@ pylint() {
     then
         ruff check -q "$SRCDIR"
     else
-        uv -q run --with=ruff==0.14.14 ruff check -q "$SRCDIR"
+        uv -q run --with=ruff==0.16.1 ruff check -q "$SRCDIR"
     fi
 
     if have_command pyrefly

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -155,7 +155,7 @@ cpplint() {
         cat <<EOF >&2
 Could not find compile flags for clang-tidy run.
 
-Run this script from a build directry prepared with either configure or cmake.
+Run this script from a build directory prepared with either configure or cmake.
 EOF
         exit 1
     fi

--- a/tools/m4esc.py
+++ b/tools/m4esc.py
@@ -7,11 +7,6 @@ Produces M4 "code" which evaluates to the input text.
 It's not easy to read plain text from an input file in M4, without having it
 expanded as M4.  Sometimes all we want is literal text!
 """
-from __future__ import (
-    absolute_import,
-    print_function,
-    unicode_literals,
-)
 
 from argparse import ArgumentParser
 from sys import (

--- a/tools/template2mak.py
+++ b/tools/template2mak.py
@@ -16,12 +16,6 @@ The available template commands are:
 Copyright (c) 2000-2026, Bart Samwel and Jeroen T. Vermeulen.
 """
 
-from __future__ import (
-    absolute_import,
-    print_function,
-    unicode_literals,
-)
-
 from argparse import (
     ArgumentError,
     ArgumentParser,

--- a/tools/template2mak.py
+++ b/tools/template2mak.py
@@ -177,7 +177,7 @@ def write_header(stream, template_path=None):
     stream.write(OUTPUT_HEADER.format(script=script))
     if template_path is not None:
         stream.write("#\n")
-        stream.write("# Generated from template '%s'.\n" % template_path)
+        stream.write(f"# Generated from template '{template_path}'.\n")
     stream.write(hr)
 
 
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     try:
         template_path, output_path = parse_args()
     except ArgumentError as error:
-        stderr.write("%s\n" % error)
+        stderr.write(f"{error}\n")
         sys.exit(2)
 
     input_stream = open_stream(template_path, stdin, "r")

--- a/tools/template2mak.py
+++ b/tools/template2mak.py
@@ -16,6 +16,8 @@ The available template commands are:
 Copyright (c) 2000-2026, Bart Samwel and Jeroen T. Vermeulen.
 """
 
+import os
+import sys
 from argparse import (
     ArgumentError,
     ArgumentParser,
@@ -23,14 +25,12 @@ from argparse import (
 )
 from contextlib import contextmanager
 from glob import glob
-import os
 from sys import (
     argv,
-    stdin,
     stderr,
+    stdin,
     stdout,
 )
-import sys
 from textwrap import dedent
 
 


### PR DESCRIPTION
Handy tool that finds typos.  Amazing: this seems to be what LLMs are best at, and this tool is much better and much faster at it.

I might make this part of the build, except there's a few places where it insists on complaining about things that aren't typos and aren't appropriate for a suppression in the config.  _In theory_ I should be able to write an inline comment to suppress these, but... that doesn't seem to work.